### PR TITLE
Adding TESS light curve classes

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -611,6 +611,9 @@ class TessLightCurve(LightCurve):
 
 
 class LightCurveFile(object):
+    """Defines a generic class to handle light curve files.
+    """
+
     def __init__(self, path, **kwargs):
         self.path = path
         self.hdu = pyfits.open(self.path, **kwargs)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -617,8 +617,14 @@ class TessLightCurve(LightCurve):
 
 class LightCurveFile(object):
     """Defines a generic class to handle light curve files.
-    """
 
+    Attributes
+    ----------
+    path : str
+        Directory path or url to a lightcurve FITS file.
+    kwargs : dict
+        Keyword arguments to be passed to astropy.io.fits.open.
+    """
     def __init__(self, path, **kwargs):
         self.path = path
         self.hdu = pyfits.open(self.path, **kwargs)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -339,9 +339,10 @@ class LightCurve(object):
         Parameters
         ----------
         transit_duration : int, optional
-            The transit duration in cadences. This is the length of the window
-            used to compute the running mean. The default is 13, which
-            corresponds to a 6.5 hour transit in data sampled at 30-min cadence.
+            The transit duration in units of number of cadences. This is the
+            length of the window used to compute the running mean. The default
+            is 13, which corresponds to a 6.5 hour transit in data sampled at
+            30-min cadence.
         savgol_window : int, optional
             Width of Savitsky-Golay filter in cadences (odd number).
             Default value 101 (2.0 days in Kepler Long Cadence mode).
@@ -363,8 +364,12 @@ class LightCurve(object):
         Jeff van Cleve but lacks the normalization factor used there:
         svn+ssh://murzim/repo/so/trunk/Develop/jvc/common/compute_SG_noise.m
         """
-        if not isinstance(transit_duration, int):
-            raise TypeError("transit_duration must be an integer")
+        try:
+            transit_duration = int(transit_duration)
+        except Exception:
+            raise Exception("transit_duration must be an integer, got {}."
+                            .format(transit_duration))
+
         detrended_lc = self.flatten(window_length=savgol_window,
                                     polyorder=savgol_polyorder)
         cleaned_lc = detrended_lc.remove_outliers(sigma=sigma_clip)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -531,7 +531,10 @@ class KeplerLightCurve(LightCurve):
         self.keplerid = keplerid
 
     def __repr__(self):
