### PR TITLE
Make the 'fast' matplotlib style optional

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -477,6 +477,11 @@ class LightCurve(object):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
+        # The "fast" style has only been in matplotlib since v2.1.
+        # Let's make it optional until >v2.1 is mainstream and can
+        # be made the minimum requirement.
+        if (context == "fast") and ("fast" not in mpl.style.available):
+            context = "default"
         if normalize:
             normalized_lc = self.normalize()
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -445,7 +445,7 @@ class LightCurve(object):
 
     def plot(self, ax=None, normalize=True, xlabel='Time - 2454833 (days)',
              ylabel='Normalized Flux', title=None,
-             fill=False, grid=True, context='fast', **kwargs):
+             fill=False, grid=True, style='fast', **kwargs):
         """Plots the light curve.
 
         Parameters
@@ -467,7 +467,7 @@ class LightCurve(object):
             Shade the region between 0 and flux
         grid : bool
             Plot with a grid
-        context : str
+        style : str
             matplotlib.pyplot.style.context, default is 'fast'
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
@@ -480,18 +480,18 @@ class LightCurve(object):
         # The "fast" style has only been in matplotlib since v2.1.
         # Let's make it optional until >v2.1 is mainstream and can
         # be made the minimum requirement.
-        if (context == "fast") and ("fast" not in mpl.style.available):
-            context = "default"
+        if (style == "fast") and ("fast" not in mpl.style.available):
+            style = "default"
         if normalize:
             normalized_lc = self.normalize()
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err
         else:
             flux, flux_err = self.flux, self.flux_err
-        with plt.style.context(context):
+        with plt.style.context(style):
             if ax is None:
                 fig, ax = plt.subplots(1)
-            if ('color' not in kwargs) and (len(ax.lines)==0):
-                kwargs['color']='black'
+            if ('color' not in kwargs) and (len(ax.lines) == 0):
+                kwargs['color'] = 'black'
             if np.any(~np.isfinite(flux_err)):
                 ax.plot(self.time, flux, **kwargs)
             else:

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -243,15 +243,21 @@ class KeplerLightCurveFile(LightCurveFile):
         from .correctors import KeplerCBVCorrector
         return KeplerCBVCorrector(self).correct(cbvs=cbvs, **kwargs)
 
-    def plot(self, flux_types=None, context='fast', **kwargs):
-        """Plot all the flux types in a light curve.
+    def plot(self, flux_types=None, style='fast', **kwargs):
+        """Plot all the light curves contained in this light curve file.
 
         Parameters
         ----------
         flux_types : str or list of str
-            List of FLUX types to plot. Default is to plot all available.
+            List of flux types to plot. Default is to plot all available.
+            (For Kepler the default fluxes are 'SAP_FLUX' and 'PDCSAP-FLUX'.
+        style : str
+            matplotlib.pyplot.style.context, default is 'fast'
+        kwargs : dict
+            Dictionary of keyword arguments to be passed to
+            `KeplerLightCurve.plot()`.
         """
-        with plt.style.context(context):
+        with plt.style.context(style):
             if not ('ax' in kwargs):
                 fig, ax = plt.subplots(1)
                 kwargs['ax'] = ax

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -542,7 +542,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         return col_centr, row_centr
 
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
-             show_colorbar=True, mask_color='pink', context='fast', **kwargs):
+             show_colorbar=True, mask_color='pink', style='fast', **kwargs):
         """
         Plot a target pixel file at a given frame (index) or cadence number.
 
@@ -564,8 +564,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
             Whether or not to show the colorbar
         mask_color : str
             Color to show the aperture mask
-        context : str
-            matplotlib.pyplot.style.context, default is ggplot
+        style : str
+            matplotlib.pyplot.style.context, default is 'fast'
         kwargs : dict
             Keywords arguments passed to `lightkurve.utils.plot_image`.
 
@@ -574,6 +574,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
+        if (style == "fast") and ("fast" not in plt.style.available):
+            style = "default"
         if cadenceno is not None:
             try:
                 frame = np.argwhere(cadenceno == self.cadenceno)[0][0]
@@ -589,7 +591,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         except IndexError:
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.shape[0]))
-        with plt.style.context(context):
+        with plt.style.context(style):
             ax = plot_image(pflux, ax=ax, title='Kepler ID: {}'.format(self.keplerid),
                     extent=(self.column, self.column + self.shape[2], self.row,
                     self.row + self.shape[1]), show_colorbar=show_colorbar, **kwargs)


### PR DESCRIPTION
`LightCurve.plot()` & `KeplerTargetPixelFile.plot()` recently got `context='fast'` as a default matplotlib style parameters, but this style is only available in matplotlib 2.1 and later (released just a few months ago).  This PR makes sure plotting doesn't crash on earlier versions of matplotlib, because 2.1 is not our minimum requirement right now.