### PR TITLE
Bugfix: ensure quality and centroid attributes are binned

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -457,7 +457,7 @@ class LightCurve(object):
 
     def plot(self, ax=None, normalize=True, xlabel='Time - 2454833 (days)',
              ylabel='Normalized Flux', title=None,
-             fill=False, grid=True, style='fast', time=None, **kwargs):
+             fill=False, grid=True, style='fast', **kwargs):
         """Plots the light curve.
 
         Parameters
@@ -494,11 +494,6 @@ class LightCurve(object):
         # be made the minimum requirement.
         if (style == "fast") and ("fast" not in mpl.style.available):
             style = "default"
-        if not normalize and ylabel == 'Normalized Flux':
-            ylabel == 'Flux'
-        if time is None:
-            time = self.time
-        # Normalize the lightcurve if requested
         if normalize:
             normalized_lc = self.normalize()
             flux, flux_err = normalized_lc.flux, normalized_lc.flux_err

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -165,7 +165,8 @@ def test_cdpp_tabby():
 
 
 def test_bin():
-    lc = LightCurve(time=np.arange(10), flux=2*np.ones(10),
+    lc = LightCurve(time=np.arange(10),
+                    flux=2*np.ones(10),
                     flux_err=2**.5*np.ones(10))
     binned_lc = lc.bin(binsize=2)
     assert_allclose(binned_lc.flux, 2*np.ones(5))
@@ -173,6 +174,19 @@ def test_bin():
     assert len(binned_lc.time) == 5
     with pytest.raises(ValueError):
         lc.bin(method='doesnotexist')
+
+
+def test_bin_quality():
+    """Binning must also revise the quality and centroid columns."""
+    lc = KeplerLightCurve(time=[1, 2, 3, 4],
+                          flux=[1, 1, 1, 1],
+                          quality=[0, 1, 2, 3],
+                          centroid_col=[0, 1, 0, 1],
+                          centroid_row=[0, 2, 0, 2])
+    binned_lc = lc.bin(binsize=2)
+    assert_allclose(binned_lc.quality, [1, 3])  # Expect bitwise or
+    assert_allclose(binned_lc.centroid_col, [0.5, 0.5])  # Expect mean
+    assert_allclose(binned_lc.centroid_row, [1, 1])  # Expect mean
 
 
 def test_normalize():


### PR DESCRIPTION
The `LightCurve.bin()` method does not currently bin the quality and centroid arrays.  This PR fixes this!