### PR TITLE
Added a fill_gaps method to LightCurve which fills in gaps in time and NaN values with linear intepolation

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -361,7 +361,7 @@ class LightCurve(object):
 
         Parameters
         ----------
-        method : string {None, ‘backfill’/’bfill’, ‘pad’/’ffill’, ‘nearest’}
+        method : string {None, 'backfill'/'bfill', 'pad'/'ffill', 'nearest'}
             Method to use for gap filling. 'nearest' by default.
 
         Returns

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -373,7 +373,6 @@ class LightCurve(object):
         clc = copy.deepcopy(lc.remove_nans())
         nlc = copy.deepcopy(lc)
 
-
         # Average gap between cadences
         dt = np.nanmedian(clc.time[1::] - clc.time[:-1:])
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -370,16 +370,18 @@ class LightCurve(object):
             A new ``LightCurve`` in which NaNs values and gaps in time have been
             filled.
         """
+        clc = copy.deepcopy(lc.remove_nans())
         nlc = copy.deepcopy(lc)
 
+
         # Average gap between cadences
-        dt = np.nanmedian(lc.time[1::] - lc.time[:-1:])
+        dt = np.nanmedian(clc.time[1::] - clc.time[:-1:])
 
         # Iterate over flux and flux_err
-        for idx, y in enumerate([lc.flux, lc.flux_err]):
-            ts = pd.Series(y, index=lc.time)
-            newindex = [lc.time[0]]
-            for t in lc.time[1::]:
+        for idx, y in enumerate([clc.flux, clc.flux_err]):
+            ts = pd.Series(y, index=clc.time)
+            newindex = [clc.time[0]]
+            for t in clc.time[1::]:
                 prevtime = newindex[-1]
                 while (t - prevtime) > 1.2*dt:
                     newindex.append(prevtime + dt)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -448,3 +448,10 @@ def test_flatten_robustness():
 def test_from_archive_should_accept_path():
     """If a url is passed to `from_archive` it should still just work."""
     KeplerLightCurveFile.from_archive(TABBY_Q8)
+
+def test_fill_gaps():
+    lc = LightCurve([1,2,3,4,6,7,8], [1,1,1,1,1,1,1])
+    nlc = lc.fill_gaps()
+    assert(len(lc.time) < len(nlc.time))
+    assert(np.any(nlc.time == 5))
+    assert(np.all(nlc.flux == 1))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -455,3 +455,10 @@ def test_fill_gaps():
     assert(len(lc.time) < len(nlc.time))
     assert(np.any(nlc.time == 5))
     assert(np.all(nlc.flux == 1))
+
+    lc = LightCurve([1,2,3,4,6,7,8], [1,1,np.nan,1,1,1,1])
+    nlc = lc.fill_gaps()
+    assert(len(lc.time) < len(nlc.time))
+    assert(np.any(nlc.time == 5))
+    assert(np.all(nlc.flux == 1))
+    assert(np.all(np.isfinite(nlc.flux)))


### PR DESCRIPTION
It's called `fill_gaps()`, it was actually written by @barentsen. We need to merge this ASAP to get the periodogram stuff from #177 merged.