### PR TITLE
Changed tpf.plot() to return only ax and accept ax as keyword.

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -323,7 +323,7 @@ class LightCurve(object):
         ----------
         ax : matplotlib.axes._subplots.AxesSubplot
             A matplotlib axes object to plot into. If no axes is provided,
-            a new one be generated.
+            a new one will be generated.
         normalize : bool
             Normalize the lightcurve before plotting?
         xlabel : str
@@ -338,7 +338,7 @@ class LightCurve(object):
             Shade the region between 0 and flux
         grid: bool
             Add a grid to the plot
-        **kwargs : dict
+        kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
 
         Returns

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -317,7 +317,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         return col_centr, row_centr
 
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
-            colorbar=True, mask_color='pink', **kwargs):
+            show_colorbar=True, mask_color='pink', **kwargs):
         """
         Plot a target pixel file at a given frame (index) or cadence number.
 
@@ -325,7 +325,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         ----------
         ax : matplotlib.axes._subplots.AxesSubplot
             A matplotlib axes object to plot into. If no axes is provided,
-            a new one be generated.
+            a new one will be generated.
         frame : int
             Frame number. The default is 0, i.e. the first frame.
         cadenceno : int, optional
@@ -335,13 +335,12 @@ class KeplerTargetPixelFile(TargetPixelFile):
             If True, background will be added to the pixel values.
         aperture_mask : ndarray
             Highlight pixels selected by aperture_mask.
-        colorbar : bool
+        show_colorbar : bool
             Whether or not to show the colorbar
         mask_color : str
             Color to show the aperture mask
         kwargs : dict
             Keywords arguments passed to `lightkurve.utils.plot_image`.
-
 
         Returns
         -------
@@ -363,16 +362,10 @@ class KeplerTargetPixelFile(TargetPixelFile):
         except IndexError:
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.flux.shape[0]))
-        if ax is None:
-            ax = plot_image(pflux, title='Kepler ID: {}'.format(self.keplerid),
-                             extent=(self.column, self.column + self.shape[2],
-                             self.row, self.row + self.shape[1]), colorbar=colorbar,
-                             **kwargs)
-        else:
-            ax = plot_image(pflux, ax=ax, title='Kepler ID: {}'.format(self.keplerid),
-                             extent=(self.column, self.column + self.shape[2],
-                             self.row, self.row + self.shape[1]), colorbar=colorbar,
-                             **kwargs)
+        ax = plot_image(pflux, ax=ax, title='Kepler ID: {}'.format(self.keplerid),
+                extent=(self.column, self.column + self.shape[2], self.row,
+                self.row + self.shape[1]), show_colorbar=show_colorbar, **kwargs)
+
         if aperture_mask is not None:
             aperture_mask = self._parse_aperture_mask(aperture_mask)
             for i in range(self.shape[1]):

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -179,15 +179,19 @@ class KeplerQualityFlags(object):
         return result
 
 
-def plot_image(image, scale='linear', origin='lower',
+def plot_image(image, ax=None, scale='linear', origin='lower',
                xlabel='Pixel Column Number', ylabel='Pixel Row Number',
-               clabel='Flux ($e^{-}s^{-1}$)', title=None, **kwargs):
+               clabel='Flux ($e^{-}s^{-1}$)', title=None, colorbar=True,
+               **kwargs):
         """Utility function to plot a 2D image
 
         Parameters
         ----------
         image : 2d array
             Image data.
+        ax : matplotlib.axes._subplots.AxesSubplot
+            A matplotlib axes object to plot into. If no axes is provided,
+            a new one be generated.
         scale : str
             Scale used to stretch the colormap.
             Options: 'linear', 'sqrt', or 'log'.
@@ -201,10 +205,19 @@ def plot_image(image, scale='linear', origin='lower',
             Label for the color bar.
         title : str or None
             Title for the plot.
+        colorbar : bool
+            Whether or not to show the colorbar
         kwargs : dict
             Keyword arguments to be passed to `matplotlib.pyplot.imshow`.
+
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
         """
-        fig, ax = plt.subplots()
+        if ax is None:
+            fig, ax = plt.subplots()
         vmin, vmax = PercentileInterval(95.).get_limits(image)
         if scale == 'linear':
             norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch())
@@ -219,8 +232,9 @@ def plot_image(image, scale='linear', origin='lower',
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
         ax.set_title(title)
-        cbar = fig.colorbar(cax, norm=norm, label=clabel)
-        return fig, ax
+        if colorbar:
+            cbar = plt.colorbar(cax, ax=ax, norm=norm, label=clabel)
+        return ax
 
 def running_mean(data, window_size):
     """Returns the moving average of an array `data`.

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -181,7 +181,7 @@ class KeplerQualityFlags(object):
 
 def plot_image(image, ax=None, scale='linear', origin='lower',
                xlabel='Pixel Column Number', ylabel='Pixel Row Number',
-               clabel='Flux ($e^{-}s^{-1}$)', title=None, colorbar=True,
+               clabel='Flux ($e^{-}s^{-1}$)', title=None, show_colorbar=True,
                **kwargs):
         """Utility function to plot a 2D image
 
@@ -191,7 +191,7 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
             Image data.
         ax : matplotlib.axes._subplots.AxesSubplot
             A matplotlib axes object to plot into. If no axes is provided,
-            a new one be generated.
+            a new one will be generated.
         scale : str
             Scale used to stretch the colormap.
             Options: 'linear', 'sqrt', or 'log'.
@@ -205,11 +205,10 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
             Label for the color bar.
         title : str or None
             Title for the plot.
-        colorbar : bool
+        show_colorbar : bool
             Whether or not to show the colorbar
         kwargs : dict
             Keyword arguments to be passed to `matplotlib.pyplot.imshow`.
-
 
         Returns
         -------
@@ -217,7 +216,7 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
             The matplotlib axes object.
         """
         if ax is None:
-            fig, ax = plt.subplots()
+            _, ax = plt.subplots()
         vmin, vmax = PercentileInterval(95.).get_limits(image)
         if scale == 'linear':
             norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch())
@@ -232,7 +231,7 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
         ax.set_title(title)
-        if colorbar:
+        if show_colorbar:
             cbar = plt.colorbar(cax, ax=ax, norm=norm, label=clabel)
         return ax
 


### PR DESCRIPTION
tpf.plot() now returns just 'ax' instead of figure and ax, in line with how lc.plot() works. tpf.plot() also now accepts an axis, just as lc.plot() does. This allows users to put target pixel file plots into their existing figures, which I find to be useful. 

I have also added these minor tweaks

- The colorbar can now be turned off with a keyword. I find this to be useful if I'm e.g. showing the source is uncontaminated.
- The color for the aperture mask can now be specified.

These tweaks have let me create this nice plot.

![rollingbandcheck](https://user-images.githubusercontent.com/14965634/35651016-06289ac2-0693-11e8-9f75-99e0d388784e.png)

