### PR TITLE
Fixed normalize bug

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -213,8 +213,8 @@ class LightCurve(object):
             by the median.
         """
         lc = copy.copy(self)
-        lc.flux = lc.flux / np.nanmedian(lc.flux)
         lc.flux_err = lc.flux_err / np.nanmedian(lc.flux)
+        lc.flux = lc.flux / np.nanmedian(lc.flux)
         return lc
 
     def remove_nans(self):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -177,8 +177,9 @@ def test_bin():
 
 def test_normalize():
     """Does the `LightCurve.normalize()` method normalize the flux?"""
-    lc = LightCurve(time=np.arange(10), flux=5*np.ones(10))
+    lc = LightCurve(time=np.arange(10), flux=5*np.ones(10), flux_err=0.05*np.ones(10))
     assert_allclose(np.median(lc.normalize().flux), 1)
+    assert_allclose(np.median(lc.normalize().flux_err), 0.05/5)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
These are the wrong way round. This won't normalize the errors, and it breaks the plotting routines.
```
lc.flux = lc.flux / np.nanmedian(lc.flux)	
lc.flux_err = lc.flux_err / np.nanmedian(lc.flux)
```
It's odd we don't have a unit test for this?