### PR TITLE
add try/except for mission property

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -258,7 +258,10 @@ class KeplerLightCurveFile(LightCurveFile):
     @property
     def mission(self):
         """Mission name"""
-        return self.header(ext=0)['MISSION']
+	try:
+            return self.header(ext=0)['MISSION']
+        except KeyError:
+            return None
 
     def compute_cotrended_lightcurve(self, cbvs=[1, 2], **kwargs):
         """Returns a LightCurve object after cotrending the SAP_FLUX

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -258,7 +258,7 @@ class KeplerLightCurveFile(LightCurveFile):
     @property
     def mission(self):
         """Mission name"""
-	try:
+        try:
             return self.header(ext=0)['MISSION']
         except KeyError:
             return None


### PR DESCRIPTION
Addressing #180, I added a try/except to handle files with a missing MISSION keyword, setting the property to None where there is a KeyError.

If mission is None, the class already returns a representation with ID rather than KIC or EPIC:
```
def __repr__(self):
    if self.mission is None:
        return('KeplerLightCurveFile(ID: {})'.format(self.keplerid))
    elif self.mission.lower() == 'kepler':
        return('KeplerLightCurveFile(KIC: {})'.format(self.keplerid))
    elif self.mission.lower() == 'k2':
        return('KeplerLightCurveFile(EPIC: {})'.format(self.keplerid))
```