### PR TITLE
Revised fix to LightCurve apend method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ Direct contributions to the code base:
 - `Christina Hedges <https://github.com/christinahedges>`_
 - `Michael Gully-Santiago <https://github.com/gully>`_
 - `Thomas Barclay <https://github.com/mrtommyb>`_
+- `Ken Mighell <https://github.com/KenMighell>`_
 
 Comments, corrections & suggestions:
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -178,7 +178,8 @@ class LightCurve(object):
             new_lc.time = np.append(new_lc.time, others[i].time)
             new_lc.flux = np.append(new_lc.flux, others[i].flux)
             new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
-            new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)
+            if hasattr(new_lc, 'cadenceno'):  # KJM
+                new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)  # KJM
             if hasattr(new_lc, 'quality'):
                 new_lc.quality = np.append(new_lc.quality, others[i].quality)
             if hasattr(new_lc, 'centroid_col'):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -178,7 +178,7 @@ class LightCurve(object):
             new_lc.time = np.append(new_lc.time, others[i].time)
             new_lc.flux = np.append(new_lc.flux, others[i].flux)
             new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
-            if hasattr(new_lc, 'cadenceno'):  # KJM
+            if hasattr(new_lc, 'cadenceno'):
                 new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)  # KJM
             if hasattr(new_lc, 'quality'):
                 new_lc.quality = np.append(new_lc.quality, others[i].quality)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -178,6 +178,7 @@ class LightCurve(object):
             new_lc.time = np.append(new_lc.time, others[i].time)
             new_lc.flux = np.append(new_lc.flux, others[i].flux)
             new_lc.flux_err = np.append(new_lc.flux_err, others[i].flux_err)
+            new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)
             if hasattr(new_lc, 'quality'):
                 new_lc.quality = np.append(new_lc.quality, others[i].quality)
             if hasattr(new_lc, 'centroid_col'):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -121,13 +121,21 @@ def test_lightcurve_fold():
 
 def test_lightcurve_append():
     """Test ``LightCurve.append()``."""
-    lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1])
+    lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1], flux_err=[0.1, 0.2, 0.3])
     lc = lc.append(lc)
-    assert_array_equal(lc.flux, 2*[1, .5, 1])
     assert_array_equal(lc.time, 2*[1, 2, 3])
+    assert_array_equal(lc.flux, 2*[1, .5, 1])
+    assert_array_equal(lc.flux_err, 2*[0.1, 0.2, 0.3])
     # KeplerLightCurve has extra data
-    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, .5, 1], quality=[10, 20, 30])
+    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, .5, 1],
+                          centroid_col=[4, 5, 6], centroid_row=[7, 8, 9],
+                          cadenceno=[10, 11, 12], quality=[10, 20, 30])
     lc = lc.append(lc)
+    assert_array_equal(lc.time, 2*[1, 2, 3])
+    assert_array_equal(lc.flux, 2*[1, .5, 1])
+    assert_array_equal(lc.centroid_col, 2*[4, 5, 6])
+    assert_array_equal(lc.centroid_row, 2*[7, 8, 9])
+    assert_array_equal(lc.cadenceno, 2*[10, 11, 12])
     assert_array_equal(lc.quality, 2*[10, 20, 30])
 
 


### PR DESCRIPTION
Fixed the LightCurve append method bug by adding these two lines:

if hasattr(new_lc, 'cadenceno'):  # KJM
    new_lc.cadenceno = np.append(new_lc.cadenceno, others[i].cadenceno)  # KJM

This should make the code work for Kepler **and** generic LightCurve objects.

-Ken Mighell
mighell at noao dot edu