-        return('KeplerLightCurve Object (ID: {})'.format(self.keplerid))
+        if self.mission.lower() == 'kepler':
+            return('KeplerLightCurveFile(KIC: {})'.format(self.keplerid))
+        elif self.mission.lower() == 'k2':
+            return('KeplerLightCurveFile(EPIC: {})'.format(self.keplerid))
 
     def correct(self, method='sff', **kwargs):
         """Corrects a lightcurve for motion-dependent systematic errors.
@@ -601,7 +604,7 @@ class TessLightCurve(LightCurve):
         self.ticid = ticid
 
     def __repr__(self):
-        return('TessLightCurve Object (ID: {})'.format(self.ticid))
+        return('TessLightCurveFile(TICID: {})'.format(self.ticid))
 
     def to_fits(self):
         raise NotImplementedError()
@@ -862,7 +865,7 @@ class TessLightCurveFile(LightCurveFile):
         self.quality_mask = self._quality_mask(quality_bitmask)
 
     def __repr__(self):
-        return('TessLightCurveFile(TICID: {})'.format(self.keplerid))
+        return('TessLightCurveFile(TICID: {})'.format(self.ticid))
 
     @property
     def ticid(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -17,12 +17,13 @@ from astropy.io import fits as pyfits
 from astropy.stats import sigma_clip
 from astropy.table import Table
 
-from .utils import running_mean, channel_to_module_output, KeplerQualityFlags
+from .utils import (running_mean, channel_to_module_output, KeplerQualityFlags,
+                    TessQualityFlags)
 
 
-__all__ = ['LightCurve', 'KeplerLightCurve', 'KeplerLightCurveFile',
-           'KeplerCBVCorrector', 'SPLDCorrector', 'SFFCorrector',
-           'box_period_search', 'iterative_box_period_search']
+__all__ = ['LightCurve', 'KeplerLightCurve', 'TessLightCurve',
+           'KeplerLightCurveFile', 'TessLightCurveFile', 'KeplerCBVCorrector',
+           'SFFCorrector', 'iterative_box_period_search']
 
 
 class LightCurve(object):
@@ -565,7 +566,112 @@ class KeplerLightCurve(LightCurve):
         raise NotImplementedError()
 
 
-class KeplerLightCurveFile(object):
+class TessLightCurve(LightCurve):
+    """Defines a light curve class for NASA's TESS mission.
+
+    Attributes
+    ----------
+    time : array-like
+        Time measurements
+    flux : array-like
+        Data flux for every time point
+    flux_err : array-like
+        Uncertainty on each flux data point
+    centroid_col, centroid_row : array-like, array-like
+        Centroid column and row coordinates as a function of time
+    quality : array-like
+        Array indicating the quality of each data point
+    quality_bitmask : int
+        Bitmask specifying quality flags of cadences that should be ignored
+    cadenceno : array-like
+        Cadence numbers corresponding to every time measurement
+    ticid : int
+        Tess Input Catalog ID number
+    """
+    def __init__(self, time, flux, flux_err=None, centroid_col=None,
+                 centroid_row=None, quality=None, quality_bitmask=None,
+                 cadenceno=None, ticid=None):
+        super(TessLightCurve, self).__init__(time, flux, flux_err)
+        self.centroid_col = centroid_col
+        self.centroid_row = centroid_row
+        self.quality = quality
+        self.quality_bitmask = quality_bitmask
+        self.mission = "TESS"
+        self.cadenceno = cadenceno
+        self.ticid = ticid
+
+    def __repr__(self):
+        return('TessLightCurve Object (ID: {})'.format(self.ticid))
+
+    def to_fits(self):
+        raise NotImplementedError()
+
+
+class LightCurveFile(object):
+    def __init__(self, path, **kwargs):
+        self.path = path
+        self.hdu = pyfits.open(self.path, **kwargs)
+
+    def header(self, ext=0):
+        """Header of the object at extension `ext`"""
+        return self.hdu[ext].header
+
+    @property
+    def time(self):
+        """Time measurements"""
+        return self.hdu[1].data['TIME'][self.quality_mask]
+
+    @property
+    def SAP_FLUX(self):
+        """Returns a LightCurve object for SAP_FLUX"""
+        return self.get_lightcurve('SAP_FLUX')
+
+    @property
+    def PDCSAP_FLUX(self):
+        """Returns a LightCurve object for PDCSAP_FLUX"""
+        return self.get_lightcurve('PDCSAP_FLUX')
+
+    @property
+    def cadenceno(self):
+        """Cadence number"""
+        return self.hdu[1].data['CADENCENO'][self.quality_mask]
+
+    def _flux_types(self):
+        """Returns a list of available flux types for this light curve file"""
+        types = [n for n in self.hdu[1].data.columns.names if 'FLUX' in n]
+        types = [n for n in types if not ('ERR' in n)]
+        return types
+
+    def _quality_mask(self, bitmask):
+        """Returns a boolean mask which flags all good-quality cadences.
+
+        Parameters
+        ----------
+        bitmask : str or int
+            Bitmask. See ref. [1], table 2-3.
+
+        Returns
+        -------
+        boolean_mask : array of bool
+            Boolean array in which `True` means the data is of good quality.
+        """
+        if bitmask is None:
+            return np.ones(len(self.hdu[1].data['TIME']), dtype=bool)
+
+        try:
+            if isinstance(bitmask, str):
+                bitmask = KeplerQualityFlags.OPTIONS[bitmask]
+            return (self.hdu[1].data['SAP_QUALITY'] & bitmask) == 0
+        except KeyError:
+            try:
+                if isinstance(bitmask, str):
+                    bitmask = TessQualityFlags.OPTIONS[bitmask]
+                return (self.hdu[1].data['QUALITY'] & bitmask) == 0
+            except KeyError:
+                raise
+
+
+class KeplerLightCurveFile(LightCurveFile):
     """Defines a class for a given light curve FITS file from NASA's Kepler and
     K2 missions.
 
