### PR TITLE
Fixed plot marker bug and cycling issue, added style support.

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -10,6 +10,8 @@ import numpy as np
 from scipy import signal
 from scipy.optimize import minimize
 from matplotlib import pyplot as plt
+from cycler import cycler
+import matplotlib as mpl
 
 from astropy.stats import sigma_clip
 from astropy.table import Table
@@ -423,8 +425,8 @@ class LightCurve(object):
         return cdpp_ppm
 
     def plot(self, ax=None, normalize=True, xlabel='Time - 2454833 (days)',
-             ylabel='Normalized Flux', title=None, color='#363636', linestyle="",
-             fill=False, grid=True, **kwargs):
+             ylabel='Normalized Flux', title=None,
+             fill=False, grid=True, context='fast', **kwargs):
         """Plots the light curve.
 
         Parameters
@@ -440,12 +442,14 @@ class LightCurve(object):
             Plot y axis label
         title : str
             Plot set_title
-        color: str
-            Color to plot flux points
-        fill: bool
+        color : str
+            Color to plot line in
+        fill : bool
             Shade the region between 0 and flux
-        grid: bool
-            Add a grid to the plot
+        grid : bool
+            Plot with a grid
+        context : str
+            matplotlib.pyplot.style.context, default is 'default'
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
 
@@ -454,29 +458,29 @@ class LightCurve(object):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
-        if ax is None:
-            fig, ax = plt.subplots(1)
         if normalize:
             normalized_lc = self.normalize()
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err
         else:
             flux, flux_err = self.flux, self.flux_err
-        if np.any(np.isfinite(flux_err)):
-            ax.plot(self.time, flux, marker='.', color=color,
-                    linestyle=linestyle, **kwargs)
-        else:
-            ax.errorbar(self.time, flux, flux_err, color=color,
-                        linestyle=linestyle, **kwargs)
-        if fill:
-            ax.fill(self.time, flux, fc='#a8a7a7', linewidth=0.0, alpha=0.3)
-        if grid:
-            ax.grid(alpha=0.3)
-        if 'label' in kwargs:
-            ax.legend()
-        if title is not None:
-            ax.set_title(title)
-        ax.set_xlabel(xlabel, {'color': 'k'})
-        ax.set_ylabel(ylabel, {'color': 'k'})
+        with plt.style.context(context):
+            if ax is None:
+                fig, ax = plt.subplots(1)
+            if ('color' not in kwargs) and (len(ax.lines)==0):
+                kwargs['color']='black'
+            if np.any(~np.isfinite(flux_err)):
+                ax.plot(self.time, flux, **kwargs)
+            else:
+                ax.errorbar(self.time, flux, flux_err, **kwargs)
+            if fill:
+                ax.fill(self.time, flux, linewidth=0.0, alpha=0.3)
+            if 'label' in kwargs:
+                ax.legend()
+            if title is not None:
+                ax.set_title(title)
+            ax.grid(grid, alpha=0.3)
+            ax.set_xlabel(xlabel)
+            ax.set_ylabel(ylabel)
         return ax
 
     def to_table(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -449,7 +449,7 @@ class LightCurve(object):
         grid : bool
             Plot with a grid
         context : str
-            matplotlib.pyplot.style.context, default is 'default'
+            matplotlib.pyplot.style.context, default is 'fast'
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
 

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -3,6 +3,7 @@
 from __future__ import division, print_function
 
 import numpy as np
+import matplotlib as mpl
 from matplotlib import pyplot as plt
 
 from astropy.io import fits as pyfits
@@ -242,7 +243,7 @@ class KeplerLightCurveFile(LightCurveFile):
         from .correctors import KeplerCBVCorrector
         return KeplerCBVCorrector(self).correct(cbvs=cbvs, **kwargs)
 
-    def plot(self, flux_types=None, **kwargs):
+    def plot(self, flux_types=None, context='fast', **kwargs):
         """Plot all the flux types in a light curve.
 
         Parameters
