### PR TITLE
Rename `stitch()` to `append()`

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -93,32 +93,34 @@ class LightCurve(object):
     def __rdiv__(self, other):
         return self.__rtruediv__(other)
 
-    def stitch(self, others):
+    def append(self, others):
         """
-        Stitches LightCurve objects.
+        Append LightCurve objects.
 
         Parameters
         ----------
         others : LightCurve object or list of LightCurve objects
-            Light curves to be stitched.
+            Light curves to be appended to the current one.
 
         Returns
         -------
-        stitched_lc : LightCurve object
-            Stitched light curve.
+        new_lc : LightCurve object
+            Concatenated light curve.
         """
         if not hasattr(others, '__iter__'):
             others = [others]
-        time = self.time
-        flux = self.flux
-        flux_err = self.flux_err
-
+        new_lc = copy.copy(self)
         for i in range(len(others)):
-            time = np.append(time, others[i].time)
-            flux = np.append(flux, others[i].flux)
-            flux_err = np.append(flux_err, others[i].flux_err)
-
-        return LightCurve(time=time, flux=flux, flux_err=flux_err)
+            new_lc.time = np.append(new_lc.time, others[i].time)
+            new_lc.flux = np.append(new_lc.flux, others[i].flux)
+            new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
+            if hasattr(new_lc, 'quality'):
+                new_lc.quality = np.append(new_lc.quality, others[i].quality)
+            if hasattr(new_lc, 'centroid_col'):
+                new_lc.centroid_col = np.append(new_lc.centroid_col, others[i].centroid_col)
+            if hasattr(new_lc, 'centroid_row'):
+                new_lc.centroid_row = np.append(new_lc.centroid_row, others[i].centroid_row)
+        return new_lc
 
     def flatten(self, window_length=101, polyorder=3, return_trend=False, **kwargs):
         """

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -115,18 +115,22 @@ def test_lightcurve_fold():
     assert_almost_equal(np.max(fold.time), 0.5, 2)
 
 
-def test_lightcurve_stitch():
-    """Test ``LightCurve.stitch()``."""
+def test_lightcurve_append():
+    """Test ``LightCurve.append()``."""
     lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1])
-    lc = lc.stitch(lc)
+    lc = lc.append(lc)
     assert_array_equal(lc.flux, 2*[1, .5, 1])
     assert_array_equal(lc.time, 2*[1, 2, 3])
+    # KeplerLightCurve has extra data
+    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, .5, 1], quality=[10, 20, 30])
+    lc = lc.append(lc)
+    assert_array_equal(lc.quality, 2*[10, 20, 30])
 
 
-def test_lightcurve_stitch_multiple():
-    """Test ``LightCurve.stitch()`` for multiple lightcurves at once."""
+def test_lightcurve_append_multiple():
+    """Test ``LightCurve.append()`` for multiple lightcurves at once."""
     lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1])
-    lc = lc.stitch([lc, lc, lc])
+    lc = lc.append([lc, lc, lc])
     assert_array_equal(lc.flux, 4*[1, .5, 1])
     assert_array_equal(lc.time, 4*[1, 2, 3])
 


### PR DESCRIPTION
This PR proposes to rename `stitch()` to `append()`, consistent with e.g. Python lists and numpy arrays.

We might consider adding a `sitch()` function that takes care of e.g. removing the jumps between different quarters of campaigns, but right now all the function was doing was appending data, so I feel like it should be called "append".

Thoughts?