### PR TITLE
Add a `FoldedLightCurve` class to fix the default plot labels of a folded light curve

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -268,9 +268,9 @@ class LightCurve(object):
         # fold time domain from -.5 to .5
         fold_time[fold_time > 0.5] -= 1
         sorted_args = np.argsort(fold_time)
-        return LightCurve(fold_time[sorted_args],
-                          self.flux[sorted_args],
-                          flux_err=self.flux_err[sorted_args])
+        return FoldedLightCurve(fold_time[sorted_args],
+                                self.flux[sorted_args],
+                                flux_err=self.flux_err[sorted_args])
 
     def normalize(self):
         """Returns a normalized version of the lightcurve.
@@ -550,6 +550,18 @@ class LightCurve(object):
             returns None otherwise.
         """
         return self.to_pandas().to_csv(path_or_buf=path_or_buf, **kwargs)
+
+
+class FoldedLightCurve(LightCurve):
+    """Defines a folded lightcurve with different plotting defaults."""
+    def __init__(self, *args, **kwargs):
+        super(FoldedLightCurve, self).__init__(*args, **kwargs)
+
+    def plot(self, **kwargs):
+        ax = super(FoldedLightCurve, self).plot(**kwargs)
+        if 'xlabel' not in kwargs:
+            ax.set_xlabel("Phase", {'color': 'k'})
+        return ax
 
 
 class KeplerLightCurve(LightCurve):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -557,6 +557,10 @@ class FoldedLightCurve(LightCurve):
     def __init__(self, *args, **kwargs):
         super(FoldedLightCurve, self).__init__(*args, **kwargs)
 
+    @property
+    def phase(self):
+        return self.time
+
     def plot(self, **kwargs):
         ax = super(FoldedLightCurve, self).plot(**kwargs)
         if 'xlabel' not in kwargs:

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -106,13 +106,13 @@ def test_lightcurve_fold():
     """Test the ``LightCurve.fold()`` method."""
     lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1)
     fold = lc.fold(period=1)
-    assert_almost_equal(fold.time[0], -0.5, 2)
-    assert_almost_equal(np.min(fold.time), -0.5, 2)
-    assert_almost_equal(np.max(fold.time), 0.5, 2)
+    assert_almost_equal(fold.phase[0], -0.5, 2)
+    assert_almost_equal(np.min(fold.phase), -0.5, 2)
+    assert_almost_equal(np.max(fold.phase), 0.5, 2)
     fold = lc.fold(period=1, phase=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
-    assert_almost_equal(np.min(fold.time), -0.5, 2)
-    assert_almost_equal(np.max(fold.time), 0.5, 2)
+    assert_almost_equal(np.min(fold.phase), -0.5, 2)
+    assert_almost_equal(np.max(fold.phase), 0.5, 2)
 
 
 def test_lightcurve_append():


### PR DESCRIPTION
This PR introduces a `FoldedLightCurve` class for the purpose of fixing the default plot labels (cf. #6).

It's not clear to me that there are other differences which justify the difference between `LightCurve` and `FoldedLightCurve`, so perhaps the use of inheritance is overkill here, but it's a nifty solution to #6 nonetheless.