### PR TITLE
Make the SFFCorrector bspline more robust

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -755,9 +755,9 @@ class SFFCorrector(object):
                 # First, fit a spline to capture the long-term varation
                 # We don't want to fit the long-term trend because we know
                 # that the K2 motion noise is a high-frequency effect.
-                self.bspline = self.fit_bspline(time[i], flux[i])
+                self.bspline = self.fit_bspline(np.arange(len(flux[i])), flux[i])
                 # Remove the long-term variation by dividing the flux by the spline
-                self.normflux = flux[i] / self.bspline(time[i] - time[i][0])
+                self.normflux = flux[i] / self.bspline(np.arange(len(flux[i])))
                 # Bin and interpolate normalized flux to capture the dependency
                 # of the flux as a function of arclength
                 self.interp = self.bin_and_interpolate(self.s, self.normflux, bins,

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -93,7 +93,7 @@ def test_sff_corrector():
     # the factor self.bspline(time-time[0]) accounts for
     # the long term trend which is divided out in order to get a "flat"
     # lightcurve.
-    assert_almost_equal(corrected_lc.flux*sff.bspline(time-time[0]),
+    assert_almost_equal(corrected_lc.flux*sff.bspline(np.arange(len(raw_flux))),
                         corrected_flux, decimal=3)
     assert_array_equal(time, corrected_lc.time)
     # the factor of 4 below accounts for the conversion


### PR DESCRIPTION
This PR makes the `SFFCorrector` more robust by fitting its smoothing bspline against an arbitrary index instead of time.  This helps in the event of a big time gaps in the data, which make the bspline fit fail due to the knots being linearly spaced in time.

This PR very slightly changes the outcome of the SFF algorithm and, as a result, makes on of the unit tests fail.  This needs to be investigated.