@@ -250,17 +251,18 @@ class KeplerLightCurveFile(LightCurveFile):
         flux_types : str or list of str
             List of FLUX types to plot. Default is to plot all available.
         """
-        if not ('ax' in kwargs):
-            fig, ax = plt.subplots(1)
-            kwargs['ax'] = ax
-        if flux_types is None:
-            flux_types = self._flux_types()
-        if isinstance(flux_types, str):
-            flux_types = [flux_types]
-        for idx, ft in enumerate(flux_types):
-            lc = self.get_lightcurve(ft)
-            kwargs['color'] = 'C{}'.format(idx)
-            lc.plot(label=ft, **kwargs)
+        with plt.style.context(context):
+            if not ('ax' in kwargs):
+                fig, ax = plt.subplots(1)
+                kwargs['ax'] = ax
+            if flux_types is None:
+                flux_types = self._flux_types()
+            if isinstance(flux_types, str):
+                flux_types = [flux_types]
+            for idx, ft in enumerate(flux_types):
+                lc = self.get_lightcurve(ft)
+                kwargs['color'] = np.asarray(mpl.rcParams['axes.prop_cycle'])[idx]['color']
+                lc.plot(label=ft, **kwargs)
 
 
 class TessLightCurveFile(LightCurveFile):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -8,6 +8,7 @@ from astropy.nddata import Cutout2D
 from astropy.table import Table
 from astropy.wcs import WCS
 from matplotlib import patches
+import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
 
@@ -541,7 +542,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         return col_centr, row_centr
 
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
-             show_colorbar=True, mask_color='pink', **kwargs):
+             show_colorbar=True, mask_color='pink', context='fast', **kwargs):
         """
         Plot a target pixel file at a given frame (index) or cadence number.
 
@@ -563,6 +564,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
             Whether or not to show the colorbar
         mask_color : str
             Color to show the aperture mask
+        context : str
+            matplotlib.pyplot.style.context, default is ggplot
         kwargs : dict
             Keywords arguments passed to `lightkurve.utils.plot_image`.
 
@@ -586,10 +589,11 @@ class KeplerTargetPixelFile(TargetPixelFile):
         except IndexError:
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.shape[0]))
-        ax = plot_image(pflux, ax=ax, title='Kepler ID: {}'.format(self.keplerid),
-                extent=(self.column, self.column + self.shape[2], self.row,
-                self.row + self.shape[1]), show_colorbar=show_colorbar, **kwargs)
-
+        with plt.style.context(context):
+            ax = plot_image(pflux, ax=ax, title='Kepler ID: {}'.format(self.keplerid),
+                    extent=(self.column, self.column + self.shape[2], self.row,
+                    self.row + self.shape[1]), show_colorbar=show_colorbar, **kwargs)
+            ax.grid(False)
         if aperture_mask is not None:
             aperture_mask = self._parse_aperture_mask(aperture_mask)
             for i in range(self.shape[1]):


### PR DESCRIPTION
Fixes #9 
There were a few problems with plotting which was preventing me from producing really nice tutorials/notebooks:

**marker bug** has where plot wouldn't accept a different marker style has been fixed.

**color cycling** has been fixed. Before if an additional line was added to a plot, they would always be plotted in black. Now they will be plotted in the color cycling order.
<img width="472" alt="screen shot 2018-03-01 at 5 17 51 pm" src="https://user-images.githubusercontent.com/14965634/36878681-e8174634-1d74-11e8-8f8e-1ad9fb455ce6.png">

**style sheets** now you can use the plt.style.context choices to make prettier plots by passing `context='ggplot'` to any of the plot functions, or your favorite style.
<img width="357" alt="screen shot 2018-03-01 at 5 18 02 pm" src="https://user-images.githubusercontent.com/14965634/36878688-f21fd574-1d74-11e8-9f50-fa3a1d598b6f.png">

**[Hopefully] the default style has not been changed by this PR**