### PR TITLE
Add a cdpp() convenience function

### DIFF
--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -7,3 +7,4 @@ from .prf import *
 from .lightcurve import *
 from .targetpixelfile import *
 from .utils import *
+from .convenience import *

--- a/lightkurve/convenience.py
+++ b/lightkurve/convenience.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from .lightcurve import LightCurve
+
+
+__all__ = ['cdpp']
+
+
+def cdpp(flux, **kwargs):
+    """A convenience function which wraps LightCurve.cdpp().
+
+    For details on the algorithm used to compute the Combined Differential
+    Photometric Precision (CDPP) noise metric, please see the docstring of
+    the `LightCurve.cdpp()` method.
+
+    Parameters
+    ----------
+    flux : array-like
+        Flux values.
+    **kwargs : dict
+        Dictionary of arguments to be passed to `LightCurve.cdpp()`.
+
+    Returns
+    -------
+    cdpp : float
+        Savitzky-Golay CDPP noise metric in units parts-per-million (ppm).
+    """
+    return LightCurve(time=np.arange(len(flux)), flux=flux).cdpp(**kwargs)

--- a/lightkurve/tests/test_convenience.py
+++ b/lightkurve/tests/test_convenience.py
@@ -1,0 +1,12 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+from ..lightcurve import LightCurve
+from ..convenience import cdpp
+
+
+def test_cdpp():
+    """Tests the cdpp() convenience function which wraps `LightCurve.cdpp()`"""
+    flux = np.random.normal(loc=1, scale=100e-6, size=10000)
+    lc = LightCurve(np.arange(10000), flux)
+    assert_almost_equal(cdpp(flux), lc.cdpp())


### PR DESCRIPTION
I propose adding a `cdpp(flux)` convenience function, so that one can do `from lightkurve import cdpp` without having to instantiate a `LightCurve` object.