### PR TITLE
Flatten has better behavior around discontinuities.

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -131,7 +131,8 @@ class LightCurve(object):
                 new_lc.centroid_row = np.append(new_lc.centroid_row, others[i].centroid_row)
         return new_lc
 
-    def flatten(self, window_length=101, polyorder=2, return_trend=False, **kwargs):
+    def flatten(self, window_length=101, polyorder=2, return_trend=False,
+                break_tolerance = 5, **kwargs):
         """
         Removes low frequency trend using scipy's Savitzky-Golay filter.
 
@@ -146,6 +147,11 @@ class LightCurve(object):
         return_trend : bool
             If `True`, the method will return a tuple of two elements
             (flattened_lc, trend_lc) where trend_lc is the removed trend.
+        break_tolerance : int
+            If there are large gaps in time, flatten will split the flux into several
+            sub-lightcurves and apply a savgol_filter to each individually. A gap is
+            defined as break_tolerance * the median gap in time. To turn off this feature,
+            set break_tolerance to None
         **kwargs : dict
             Dictionary of arguments to be passed to `scipy.signal.savgol_filter`.
 
@@ -157,10 +163,12 @@ class LightCurve(object):
         trend_lc : LightCurve object
             Trend in the lightcurve data
         """
-        lc_clean = self.remove_nans()  # The SG filter does not allow NaNs
+        if break_tolerance is None:
+            break_tolerance = np.nan
+        lc_clean = self.remove_nans()
         #Find breaks in time
-        dt = lc_clean.time[1:]-lc_clean.time[0:-1]
-        cut = np.where(dt > 5*np.nanmedian(dt))[0]+1
+        dt = lc_clean.time[1:] - lc_clean.time[0:-1]
+        cut = np.where(dt > break_tolerance * np.nanmedian(dt))[0] + 1
         low = np.append([0], cut)
         high = np.append(cut, len(lc_clean.time))
         trend_signal = np.zeros(len(lc_clean.time))
@@ -168,12 +176,10 @@ class LightCurve(object):
             trend_signal[l:h] = signal.savgol_filter(x=lc_clean.flux[l:h],
                                                      window_length=window_length,
                                                      polyorder=polyorder, **kwargs)
-
         trend_signal = np.interp(self.time, lc_clean.time, trend_signal)
         flatten_lc = copy.deepcopy(self)
         flatten_lc.flux /= trend_signal
         flatten_lc.flux_err /= trend_signal
-
         if return_trend:
             trend_lc = copy.deepcopy(self)
             trend_lc.flux = trend_signal

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -131,7 +131,7 @@ class LightCurve(object):
                 new_lc.centroid_row = np.append(new_lc.centroid_row, others[i].centroid_row)
         return new_lc
 
-    def flatten(self, window_length=101, polyorder=1, return_trend=False, **kwargs):
+    def flatten(self, window_length=101, polyorder=2, return_trend=False, **kwargs):
         """
         Removes low frequency trend using scipy's Savitzky-Golay filter.
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -131,7 +131,7 @@ class LightCurve(object):
                 new_lc.centroid_row = np.append(new_lc.centroid_row, others[i].centroid_row)
         return new_lc
 
-    def flatten(self, window_length=101, polyorder=3, return_trend=False, **kwargs):
+    def flatten(self, window_length=101, polyorder=1, return_trend=False, **kwargs):
         """
         Removes low frequency trend using scipy's Savitzky-Golay filter.
 


### PR DESCRIPTION
When the spacecraft is down there is a break in the 'time' axis of a light curve and usually a sharp increase or decrease in flux as the spacecraft settles. This causes a problem for the savgol filter in flatten.

I've fixed this by having flatten 'split' the light curve into different groups anywhere where 5 or more time points are missing.

I've also made it so that flatten returns a light curve that's the same shape as the original. Before it would remove nans and then give that shorter light curve back.

<img width="446" alt="screen shot 2018-03-01 at 4 06 35 pm" src="https://user-images.githubusercontent.com/14965634/36876577-891caeee-1d6a-11e8-9149-c4999753cc16.png">
