### PR TITLE
Implement `LightCurve.__getitem__()` to enable slicing and masking

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -38,21 +38,30 @@ class LightCurve(object):
     """
 
     def __init__(self, time, flux, flux_err=None, meta={}):
-        self.time, self.flux, self.flux_err = self._validate_inputs(time, flux, flux_err)
+        self.time = np.asarray(time)
+        self.flux = self._validate_array(flux, name='flux')
+        self.flux_err = self._validate_array(flux_err, name='flux_err')
         self.meta = meta
 
-    def _validate_inputs(self, time, flux, flux_err):
-        if flux_err is not None:
-            flux_err = np.asarray(flux_err)
+    def _validate_array(self, arr, name='array'):
+        """Ensure the input arrays have the same length as `self.time`."""
+        if arr is not None:
+            arr = np.asarray(arr)
         else:
-            flux_err = np.nan * np.ones_like(flux)
+            arr = np.nan * np.ones_like(self.time)
 
-        if not (len(time) == len(flux)):
+        if not (len(self.time) == len(arr)):
             raise ValueError("Input arrays have different lengths."
-                             " len(time)={}, len(flux)={}, len(flux_err)={}"
-                             .format(len(time), len(flux), len(flux_err)))
+                             " len(time)={}, len({})={}"
+                             .format(len(self.time), name, len(arr)))
+        return arr
 
-        return np.asarray(time), np.asarray(flux), flux_err
+    def __getitem__(self, key):
+        copy_self = copy.copy(self)
+        copy_self.time = self.time[key]
+        copy_self.flux = self.flux[key]
+        copy_self.flux_err = self.flux_err[key]
+        return copy_self
 
     def __add__(self, other):
         copy_self = copy.copy(self)
@@ -214,12 +223,7 @@ class LightCurve(object):
         clean_lightcurve : LightCurve object
             A new ``LightCurve`` from which NaNs fluxes have been removed.
         """
-        lc = copy.copy(self)
-        nan_mask = np.isnan(lc.flux)
-        lc.time = self.time[~nan_mask]
-        lc.flux = self.flux[~nan_mask]
-        lc.flux_err = self.flux_err[~nan_mask]
-        return lc
+        return self[~np.isnan(self.flux)]  # This will return a sliced copy
 
     def remove_outliers(self, sigma=5., return_mask=False, **kwargs):
         """Removes outlier flux values using sigma-clipping.
@@ -244,18 +248,10 @@ class LightCurve(object):
         clean_lightcurve : LightCurve object
             A new ``LightCurve`` in which outliers have been removed.
         """
-        new_lc = copy.copy(self)
-        outlier_mask = sigma_clip(data=new_lc.flux, sigma=sigma, **kwargs).mask
-        new_lc.time = self.time[~outlier_mask]
-        new_lc.flux = self.flux[~outlier_mask]
-        new_lc.flux_err = self.flux_err[~outlier_mask]
-        if hasattr(new_lc, 'centroid_col') and new_lc.centroid_col is not None:
-            new_lc.centroid_col = self.centroid_col[~outlier_mask]
-        if hasattr(new_lc, 'centroid_row') and new_lc.centroid_row is not None:
-            new_lc.centroid_row = self.centroid_row[~outlier_mask]
+        outlier_mask = sigma_clip(data=self.flux, sigma=sigma, **kwargs).mask
         if return_mask:
