### PR TITLE
Added a describe function

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -111,7 +111,7 @@ class LightCurve(object):
         attrs = {}
         for attr in dir(self):
             if not attr.startswith('_'):
-                res = getattr(self,attr)
+                res = getattr(self, attr)
                 if callable(res):
                     continue
                 if attr == 'hdu':
@@ -122,7 +122,6 @@ class LightCurve(object):
                         else:
                             attrs[attr]['print'] = '{}, {}'.format(attrs[attr]['print'], '{}'.format(r.header['EXTNAME']))
                     continue
-
                 else:
                     attrs[attr] = {'res':res}
                 if isinstance(res, int):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy import signal
 from scipy.optimize import minimize
 from matplotlib import pyplot as plt
+import pandas as pd
 
 from astropy.stats import sigma_clip
 from astropy.table import Table
@@ -101,6 +102,50 @@ class LightCurve(object):
 
     def __rdiv__(self, other):
         return self.__rtruediv__(other)
+
+    def describe(self):
+        '''Print out a description of each of the non-callable attributes of a
+        LightCurve object.
+
+        Prints in order of type (ints, strings, lists, arrays and others)
+        Prints in alphabetical order.'''
+        attrs = {}
+        for attr in dir(self):
+            if not attr.startswith('_'):
+                res = getattr(self,attr)
+                if callable(res):
+                    continue
+                attrs[attr] = {'res':res}
+                if isinstance(res, int):
+                    attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'int'
+                elif isinstance(res, np.ndarray):
+                    attrs[attr]['print'] = 'np.ndarray shape {}'.format(res.shape)
+                    attrs[attr]['type'] = 'array'
+                elif isinstance(res, list):
+                    attrs[attr]['print'] = 'list length {}'.format(len(res))
+                    attrs[attr]['type'] = 'list'
+                elif isinstance(res, str):
+                    if res == '':
+                        attrs[attr]['print'] = '{}'.format('None')
+                    else:
+                        attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'str'
+                elif attr == 'wcs':
+                    attrs[attr]['print'] = 'astropy.wcs.wcs.WCS'.format(attr)
+                    attrs[attr]['type'] = 'other'
+                else:
+                    attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'other'
+        output = pd.DataFrame(columns=['Attribute', 'Description'], dtype=str)
+        idx = 0
+        types = ['int','str', 'list', 'array', 'other']
+        for typ in types:
+            for attr, dic in attrs.items():
+                if dic['type'] == typ:
+                    output.loc[idx, ['Attribute', 'Description']] = [attr, dic['print']]
+                    idx+=1
+        print (output.to_string(index=False))
 
     def append(self, others):
         """

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -9,6 +9,7 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from matplotlib import patches
 import numpy as np
+import pandas as pd
 from tqdm import tqdm
 
 from . import PACKAGEDIR
@@ -35,6 +36,51 @@ class TargetPixelFile(object):
             for each cadence.
         """
         pass
+
+    def describe(self):
+        '''Print out a description of each of the non-callable attributes of a
+        TargetPixelFile object.
+
+        Prints in order of type (ints, strings, lists, arrays and others)
+        Prints in alphabetical order.'''
+        attrs = {}
+        for attr in dir(self):
+            if not attr.startswith('_'):
+                res = getattr(self,attr)
+                if callable(res):
+                    continue
+                attrs[attr] = {'res':res}
+                if isinstance(res, int):
+                    attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'int'
+                elif isinstance(res, np.ndarray):
+                    attrs[attr]['print'] = 'np.ndarray shape {}'.format(res.shape)
+                    attrs[attr]['type'] = 'array'
+                elif isinstance(res, list):
+                    attrs[attr]['print'] = 'list length {}'.format(len(res))
+                    attrs[attr]['type'] = 'list'
+                elif isinstance(res, str):
+                    if res == '':
+                        attrs[attr]['print'] = '{}'.format('None')
+                    else:
+                        attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'str'
+                elif attr == 'wcs':
+                    attrs[attr]['print'] = 'astropy.wcs.wcs.WCS'.format(attr)
+                    attrs[attr]['type'] = 'other'
+                else:
+                    attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['type'] = 'other'
+        output = pd.DataFrame(columns=['Attribute', 'Description'], dtype=str)
+        idx = 0
+        types = ['int','str', 'list', 'array', 'other']
+        for typ in types:
+            for attr, dic in attrs.items():
+                if dic['type'] == typ:
+                    output.loc[idx, ['Attribute', 'Description']] = [attr, dic['print']]
+                    idx+=1
+        print (output.to_string(index=False))
+
 
 
 class TessTargetPixelFile(TargetPixelFile):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -9,7 +9,6 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from matplotlib import patches
 import numpy as np
-import pandas as pd
 from tqdm import tqdm
 
 from . import PACKAGEDIR