@@ -583,31 +689,15 @@ class KeplerLightCurveFile(object):
     kwargs : dict
         Keyword arguments to be passed to astropy.io.fits.open.
     """
+
     def __init__(self, path, quality_bitmask=KeplerQualityFlags.DEFAULT_BITMASK,
                  **kwargs):
-        self.path = path
-        self.hdu = pyfits.open(self.path, **kwargs)
+        super(KeplerLightCurveFile, self).__init__(path, **kwargs)
         self.quality_bitmask = quality_bitmask
         self.quality_mask = self._quality_mask(quality_bitmask)
 
     def __repr__(self):
         return('KeplerLightCurveFile Object (ID: {})'.format(self.keplerid))
-
-    @property
-    def hdu(self):
-        return self._hdu
-
-    @hdu.setter
-    def hdu(self, value, keys=['SAP_FLUX', 'SAP_QUALITY']):
-        '''Raises a ValueError exception if value does not appear to be a Light Curve file.
-        '''
-        for key in keys:
-            if ~(np.any([value[1].header[ttype] == key
-                for ttype in value[1].header['TTYPE*']])):
-                raise ValueError("File {} does not have a {} column, "
-                         "is this a light curve file?".format(self.path, key))
-        else:
-            self._hdu = value
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():
@@ -627,45 +717,6 @@ class KeplerLightCurveFile(object):
         else:
             raise KeyError("{} is not a valid flux type. Available types are: {}".
                            format(flux_type, self._flux_types))
-
-    def _quality_mask(self, bitmask):
-        """Returns a boolean mask which flags all good-quality cadences.
-
-        Parameters
-        ----------
-        bitmask : str or int
-            Bitmask. See ref. [1], table 2-3.
-
-        Returns
-        -------
-        boolean_mask : array of bool
-            Boolean array in which `True` means the data is of good quality.
-        """
-        if bitmask is None:
-            return np.ones(len(self.hdu[1].data['TIME']), dtype=bool)
-        elif isinstance(bitmask, str):
-            bitmask = KeplerQualityFlags.OPTIONS[bitmask]
-        return (self.hdu[1].data['SAP_QUALITY'] & bitmask) == 0
-
-    @property
-    def SAP_FLUX(self):
-        """Returns a KeplerLightCurve object for SAP_FLUX"""
-        return self.get_lightcurve('SAP_FLUX')
-
-    @property
-    def PDCSAP_FLUX(self):
-        """Returns a KeplerLightCurve object for PDCSAP_FLUX"""
-        return self.get_lightcurve('PDCSAP_FLUX')
-
-    @property
-    def time(self):
-        """Time measurements"""
-        return self.hdu[1].data['TIME'][self.quality_mask]
-
-    @property
-    def cadenceno(self):
-        """Cadence number"""
-        return self.hdu[1].data['CADENCENO'][self.quality_mask]
 
     @property
     def channel(self):
@@ -717,37 +768,70 @@ class KeplerLightCurveFile(object):
         """
         return KeplerCBVCorrector(self).correct(cbvs=cbvs, **kwargs)
 
-    def header(self, ext=0):
-        """Header of the object at extension `ext`"""
-        return self.hdu[ext].header
-
-    def _flux_types(self):
-        """Returns a list of available flux types for this light curve file"""
-        types = [n for n in self.hdu[1].data.columns.names if 'FLUX' in n]
-        types = [n for n in types if not ('ERR' in n)]
-        return types
-
-    def plot(self, plottype=None, **kwargs):
+    def plot(self, flux_types=None, **kwargs):
         """Plot all the flux types in a light curve.
 
         Parameters
         ----------
-        plottype : str or list of str
+        flux_types : str or list of str
             List of FLUX types to plot. Default is to plot all available.
         """
         if not ('ax' in kwargs):
             fig, ax = plt.subplots(1)
             kwargs['ax'] = ax
-        if not ('title' in kwargs):
-            kwargs['title'] = 'KeplerID: {}'.format(self.SAP_FLUX.keplerid)
-        if plottype is None:
-            plottype = self._flux_types()
-        if isinstance(plottype, str):
-            plottype = [plottype]
-        for idx, pl in enumerate(plottype):
-            lc = self.get_lightcurve(pl)
+        if flux_types is None:
+            flux_types = self._flux_types()
+        if isinstance(flux_types, str):
+            flux_types = [flux_types]
+        for idx, ft in enumerate(flux_types):
+            lc = self.get_lightcurve(ft)
             kwargs['color'] = 'C{}'.format(idx)
