### PR TITLE
Made plots not break if errors are all Nans

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -408,8 +408,8 @@ class LightCurve(object):
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err
         else:
             flux, flux_err = self.flux, self.flux_err
-        if flux_err is None:
-            ax.plot(self.time, flux, marker='o', color=color,
+        if (flux_err is None) or (np.nansum(flux_err)==0):
+            ax.plot(self.time, flux, marker='.', color=color,
                     linestyle=linestyle, **kwargs)
         else:
             ax.errorbar(self.time, flux, flux_err, color=color,

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -408,7 +408,7 @@ class LightCurve(object):
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err
         else:
             flux, flux_err = self.flux, self.flux_err
-        if (flux_err is None) or (np.nansum(flux_err)==0):
+        if np.any(np.isfinite(flux_err)):
             ax.plot(self.time, flux, marker='.', color=color,
                     linestyle=linestyle, **kwargs)
         else:


### PR DESCRIPTION
Now plots won't break if all the errors are NaN's or zeros. This was a common gotcha for why `lc.plot()` produced a blank frame.