### PR TITLE
makes bkjd_to_time discoverable

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -7,8 +7,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-__all__ = ['KeplerQualityFlags', 'TessQualityFlags', 'channel_to_module_output',
-           'module_output_to_channel', 'running_mean']
+__all__ = ['KeplerQualityFlags', 'TessQualityFlags', 'bkjd_to_time',
+           'channel_to_module_output', 'module_output_to_channel',
+           'running_mean']
 
 
 class KeplerQualityFlags(object):


### PR DESCRIPTION
Tiny PR to make the function ``bkjd_to_time`` importable from the top-level.
``bkjd_to_time`` will also show up in the sphinx docs next time we build the docs.