-            return new_lc, outlier_mask
-        return new_lc
+            return self[~outlier_mask], outlier_mask
+        return self[~outlier_mask]
 
     def bin(self, binsize=13, method='mean'):
         """Bins a lightcurve using a function defined by `method`
@@ -518,9 +514,9 @@ class KeplerLightCurve(LightCurve):
                  channel=None, campaign=None, quarter=None, mission=None,
                  cadenceno=None, keplerid=None):
         super(KeplerLightCurve, self).__init__(time, flux, flux_err)
-        self.centroid_col = centroid_col
-        self.centroid_row = centroid_row
-        self.quality = quality
+        self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
+        self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
+        self.quality = self._validate_array(quality, name='quality')
         self.quality_bitmask = quality_bitmask
         self.channel = channel
         self.campaign = campaign
@@ -528,6 +524,14 @@ class KeplerLightCurve(LightCurve):
         self.mission = mission
         self.cadenceno = cadenceno
         self.keplerid = keplerid
+
+    def __getitem__(self, key):
+        lc = super(KeplerLightCurve, self).__getitem__(key)
+        # Compared to `LightCurve`, we need to slice a few additional arrays:
+        lc.quality = self.quality[key]
+        lc.centroid_col = self.centroid_col[key]
+        lc.centroid_row = self.centroid_row[key]
+        return lc
 
     def __repr__(self):
         if self.mission is None:
@@ -601,13 +605,21 @@ class TessLightCurve(LightCurve):
                  centroid_row=None, quality=None, quality_bitmask=None,
                  cadenceno=None, ticid=None):
         super(TessLightCurve, self).__init__(time, flux, flux_err)
-        self.centroid_col = centroid_col
-        self.centroid_row = centroid_row
-        self.quality = quality
+        self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
+        self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
+        self.quality = self._validate_array(quality, name='quality')
         self.quality_bitmask = quality_bitmask
         self.mission = "TESS"
         self.cadenceno = cadenceno
         self.ticid = ticid
+
+    def __getitem__(self, key):
+        lc = super(TessLightCurve, self).__getitem__(key)
+        # Compared to `LightCurve`, we need to slice a few additional arrays:
+        lc.quality = self.quality[key]
+        lc.centroid_col = self.centroid_col[key]
+        lc.centroid_row = self.centroid_row[key]
+        return lc
 
     def __repr__(self):
         return('TessLightCurve(TICID: {})'.format(self.ticid))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -24,12 +24,12 @@ TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/"
 
 def test_LightCurve():
     err_string = ("Input arrays have different lengths."
-                  " len(time)=5, len(flux)=4, len(flux_err)=4")
+                  " len(time)=5, len(flux)=4")
     time = np.array([1, 2, 3, 4, 5])
     flux = np.array([1, 2, 3, 4])
 
     with pytest.raises(ValueError) as err:
-        lc = LightCurve(time=time, flux=flux)
+        LightCurve(time=time, flux=flux)
     assert err_string == err.value.args[0]
 
 
@@ -253,3 +253,47 @@ def test_lightcurvefile_repr():
     lcf = TessLightCurveFile(TESS_SIM)
     str(lcf)
     repr(lcf)
+
+
+def test_slicing():
+    """Does LightCurve.__getitem__() allow slicing?"""
+    time = np.linspace(0, 10, 10)
+    flux = np.linspace(100, 200, 10)
+    flux_err = np.linspace(5, 50, 10)
+    lc = LightCurve(time, flux, flux_err)
+    assert_array_equal(lc[0:5].time, time[0:5])
+    assert_array_equal(lc[2::2].flux, flux[2::2])
+    assert_array_equal(lc[5:9:-1].flux_err, flux_err[5:9:-1])
+
+    # KeplerLightCurves contain additional data arrays that need to be sliced
+    centroid_col = np.linspace(40, 50, 10)
+    centroid_row = np.linspace(50, 60, 10)
+    quality = np.linspace(70, 80, 10)
+    lc = KeplerLightCurve(time, flux, flux_err,
+                          centroid_col=centroid_col,
+                          centroid_row=centroid_row,
+                          quality=quality)
+    assert_array_equal(lc[::3].centroid_col, centroid_col[::3])
+    assert_array_equal(lc[4:].centroid_row, centroid_row[4:])
+    assert_array_equal(lc[10:2].quality, quality[10:2])
+
+
+def test_boolean_masking():
+    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, 1, 10], quality=[0, 0, 200])
+    assert_array_equal(lc[lc.flux < 5].time, [1, 2])
+    assert_array_equal(lc[lc.flux < 5].quality, [0, 0])
+
+
+def test_remove_nans():
+    """Does LightCurve.__getitem__() allow slicing?"""
+    time, flux = [1, 2, 3, 4], [100, np.nan, 102, np.nan]
+    lc_clean = LightCurve(time, flux).remove_nans()
+    assert_array_equal(lc_clean.time, [1, 3])
+    assert_array_equal(lc_clean.flux, [100, 102])
+
+
+def test_remove_outliers():
+    time, flux = [1, 2, 3, 4], [1, 1, 1000, 1]
+    lc_clean = LightCurve(time, flux).remove_outliers(sigma=1)
+    assert_array_equal(lc_clean.time, [1, 2, 4])
+    assert_array_equal(lc_clean.flux, [1, 1, 1])

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -277,6 +277,15 @@ def test_slicing():
     assert_array_equal(lc[4:].centroid_row, centroid_row[4:])
     assert_array_equal(lc[10:2].quality, quality[10:2])
 
+    # The same is true for TessLightCurve
+    lc = TessLightCurve(time, flux, flux_err,
+                        centroid_col=centroid_col,
+                        centroid_row=centroid_row,
+                        quality=quality)
+    assert_array_equal(lc[::4].centroid_col, centroid_col[::4])
+    assert_array_equal(lc[5:].centroid_row, centroid_row[5:])
+    assert_array_equal(lc[10:3].quality, quality[10:3])
+
 
 def test_boolean_masking():
     lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, 1, 10], quality=[0, 0, 200])


### PR DESCRIPTION
This PR adds a `__getitem__` method to `LightCurve` and its sub-classes so that you can now slice and mask `LightCurve` objects just like an array.  For example, this test now passes:

```
lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, 1, 10], quality=[0, 0, 200])
assert_array_equal(lc[lc.flux < 5].time, [1, 2])
assert_array_equal(lc[lc.flux < 5].quality, [0, 0])
```

An extra bonus is that this allowed me to considerably simplify the implementation of `remove_nans()` and `remove_outliers()` as part of this PR.  It also resolves the bug of `remove_outliers` not masking `quality` as was reported in #34.

To simplify the slicing, I changed `quality`, `centroid_col`, and `centroid_row` to behave just like `flux_err`: if any of these arrays are None, the constructor will convert them to an array of NaNs with the same length as `time`.  To do this, I replaced the `_validate_inputs` method with a more generic `_validate_array` method which is called by the constructor for each data array.