@@ -37,7 +36,7 @@ class TargetPixelFile(object):
         """
         pass
 
-    def describe(self):
+    def properties(self):
         '''Print out a description of each of the non-callable attributes of a
         TargetPixelFile object.
 
@@ -49,12 +48,22 @@ class TargetPixelFile(object):
                 res = getattr(self,attr)
                 if callable(res):
                     continue
-                attrs[attr] = {'res':res}
+                if attr == 'hdu':
+                    attrs[attr] = {'res':res, 'type':'list'}
+                    for idx, r in enumerate(res):
+                        if idx == 0:
+                            attrs[attr]['print'] = '{}'.format(r.header['EXTNAME'])
+                        else:
+                            attrs[attr]['print'] = '{}, {}'.format(attrs[attr]['print'], '{}'.format(r.header['EXTNAME']))
+                    continue
+
+                else:
+                    attrs[attr] = {'res':res}
                 if isinstance(res, int):
                     attrs[attr]['print'] = '{}'.format(res)
                     attrs[attr]['type'] = 'int'
                 elif isinstance(res, np.ndarray):
-                    attrs[attr]['print'] = 'np.ndarray shape {}'.format(res.shape)
+                    attrs[attr]['print'] = 'array {}'.format(res.shape)
                     attrs[attr]['type'] = 'array'
                 elif isinstance(res, list):
                     attrs[attr]['print'] = 'list length {}'.format(len(res))
@@ -69,17 +78,17 @@ class TargetPixelFile(object):
                     attrs[attr]['print'] = 'astropy.wcs.wcs.WCS'.format(attr)
                     attrs[attr]['type'] = 'other'
                 else:
-                    attrs[attr]['print'] = '{}'.format(res)
+                    attrs[attr]['print'] = '{}'.format(type(res))
                     attrs[attr]['type'] = 'other'
-        output = pd.DataFrame(columns=['Attribute', 'Description'], dtype=str)
+        output = Table(names=['Attribute', 'Description'], dtype=[object, object])
         idx = 0
-        types = ['int','str', 'list', 'array', 'other']
+        types = ['int', 'str', 'list', 'array', 'other']
         for typ in types:
             for attr, dic in attrs.items():
                 if dic['type'] == typ:
-                    output.loc[idx, ['Attribute', 'Description']] = [attr, dic['print']]
+                    output.add_row([attr, dic['print']])
                     idx+=1
-        print (output.to_string(index=False))
+        output.pprint(max_lines=-1, max_width=-1)
 
 
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -45,7 +45,7 @@ class TargetPixelFile(object):
         attrs = {}
         for attr in dir(self):
             if not attr.startswith('_'):
-                res = getattr(self,attr)
+                res = getattr(self, attr)
                 if callable(res):
                     continue
                 if attr == 'hdu':
@@ -56,7 +56,6 @@ class TargetPixelFile(object):
                         else:
                             attrs[attr]['print'] = '{}, {}'.format(attrs[attr]['print'], '{}'.format(r.header['EXTNAME']))
                     continue
-
                 else:
                     attrs[attr] = {'res':res}
                 if isinstance(res, int):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -313,11 +313,11 @@ def test_remove_outliers():
     assert_array_equal(lc_clean.flux, [1, 1, 1])
 
 @pytest.mark.remote_data
-def test_describe(capfd):
+def test_properties(capfd):
     '''Test if the describe function produces an output.
     The output is 624 characters at the moment, but we might add more properties.'''
     lcf = KeplerLightCurveFile(TABBY_Q8)
     kplc = lcf.get_lightcurve('SAP_FLUX')
-    kplc.describe()
+    kplc.properties()
     out, err = capfd.readouterr()
     assert len(out) > 500

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -311,3 +311,13 @@ def test_remove_outliers():
     lc_clean = LightCurve(time, flux).remove_outliers(sigma=1)
     assert_array_equal(lc_clean.time, [1, 2, 4])
     assert_array_equal(lc_clean.flux, [1, 1, 1])
+
+@pytest.mark.remote_data
+def test_describe(capfd):
+    '''Test if the describe function produces an output.
+    The output is 624 characters at the moment, but we might add more properties.'''
+    lcf = KeplerLightCurveFile(TABBY_Q8)
+    kplc = lcf.get_lightcurve('SAP_FLUX')
+    kplc.describe()
+    out, err = capfd.readouterr()
+    assert len(out) > 500

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -189,10 +189,10 @@ def test_tpf_factory():
     assert(tpf.time[0] == 5)
     assert(tpf.time[9] == 95)
 
-def test_describe(capfd):
+def test_properties(capfd):
     '''Test if the describe function produces an output.
     The output is 1870 characters at the moment, but we might add more properties.'''
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
-    tpf.describe()
+    tpf.properties()
     out, err = capfd.readouterr()
     assert len(out) > 1000

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 import tempfile
-
+import sys
 from ..targetpixelfile import KeplerTargetPixelFile, KeplerTargetPixelFileFactory
 from ..utils import KeplerQualityFlags
 
@@ -188,3 +188,11 @@ def test_tpf_factory():
     assert_array_equal(tpf.flux[9], flux_9)
     assert(tpf.time[0] == 5)
     assert(tpf.time[9] == 95)
+
+def test_describe(capfd):
+    '''Test if the describe function produces an output.
+    The output is 1870 characters at the moment, but we might add more properties.'''
+    tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
+    tpf.describe()
+    out, err = capfd.readouterr()
+    assert len(out) > 1000


### PR DESCRIPTION
Since we're making new TPFs out of data from all kinds of sources I've found it useful to have a print function that gives me a clear/pretty overview of what's in the target pixel file. I've added a `describe` function to LightCurve and TargetPixelFile which describes the attributes in the object in a logical order.

<img width="634" alt="screen shot 2018-03-01 at 11 46 05 am" src="https://user-images.githubusercontent.com/14965634/36866067-24ab7d6a-1d46-11e8-9189-f04b0779427e.png">

<img width="398" alt="screen shot 2018-03-01 at 11 45 34 am" src="https://user-images.githubusercontent.com/14965634/36866043-1601aff0-1d46-11e8-9323-0eb591109cd4.png">

Comments/suggestions/improvements welcome!