### PR TITLE
Fixed LightCurve append method

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -178,7 +178,8 @@ class LightCurve(object):
             new_lc.time = np.append(new_lc.time, others[i].time)
             new_lc.flux = np.append(new_lc.flux, others[i].flux)
             new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
-            new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)
+            if hasattr(new_lc, 'cadenceno'):  # KJM
+                new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)  # KJM
             if hasattr(new_lc, 'quality'):
                 new_lc.quality = np.append(new_lc.quality, others[i].quality)
             if hasattr(new_lc, 'centroid_col'):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -178,6 +178,7 @@ class LightCurve(object):
             new_lc.time = np.append(new_lc.time, others[i].time)
             new_lc.flux = np.append(new_lc.flux, others[i].flux)
             new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
+            new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)
             if hasattr(new_lc, 'quality'):
                 new_lc.quality = np.append(new_lc.quality, others[i].quality)
             if hasattr(new_lc, 'centroid_col'):


### PR DESCRIPTION
My one-line solution to issue https://github.com/KeplerGO/lightkurve/issues/129
[The LightCurve remove_nans method functionality changed --- now breaks a tutorial]

One line has been added to the LightCurve append method code in the   
**lightkurve/lightcurve.py** file.

This fix has been tested and works on my development system.

-Ken Mighell
mighell at noao dot edu


