### PR TITLE
Remove sensitivity to uppercase/lowercase in MAST API description field (fixes #68)

### DIFF
--- a/lightkurve/mast.py
+++ b/lightkurve/mast.py
@@ -103,8 +103,8 @@ def search_kepler_tpf_products(target, cadence='long', quarter=None,
     # Identify the campaign or quarter by the description.
     quarter_or_campaign = campaign if campaign is not None else quarter
     if quarter_or_campaign is not None:
-        mask &= np.array([desc.endswith('Q{}'.format(quarter_or_campaign)) or
-                          desc.endswith('C{:02d}'.format(quarter_or_campaign))
+        mask &= np.array([desc.lower().endswith('q{}'.format(quarter_or_campaign)) or
+                          desc.lower().endswith('c{:02d}'.format(quarter_or_campaign))
                           for desc in products['description']])
     return products[mask]
 
@@ -140,7 +140,7 @@ def search_kepler_lightcurve_products(target, cadence='long', quarter=None,
     # Identify the campaign or quarter by the description.
     quarter_or_campaign = campaign if campaign is not None else quarter
     if quarter_or_campaign is not None:
-        mask &= np.array([desc.endswith('Q{}'.format(quarter_or_campaign)) or
-                          desc.endswith('C{:02d}'.format(quarter_or_campaign))
+        mask &= np.array([desc.lower().endswith('q{}'.format(quarter_or_campaign)) or
+                          desc.lower().endswith('c{:02d}'.format(quarter_or_campaign))
                           for desc in products['description']])
     return products[mask]


### PR DESCRIPTION
This PR resolves #68.

The issue was that the MAST API used lowercase "c14" in the description of Campaign 14 products, and uppercase "C12" in the description of e.g. Campaign 12 products. (/cc @scfleming)

```
In [8]: mast.search_kepler_tpf_products(201885041)['description']
Out[8]: 
<MaskedColumn name='description' dtype='str38' length=1>
Target Pixel Long Cadence (KTL) - c14

In [9]: mast.search_kepler_tpf_products(246199087)['description']
Out[9]: 
<MaskedColumn name='description' dtype='str38' length=1>
Target Pixel Long Cadence (KTL) - C12
``` 