-            lc.plot(label=pl, **kwargs)
+            lc.plot(label=ft, **kwargs)
+
+
+class TessLightCurveFile(LightCurveFile):
+    """Defines a class for a given light curve FITS file from NASA's TESS
+    mission.
+
+    Attributes
+    ----------
+    path : str
+        Directory path or url to a lightcurve FITS file.
+    quality_bitmask : str or int
+        Bitmask specifying quality flags of cadences that should be ignored.
+        If a string is passed, it has the following meaning:
+
+            * default: recommended quality mask
+            * hard: removes more flags, known to remove good data
+            * hardest: removes all data that has been flagged
+    kwargs : dict
+        Keyword arguments to be passed to astropy.io.fits.open.
+    """
+
+    def __init__(self, path, quality_bitmask=TessQualityFlags.DEFAULT_BITMASK,
+                 **kwargs):
+        super(TessLightCurveFile, self).__init__(path, **kwargs)
+        self.quality_bitmask = quality_bitmask
+        self.quality_mask = self._quality_mask(quality_bitmask)
+
+    def __repr__(self):
+        return('TessLightCurveFile Object (ID: {})'.format(self.keplerid))
+
+    @property
+    def ticid(self):
+        return self.header(ext=0)['TICID']
+
+    def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
+        if flux_type in self._flux_types():
+            return TessLightCurve(self.hdu[1].data['TIME'][self.quality_mask],
+                                  self.hdu[1].data[flux_type][self.quality_mask],
+                                  flux_err=self.hdu[1].data[flux_type + "_ERR"][self.quality_mask],
+                                  centroid_col=self.hdu[1].data[centroid_type + "1"][self.quality_mask],
+                                  centroid_row=self.hdu[1].data[centroid_type + "2"][self.quality_mask],
+                                  quality=self.hdu[1].data['SAP_QUALITY'][self.quality_mask],
+                                  quality_bitmask=self.quality_bitmask,
+                                  cadenceno=self.cadenceno,
+                                  ticid=self.keplerid)
 
 
 class SFFCorrector(object):
@@ -1137,161 +1221,6 @@ class KeplerCBVCorrector(object):
                     break
 
         return self.cbv_base_url + cbv_file
