### PR TITLE
Increase the unit test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - pip install pytest-remotedata
   - pip install sphinx_rtd_theme
   - pip install numpydoc
+  - pip install pandas
 install:
   - pip install -r requirements.txt
 # command to run tests

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -376,7 +376,7 @@ class LightCurve(object):
         binned_lc.time = np.array([methodf(a) for a in np.array_split(self.time, n_bins)])
         binned_lc.flux = np.array([methodf(a) for a in np.array_split(self.flux, n_bins)])
 
-        if self.flux_err is not None:
+        if np.any(np.isfinite(self.flux_err)):
             # root-mean-square error
             binned_lc.flux_err = np.array(
                                     [np.sqrt(np.nansum(a**2))
@@ -721,9 +721,6 @@ class KeplerLightCurve(LightCurve):
         """
         return super(KeplerLightCurve, self).to_pandas(columns=columns)
 
-    def to_fits(self):
-        raise NotImplementedError()
-
 
 class TessLightCurve(LightCurve):
     """Defines a light curve class for NASA's TESS mission.
@@ -769,9 +766,6 @@ class TessLightCurve(LightCurve):
 
     def __repr__(self):
         return('TessLightCurve(TICID: {})'.format(self.ticid))
-
-    def to_fits(self):
-        raise NotImplementedError()
 
 
 def iterative_box_period_search(lc, niters=2, min_period=0.5, max_period=30,

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -260,7 +260,7 @@ class KeplerLightCurveFile(LightCurveFile):
         ----------
         flux_types : str or list of str
             List of flux types to plot. Default is to plot all available.
-            (For Kepler the default fluxes are 'SAP_FLUX' and 'PDCSAP-FLUX'.
+            (For Kepler the default fluxes are 'SAP_FLUX' and 'PDCSAP_FLUX'.
         style : str
             matplotlib.pyplot.style.context, default is 'fast'
         kwargs : dict

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -25,19 +25,8 @@ __all__ = ['KeplerTargetPixelFile']
 
 class TargetPixelFile(object):
     """
-    TargetPixelFile class
+    Generic TargetPixelFile class
     """
-    def to_lightcurve(self):
-        """Returns a raw light curve of the TPF.
-
-        Returns
-        -------
-        lc : LightCurve object
-            Array containing the summed or detrended flux within the aperture
-            for each cadence.
-        """
-        pass
-
     def properties(self):
         '''Print out a description of each of the non-callable attributes of a
         TargetPixelFile object.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -586,7 +586,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                                  "must be in the range {}-{}.".format(
                                     cadenceno, self.cadenceno[0], self.cadenceno[-1]))
         try:
-            if bkg:
+            if bkg and np.any(np.isfinite(self.flux_bkg[frame])):
                 pflux = self.flux[frame] + self.flux_bkg[frame]
             else:
                 pflux = self.flux[frame]

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -41,9 +41,16 @@ def test_tpf_plot():
     tpf.plot(aperture_mask=tpf.pipeline_mask)
     tpf.plot(aperture_mask='all')
     tpf.plot(frame=5)
+    with pytest.raises(ValueError):
+        tpf.plot(frame=999999)
     tpf.plot(cadenceno=125250)
     with pytest.raises(ValueError):
         tpf.plot(cadenceno=999)
+    tpf.plot(bkg=True)
+    tpf.plot(scale="sqrt")
+    tpf.plot(scale="log")
+    with pytest.raises(ValueError):
+        tpf.plot(scale="blabla")
 
 
 def test_tpf_zeros():


### PR DESCRIPTION
This PR increases the unit test coverage by hitting lines which `Codecov` identified as being missed.

Also:
* Travis is now told to install `pandas` so we can test `to_pandas` and `to_csv`.
* Some unimplemented functions were removed for now (e.g. `LightCurve.to_fits`).
* Small fixes in docstrings etc.