### PR TITLE
A quick fix for Issue #32-- simply put None for mission, if not available

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -366,8 +366,12 @@ class KeplerTargetPixelFile(TargetPixelFile):
 
     @property
     def mission(self):
-        """Mission name"""
-        return self.header(ext=0)['MISSION']
+        """Mission name, defaults to None if Not available"""
+        try:
+            out = self.header(ext=0)['MISSION']
+        except:
+            out = None
+        return
 
     def to_fits(self):
         """Save the TPF to fits"""

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -371,7 +371,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
             out = self.header(ext=0)['MISSION']
         except:
             out = None
-        return
+        return out
 
     def to_fits(self):
         """Save the TPF to fits"""


### PR DESCRIPTION
A teeny-tiny pull request to allow the Kepler "two-wheeled concept engineering" data to be used in its current form.  Useful for our K2SFF head-to-head comparison.