### PR TITLE
Add `restore_trend` as an option to SFFCorrector

### DIFF
--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -363,7 +363,7 @@ class SFFCorrector(object):
 
             flux_hat = np.append(flux_hat, flux[i])
             if restore_trend:
-                flux_hat += self.trend
+                flux_hat *= self.trend
 
         return LightCurve(time=timecopy, flux=flux_hat)
 

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -272,7 +272,7 @@ class SFFCorrector(object):
 
     def correct(self, time, flux, centroid_col, centroid_row,
                 polyorder=5, niters=3, bins=15, windows=1, sigma_1=3.,
-                sigma_2=5., restore_trend=True):
+                sigma_2=5., restore_trend=False):
         """Returns a systematics-corrected LightCurve.
 
         Note that it is assumed that time and flux do not contain NaNs.


### PR DESCRIPTION
This PR provides the ability to put the long-term trend back into an SFF-corrected lightcurve, which is essential for supernovae.  Someone please review!