### PR TITLE
Allow `from_archive` to accept a path or url

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, print_function
 
+import os
 import numpy as np
 import matplotlib as mpl
 from matplotlib import pyplot as plt
@@ -139,10 +140,13 @@ class KeplerLightCurveFile(LightCurveFile):
         -------
         lcf : KeplerLightCurveFile object or list of KeplerLightCurveFile objects
         """
-        path = download_kepler_products(
-            target=target, filetype='Lightcurve', cadence=cadence,
-            quarter=quarter, campaign=campaign, month=month,
-            radius=radius, targetlimit=targetlimit)
+        if os.path.exists(target) or str(target).startswith('http'):
+            path = [target]
+        else:
+            path = download_kepler_products(
+                target=target, filetype='Lightcurve', cadence=cadence,
+                quarter=quarter, campaign=campaign, month=month,
+                radius=radius, targetlimit=targetlimit)
         if len(path) == 1:
             return KeplerLightCurveFile(path[0], **kwargs)
         return [KeplerLightCurveFile(p, **kwargs) for p in path]

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -3,6 +3,7 @@
 from __future__ import division, print_function
 
 import os
+import logging
 import numpy as np
 import matplotlib as mpl
 from matplotlib import pyplot as plt
@@ -14,6 +15,8 @@ from .mast import download_kepler_products
 
 
 __all__ = ['KeplerLightCurveFile', 'TessLightCurveFile']
+
+log = logging.getLogger(__name__)
 
 
 class LightCurveFile(object):
@@ -140,7 +143,10 @@ class KeplerLightCurveFile(LightCurveFile):
         -------
         lcf : KeplerLightCurveFile object or list of KeplerLightCurveFile objects
         """