-
-
-class SPLDCorrector(object):
-    r"""
-    Implements the simple first order Pixel Level Decorrelation (PLD) proposed by
-    Deming et. al. [1]_ and Luger et. al. [2]_, [3]_.
-
-    Attributes
-    ----------
-
-
-    Notes
-    -----
-    This code serves only as a quick look into the PLD technique.
-    Users are encouraged to check out the GitHub repos
-    `everest <http://www.github.com/rodluger/everest>`_
-    and `everest3 <http://www.github.com/rodluger/everest3>`_.
-
-    References
-    ----------
-    .. [1] Deming et. al. Spitzer Secondary Eclipses of the Dense, \
-           Modestly-irradiated, Giant Exoplanet HAT-P-20b using Pixel-Level Decorrelation.
-    .. [2] Luger et. al. EVEREST: Pixel Level Decorrelation of K2 Light Curves.
-    .. [3] Luger et. al. An Update to the EVEREST K2 Pipeline: short cadence, \
-           saturated stars, and Kepler-like photometry down to K_p = 15.
-    """
-
-    def __init__(self):
-        pass
-
-    def correct(self, time, tpf_flux, window_length=None, polyorder=2):
-        """
-        Parameters
-        ----------
-        time : array-like
-            Time array
-        tpf_flux : array-like
-            Pixel values series
-        window_length : int
-        polyorder : int
-        """
-        k = window_length
-        if not k:
-            k = int(len(time) / 2) - 1
-        n_windows = int(len(time) / k)
-        flux_hat = np.array([])
-        for n in range(1, n_windows + 1):
-            flux_hat = np.append(flux_hat,
-                                 self._pld(tpf_flux[(n - 1) * k:n * k], polyorder))
-        flux_hat = np.append(flux_hat, self._pld(tpf_flux[n * k:], polyorder))
-        return LightCurve(time, flux_hat + np.nanmedian(np.nansum(tpf_flux, axis=(1, 2))))
-
-    def _pld(self, tpf_flux, polyorder=2):
-        if len(tpf_flux) == 0:
-            return np.array([])
-        pixels_series = tpf_flux.reshape((tpf_flux.shape[0], -1))
-        lightcurve = np.nansum(pixels_series, axis=1).reshape(-1, 1)
-        # design matrix
-        X = pixels_series / lightcurve
-        X = np.hstack((X, np.array([np.linspace(0, 1, tpf_flux.shape[0]) ** n for n in range(polyorder+1)]).T))
-        opt_weights = np.linalg.solve(np.dot(X.T, X), np.dot(X.T, lightcurve))
-        model = np.dot(X, opt_weights)
-        flux_hat = lightcurve - model
-        return flux_hat
-
-
-def box_period_search(lc, min_period=0.5, max_period=30, nperiods=2000,
-                      prior=None, period_scale='log'):
-    """
-    Implements a brute force search to find transit-like periodic events.
-    This function fits a "box" model defined as:
-
-    .. math::
-
-        \Pi (t) = h - d\cdot \mathbb{I}(t_0 \leq t_i \leq t_0 + w)
-
-    to a list of `nperiods` periods between `min_period` and `max_period`.
-    It's assumed that the best period is the one that maximizes the posterior
-    probability of the fit.
-
-    Parameters
-    ----------
-    lc : LightCurve object
-        An object from KeplerLightCurve or LightCurve.
-        Note that flattening the lightcurve beforehand does aid the quest
-        for the transit period.
-    min_period : float
-        Minimum period to search for. Units must be the same as `lc.time`.
-    max_period : float
-        Maximum period to search for. Units must be the same as `lc.time`.
-    nperiods : int
-        Number of periods to search between `min_period` and `max_period`.
-    prior : oktopus.Prior object
-        Prior probability on the parameters of the box function,
-        namely, `amplitude`, `depth`, `to` (time of the first discontinuity),
-        and `width`.
-    period_scale : str
-        Type of the scale used to create the grid of periods between `min_period`
-        and `max_period` used to search for the best period.
-        Options are 'linear' or 'log'.
-
-    Returns
-    -------
-    log_posterior : list
-        Log posterior (up to an additive constant) of the fit. The "best"
-        period is therefore the one that maximizes the log posterior
-        probability.
-    trial_periods : numpy array
-        List of trial periods.
-    best_period : float
-        Best period.
-
-    Notes
-    -----
-    This function is experimental. Changes may be made in both its signature
-    and implementation.
-    """
-
-    t = np.linspace(-.5, .5, len(lc.time))
-    val = np.zeros(len(lc.time))
-
-    def box(amplitude, depth, to, width):
-        """A simple box function defined in the interval [-.5, .5].
-        `to` is the time of the first discontinuity.
-        """
-        out_of_transit = (t < to) + (t >= to + width)
-        in_transit = np.logical_not(out_of_transit)
-        val[out_of_transit] = amplitude
-        val[in_transit] = amplitude - depth
-        return val
-
-    if prior is None:
-        prior = oktopus.UniformPrior(lb=[0.98, 0., -.4, 0.],
-                                     ub=[1.02, .1, .5, .2])
-    lc = lc.normalize()
-    log_posterior = []
-
-    if period_scale == 'linear':
-        trial_periods = np.linspace(min_period, max_period, nperiods)
-    elif period_scale == 'log':
-        trial_periods = np.logspace(np.log10(min_period), np.log10(max_period), nperiods)
-    else:
-        raise ValueError("period_scale must be one of {}. Got {}."
-                         .format("{'linear', 'log'}", period_scale))
-    for p in tqdm(trial_periods):
-        folded = lc.fold(period=p)
-        # var should be set to the uncertainty in the data point
-        ll = oktopus.GaussianPosterior(data=folded.flux, mean=box, var=1.,
-                                       prior=prior)
-        res = ll.fit(x0=prior.mean, method='powell',
-                     options={'ftol':1e-9, 'xtol':1e-9, 'maxfev': 2000})
-        # fun is the negative log posterior
-        log_posterior.append(-res.fun)
-
-    return log_posterior, trial_periods, trial_periods[np.argmax(log_posterior)]
 
 
 def iterative_box_period_search(lc, niters=2, min_period=0.5, max_period=30,

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -741,7 +741,10 @@ class KeplerLightCurveFile(LightCurveFile):
         return KeplerLightCurveFile(path)
 
     def __repr__(self):
-        return('KeplerLightCurveFile Object (ID: {})'.format(self.keplerid))
+        if self.mission.lower() == 'kepler':
+            return('KeplerLightCurveFile(KIC: {})'.format(self.keplerid))
+        elif self.mission.lower() == 'k2':
+            return('KeplerLightCurveFile(EPIC: {})'.format(self.keplerid))
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():
@@ -859,7 +862,7 @@ class TessLightCurveFile(LightCurveFile):
         self.quality_mask = self._quality_mask(quality_bitmask)
 
     def __repr__(self):
-        return('TessLightCurveFile Object (ID: {})'.format(self.keplerid))
+        return('TessLightCurveFile(TICID: {})'.format(self.keplerid))
 
     @property
     def ticid(self):
@@ -872,10 +875,10 @@ class TessLightCurveFile(LightCurveFile):
                                   flux_err=self.hdu[1].data[flux_type + "_ERR"][self.quality_mask],
                                   centroid_col=self.hdu[1].data[centroid_type + "1"][self.quality_mask],
                                   centroid_row=self.hdu[1].data[centroid_type + "2"][self.quality_mask],
-                                  quality=self.hdu[1].data['SAP_QUALITY'][self.quality_mask],
+                                  quality=self.hdu[1].data['QUALITY'][self.quality_mask],
                                   quality_bitmask=self.quality_bitmask,
                                   cadenceno=self.cadenceno,
-                                  ticid=self.keplerid)
+                                  ticid=self.ticid)
 
 
 class SFFCorrector(object):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -653,34 +653,6 @@ class LightCurveFile(object):
         types = [n for n in types if not ('ERR' in n)]
         return types
 
