### PR TITLE
Added `__repr__` for KeplerTargetPixelFile, Lightcurve, KeplerLightCurve and KeplerLightCurveFile

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -42,6 +42,9 @@ class LightCurve(object):
             self.flux_err = np.nan * np.ones_like(self.time)
         self.meta = meta
 
+    def __repr__(self):
+        return('LightCurve Object')
+
     def stitch(self, *others):
         """
         Stitches LightCurve objects.
@@ -472,6 +475,9 @@ class KeplerLightCurve(LightCurve):
         self.cadenceno = cadenceno
         self.keplerid = keplerid
 
+    def __repr__(self):
+        return('KeplerLightCurve Object (ID: {})'.format(self.keplerid))
+
     def correct(self, method='sff', **kwargs):
         """Corrects a lightcurve for motion-dependent systematic errors.
 
@@ -529,6 +535,9 @@ class KeplerLightCurveFile(object):
         self.hdu = pyfits.open(self.path, **kwargs)
         self.quality_bitmask = quality_bitmask
         self.quality_mask = self._quality_mask(quality_bitmask)
+
+    def __repr__(self):
+        return('KeplerLightCurveFile Object (ID: {})'.format(self.hdu[0].header['KEPLERID']))
 
     @property
     def hdu(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -533,11 +533,12 @@ class KeplerLightCurveFile(object):
                  **kwargs):
         self.path = path
         self.hdu = pyfits.open(self.path, **kwargs)
+        self.keplerid = self.hdu[0].header['KEPLERID']
         self.quality_bitmask = quality_bitmask
         self.quality_mask = self._quality_mask(quality_bitmask)
 
     def __repr__(self):
-        return('KeplerLightCurveFile Object (ID: {})'.format(self.hdu[0].header['KEPLERID']))
+        return('KeplerLightCurveFile Object (ID: {})'.format(self.keplerid))
 
     @property
     def hdu(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -42,9 +42,6 @@ class LightCurve(object):
             self.flux_err = np.nan * np.ones_like(self.time)
         self.meta = meta
 
-    def __repr__(self):
-        return('LightCurve Object')
-
     def stitch(self, *others):
         """
         Stitches LightCurve objects.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -59,6 +59,10 @@ class KeplerTargetPixelFile(TargetPixelFile):
         self.quality_bitmask = quality_bitmask
         self.quality_mask = self._quality_mask(quality_bitmask)
 
+
+    def __repr__(self):
+        return('KeplerTargetPixelFile Object (ID: {})'.format(self.hdu[0].header['KEPLERID']))
+
     @property
     def hdu(self):
         return self._hdu


### PR DESCRIPTION
lightkurve now prints useful information to the user if you print `KeplerTargetPixelFile`, `Lightcurve`, `KeplerLightCurve` and `KeplerLightCurveFile`:

e.g.
<img width="403" alt="screen shot 2018-01-26 at 2 43 42 pm" src="https://user-images.githubusercontent.com/14965634/35463797-57b53494-02a7-11e8-91f3-228cf62faf86.png">