-        if os.path.exists(target) or str(target).startswith('http'):
+        # Be tolerant if a direct path or url is passed to this function by accident
+        if os.path.exists(str(target)) or str(target).startswith('http'):
+            log.warning('Warning: from_archive() is not intended to accept a '
+                        'direct path, use KeplerLightCurveFile(path) instead.')
             path = [target]
         else:
             path = download_kepler_products(

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -179,10 +179,13 @@ class KeplerTargetPixelFile(TargetPixelFile):
         -------
         tpf : KeplerTargetPixelFile object.
         """
-        path = download_kepler_products(
-            target=target, filetype='Target Pixel', cadence=cadence,
-            quarter=quarter, campaign=campaign, month=month,
-            radius=radius, targetlimit=targetlimit)
+        if os.path.exists(target) or str(target).startswith('http'):
+            path = [target]
+        else:
+            path = download_kepler_products(
+                target=target, filetype='Target Pixel', cadence=cadence,
+                quarter=quarter, campaign=campaign, month=month,
+                radius=radius, targetlimit=targetlimit)
         if len(path) == 1:
             return KeplerTargetPixelFile(path[0], **kwargs)
         return [KeplerTargetPixelFile(p, **kwargs) for p in path]

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -179,7 +179,9 @@ class KeplerTargetPixelFile(TargetPixelFile):
         -------
         tpf : KeplerTargetPixelFile object.
         """
-        if os.path.exists(target) or str(target).startswith('http'):
+        if os.path.exists(str(target)) or str(target).startswith('http'):
+            log.warning('Warning: from_archive() is not intended to accept a '
+                        'direct path, use KeplerTargetPixelFile(path) instead.')
             path = [target]
         else:
             path = download_kepler_products(

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -441,6 +441,7 @@ def test_flatten_robustness():
     assert_allclose(flat_lc.flux, expected_result)
 
 
+@pytest.mark.remote_data
 def test_from_archive_should_accept_path():
     """If a url is passed to `from_archive` it should still just work."""
     KeplerLightCurveFile.from_archive(TABBY_Q8)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -439,3 +439,8 @@ def test_flatten_robustness():
     # flatten should work even if `break_tolerance = None`
     flat_lc = lc.flatten(break_tolerance=None)
     assert_allclose(flat_lc.flux, expected_result)
+
+
+def test_from_archive_should_accept_path():
+    """If a url is passed to `from_archive` it should still just work."""
+    KeplerLightCurveFile.from_archive(TABBY_Q8)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -213,3 +213,8 @@ def test_interact():
     tpf = KeplerTargetPixelFile(filename_tpf_one_center)
     tpf.interact()
     tpf.interact(lc=tpf.to_lightcurve(aperture_mask='all'))
+
+
+def test_from_archive_should_accept_path():
+    """If a path is accidentally passed to `from_archive` it should still just work."""
+    KeplerTargetPixelFile.from_archive(filename_tpf_all_zeros)


### PR DESCRIPTION
When a user accidentally tries to open a local file or url with the `from_archive()` function, lightkurve fails ungracefully with the exception below.  This PR proposes to allow `from_archive` to accept a path or url as if it was passed to the constructor.  Before we merge, can anyone think of caveats or unexpected consequences?

```Python
In [1]: from lightkurve import KeplerLightCurveFile

In [2]: KeplerLightCurveFile.from_archive("https://archive.stsci.edu/missions/kepler/lightcurves"
   ...:                                   "/0084/008462852/kplr008462852-2011073133259_llc.fits")
   ...:                                   
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/dev/lightkurve/lightkurve/mast.py in _query_kepler_products(target, radius)
     69         # `target_name` under which MAST will know the object.
---> 70         target = int(target)
     71         if (target > 0) and (target < 200000000):

ValueError: invalid literal for int() with base 10: 'https://archive.stsci.edu/missions/kepler/lightcurves/0084/008462852/kplr008462852-2011073133259_llc.fits'

During handling of the above exception, another exception occurred:

ResolverError                             Traceback (most recent call last)
~/dev/lightkurve/lightkurve/mast.py in _query_kepler_products(target, radius)
     86                                               project=["Kepler", "K2"],
---> 87                                               obs_collection=["Kepler", "K2"])
     88             # Make sure the final table is in DISTANCE order

~/bin/anaconda/lib/python3.6/site-packages/astroquery/utils/class_or_instance.py in f(*args, **kwds)
     24             if obj is not None:
---> 25                 return self.fn(obj, *args, **kwds)
     26             else:

~/bin/anaconda/lib/python3.6/site-packages/astroquery/utils/process_asyncs.py in newmethod(self, *args, **kwargs)
     25 
---> 26             response = getattr(self, async_method_name)(*args, **kwargs)
     27             if kwargs.get('get_query_payload') or kwargs.get('field_help'):

~/bin/anaconda/lib/python3.6/site-packages/astroquery/utils/class_or_instance.py in f(*args, **kwds)
     24             if obj is not None:
---> 25                 return self.fn(obj, *args, **kwds)
     26             else:

~/bin/anaconda/lib/python3.6/site-packages/astroquery/mast/core.py in query_criteria_async(self, pagesize, page, **criteria)
    985         if objectname:
--> 986             coordinates = self._resolve_object(objectname)
    987 

~/bin/anaconda/lib/python3.6/site-packages/astroquery/mast/core.py in _resolve_object(self, objectname)
    705         if len(result['resolvedCoordinate']) == 0:
--> 706             raise ResolverError("Could not resolve {} to a sky position.".format(objectname))
    707 

ResolverError: Could not resolve https://archive.stsci.edu/missions/kepler/lightcurves/0084/008462852/kplr008462852-2011073133259_llc.fits to a sky position.

During handling of the above exception, another exception occurred:

ArchiveError                              Traceback (most recent call last)
<ipython-input-2-843a2101c0bd> in <module>()
----> 1 KeplerLightCurveFile.from_archive("https://archive.stsci.edu/missions/kepler/lightcurves"
      2                                   "/0084/008462852/kplr008462852-2011073133259_llc.fits")
      3 

~/dev/lightkurve/lightkurve/lightcurvefile.py in from_archive(target, cadence, quarter, month, campaign, radius, targetlimit, **kwargs)
    143             target=target, filetype='Lightcurve', cadence=cadence,
    144             quarter=quarter, campaign=campaign, month=month,
--> 145             radius=radius, targetlimit=targetlimit)
    146         if len(path) == 1:
    147             return KeplerLightCurveFile(path[0], **kwargs)

~/dev/lightkurve/lightkurve/mast.py in download_kepler_products(target, filetype, cadence, quarter, month, campaign, radius, targetlimit, **kwargs)
    268     products = search_kepler_products(target=target, filetype=filetype, cadence=cadence,
    269                                       quarter=quarter, campaign=campaign,
--> 270                                       radius=radius, targetlimit=targetlimit)
    271     if len(products) == 0:
    272         raise ArchiveError("No {} File found for {} at MAST.".format(filetype, target))

~/dev/lightkurve/lightkurve/mast.py in search_kepler_products(target, filetype, cadence, quarter, campaign, radius, targetlimit)
    135         qoc = np.atleast_1d(np.asarray(qoc, dtype=int))
    136 
--> 137     products = _query_kepler_products(target, radius)
    138     # Because MAST doesn't let us query based on Kepler-specific meta data
    139     # fields, we need to identify short/long-cadence TPFs by their filename.

~/dev/lightkurve/lightkurve/mast.py in _query_kepler_products(target, radius)
     89             obs.sort('distance')
     90         except ResolverError as exc:
---> 91             raise ArchiveError(exc)
     92 
     93     obsids = np.asarray(obs['obsid'])

ArchiveError: Could not resolve https://archive.stsci.edu/missions/kepler/lightcurves/0084/008462852/kplr008462852-2011073133259_llc.fits to a sky position.
```