-    def _quality_mask(self, bitmask):
-        """Returns a boolean mask which flags all good-quality cadences.
-
-        Parameters
-        ----------
-        bitmask : str or int
-            Bitmask. See ref. [1], table 2-3.
-
-        Returns
-        -------
-        boolean_mask : array of bool
-            Boolean array in which `True` means the data is of good quality.
-        """
-        if bitmask is None:
-            return np.ones(len(self.hdu[1].data['TIME']), dtype=bool)
-
-        try:
-            if isinstance(bitmask, str):
-                bitmask = KeplerQualityFlags.OPTIONS[bitmask]
-            return (self.hdu[1].data['SAP_QUALITY'] & bitmask) == 0
-        except KeyError:
-            try:
-                if isinstance(bitmask, str):
-                    bitmask = TessQualityFlags.OPTIONS[bitmask]
-                return (self.hdu[1].data['QUALITY'] & bitmask) == 0
-            except KeyError:
-                raise
-
 
 class KeplerLightCurveFile(LightCurveFile):
     """Defines a class for a given light curve FITS file from NASA's Kepler and
@@ -756,6 +728,26 @@ class KeplerLightCurveFile(LightCurveFile):
             return('KeplerLightCurveFile(KIC: {})'.format(self.keplerid))
         elif self.mission.lower() == 'k2':
             return('KeplerLightCurveFile(EPIC: {})'.format(self.keplerid))
+
+    def _quality_mask(self, bitmask):
+        """Returns a boolean mask which flags all good-quality cadences.
+
+        Parameters
+        ----------
+        bitmask : str or int
+            Bitmask. See ref. [1], table 2-3.
+
+        Returns
+        -------
+        boolean_mask : array of bool
+            Boolean array in which `True` means the data is of good quality.
+        """
+        if bitmask is None:
+            return np.ones(len(self.hdu[1].data['TIME']), dtype=bool)
+
+        if isinstance(bitmask, str):
+            bitmask = KeplerQualityFlags.OPTIONS[bitmask]
+        return (self.hdu[1].data['SAP_QUALITY'] & bitmask) == 0
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():
@@ -874,6 +866,26 @@ class TessLightCurveFile(LightCurveFile):
 
     def __repr__(self):
         return('TessLightCurveFile(TICID: {})'.format(self.ticid))
+
+    def _quality_mask(self, bitmask):
+        """Returns a boolean mask which flags all good-quality cadences.
+
+        Parameters
+        ----------
+        bitmask : str or int
+            Bitmask. See ref. [1], table 2-3.
+
+        Returns
+        -------
+        boolean_mask : array of bool
+            Boolean array in which `True` means the data is of good quality.
+        """
+        if bitmask is None:
+            return np.ones(len(self.hdu[1].data['TIME']), dtype=bool)
+
+        if isinstance(bitmask, str):
+            bitmask = TessQualityFlags.OPTIONS[bitmask]
+        return (self.hdu[1].data['QUALITY'] & bitmask) == 0
 
     @property
     def ticid(self):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -29,6 +29,29 @@ class TargetPixelFile(object):
         pass
 
 
+class TessTargetPixelFile(TargetPixelFile):
+    """
+    Defines a TargetPixelFile class for the TESS Mission.
+    Enables extraction of raw lightcurves and centroid positions.
+
+    Attributes
+    ----------
+    path : str
+        Path to a Kepler Target Pixel (FITS) File.
+    quality_bitmask : str or int
+        Bitmask specifying quality flags of cadences that should be ignored.
+        If a string is passed, it has the following meaning:
+
+            * "default": recommended quality mask
+            * "hard": removes more flags, known to remove good data
+            * "hardest": removes all data that has been flagged
+
+    References
+    ----------
+    .. [1] Kepler: A Search for Terrestrial Planets. Kepler Archive Manual.
+        http://archive.stsci.edu/kepler/manuals/archive_manual.pdf
+    """
+
 class KeplerTargetPixelFile(TargetPixelFile):
     """
     Defines a TargetPixelFile class for the Kepler/K2 Mission.

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -15,6 +15,8 @@ TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
             "/0084/008462852/kplr008462852-2011073133259_llc.fits")
 TABBY_TPF = ("https://archive.stsci.edu/missions/kepler/target_pixel_files"
             "/0084/008462852/kplr008462852-2011073133259_lpd-targ.fits.gz")
+K2_C08 = ("https://archive.stsci.edu/missions/k2/lightcurves/c8/"
+          "220100000/39000/ktwo220139473-c08_llc.fits")
 KEPLER10 = ("https://archive.stsci.edu/missions/kepler/lightcurves/"
             "0119/011904151/kplr011904151-2010009091648_llc.fits")
 TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/"
@@ -68,15 +70,21 @@ def test_kepler_cbv_fit():
 
 
 @pytest.mark.remote_data
-def test_KeplerLightCurve():
-    lcf = KeplerLightCurveFile(TABBY_Q8, quality_bitmask=None)
-    hdu = pyfits.open(TABBY_Q8)
+@pytest.mark.parametrize("path, mission", [(TABBY_Q8, "Kepler"), (K2_C08, "K2")])
+def test_KeplerLightCurve(path, mission):
+    lcf = KeplerLightCurveFile(path, quality_bitmask=None)
+    hdu = pyfits.open(path)
     kplc = lcf.get_lightcurve('SAP_FLUX')
 
     assert kplc.channel == lcf.channel
-    assert kplc.campaign is None
-    assert kplc.quarter == lcf.quarter
-    assert kplc.mission == 'Kepler'
+    assert kplc.mission.lower() == mission.lower()
+    if kplc.mission.lower() == 'kepler':
+        assert kplc.campaign is None
+        assert kplc.quarter == 8
+    elif kplc.mission.lower() == 'k2':
+        assert kplc.campaign == 8
+        assert kplc.quarter is None
+
     assert_array_equal(kplc.time, hdu[1].data['TIME'])
     assert_array_equal(kplc.flux, hdu[1].data['SAP_FLUX'])
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -16,6 +16,8 @@ TABBY_TPF = ("https://archive.stsci.edu/missions/kepler/target_pixel_files"
             "/0084/008462852/kplr008462852-2011073133259_lpd-targ.fits.gz")
 KEPLER10 = ("https://archive.stsci.edu/missions/kepler/lightcurves/"
             "0119/011904151/kplr011904151-2010009091648_llc.fits")
+TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/"
+            "004/104/tess2019128220341-0000000410458113-0016-s_lc.fits")
 
 
 def test_LightCurve():
@@ -212,7 +214,6 @@ def test_iterative_box_period_search():
     _, _, kepler10b_period = iterative_box_period_search(flat, min_period=.5, max_period=1,
                                                          nperiods=101, period_scale='log')
     assert abs(kepler10b_period - answer) < 1e-2
-
 
 
 def test_to_pandas():

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -90,8 +90,11 @@ def test_KeplerLightCurve(path, mission):
 
 
 @pytest.mark.remote_data
-def test_TessLightCurveFile():
-    tess_file = TessLightCurveFile(TESS_SIM, quality_bitmask=None)
+@pytest.mark.parametrize("quality_bitmask",
+                         ['hardest', 'hard', 'default', None,
+                          1, 100, 2096639])
+def test_TessLightCurveFile(quality_bitmask):
+    tess_file = TessLightCurveFile(TESS_SIM, quality_bitmask=quality_bitmask)
     hdu = pyfits.open(TESS_SIM)
     tlc = tess_file.SAP_FLUX
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -7,8 +7,7 @@ from numpy.testing import (assert_almost_equal, assert_array_equal,
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits as pyfits
 from ..lightcurve import (LightCurve, KeplerCBVCorrector, KeplerLightCurveFile,
-                          SFFCorrector, KeplerLightCurve, box_period_search,
-                          iterative_box_period_search)
+                          SFFCorrector, KeplerLightCurve, iterative_box_period_search)
 
 # 8th Quarter of Tabby's star
 TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
@@ -63,14 +62,6 @@ def test_kepler_cbv_fit():
     lcf = KeplerLightCurveFile(TABBY_Q8)
     cbv_lcf = lcf.compute_cotrended_lightcurve()
     assert_almost_equal(cbv_lc.flux, cbv_lcf.flux)
-
-
-@pytest.mark.remote_data
-def test_load_bad_file():
-    """Test if a TPF can be opened without exception."""
-    with pytest.raises(ValueError) as exc:
-        lcf = KeplerLightCurveFile(TABBY_TPF)
-    assert('is this a light curve file?' in exc.value.args[0])
 
 
 @pytest.mark.remote_data
@@ -211,16 +202,12 @@ def test_normalize():
 
 
 @pytest.mark.remote_data
-def test_box_period_search():
+def test_iterative_box_period_search():
     """Can we recover the orbital period of Kepler-10b?"""
     answer = 0.837495 # wikipedia
     klc = KeplerLightCurveFile(KEPLER10)
     pdc = klc.PDCSAP_FLUX
     flat, trend = pdc.flatten(return_trend=True)
-
-    _, _, kepler10b_period = box_period_search(flat, min_period=.5, max_period=1,
-                                               nperiods=101, period_scale='log')
-    assert abs(kepler10b_period - answer) < 1e-2
 
     _, _, kepler10b_period = iterative_box_period_search(flat, min_period=.5, max_period=1,
                                                          nperiods=101, period_scale='log')

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -7,7 +7,8 @@ from numpy.testing import (assert_almost_equal, assert_array_equal,
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits as pyfits
 from ..lightcurve import (LightCurve, KeplerCBVCorrector, KeplerLightCurveFile,
-                          SFFCorrector, KeplerLightCurve, iterative_box_period_search)
+                          TessLightCurveFile, SFFCorrector, KeplerLightCurve,
+                          TessLightCurve, iterative_box_period_search)
 
 # 8th Quarter of Tabby's star
 TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
@@ -77,6 +78,18 @@ def test_KeplerLightCurve():
     assert kplc.quarter == lcf.quarter
     assert kplc.mission == 'Kepler'
     assert_array_equal(kplc.time, hdu[1].data['TIME'])
+    assert_array_equal(kplc.flux, hdu[1].data['SAP_FLUX'])
+
+
+@pytest.mark.remote_data
+def test_TessLightCurveFile():
+    tess_file = TessLightCurveFile(TESS_SIM, quality_bitmask=None)
+    hdu = pyfits.open(TESS_SIM)
+    tlc = tess_file.SAP_FLUX
+
+    assert tlc.mission.lower() == 'tess'
+    assert_array_equal(tlc.time, hdu[1].data['TIME'])
+    assert_array_equal(tlc.flux, hdu[1].data['SAP_FLUX'])
 
 
 @pytest.mark.remote_data

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -4,7 +4,7 @@ from astropy.visualization import (PercentileInterval, ImageNormalize,
                                    SqrtStretch, LogStretch, LinearStretch)
 
 
-__all__ = ['KeplerQualityFlags', 'module_output_to_channel',
+__all__ = ['KeplerQualityFlags', 'TessQualityFlags', 'module_output_to_channel',
            'channel_to_module_output', 'running_mean']
 
 
@@ -177,6 +177,10 @@ class KeplerQualityFlags(object):
             if quality & flag > 0:
                 result.append(cls.STRINGS[flag])
         return result
+
+
+class TessQualityFlags(KeplerQualityFlags):
+    pass
 
 
 def plot_image(image, ax=None, scale='linear', origin='lower',


### PR DESCRIPTION
This PR implements the following:

```
import matplotlib.pyplot as plt
from lightkurve import TessLightCurveFile

tlc = TessLightCurveFile("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/004/104/"
                         "tess2019128220341-0000000410458113-0016-s_lc.fits")
sap = tlc.SAP_FLUX
flat, trend = sap.flatten(window_length=1001, return_trend=True)
plt.figure(figsize=[17, 4])
plt.plot(sap.time, sap.flux, 'ko', markersize=2)
plt.plot(trend.time, trend.flux)
```
in which ``tlc.SAP_FLUX`` is an object from the ``TessLightCurve`` class.

Additionally, this PR does the following secondary changes:

1. removes ``box_period_search`` in favor of ``iterative_box_period_search`` (which will also be removed in favor of ``transit_periodogram`` which will be available in ``astropy`` soon.)
2. removes ``SPLDCorrector`` since it was not well enough tested.