### PR TITLE
Improves TargetPixelFile color bar when using log scale 

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -1,9 +1,11 @@
 from __future__ import division, print_function
+import sys
 
 from astropy.visualization import (PercentileInterval, ImageNormalize,
-                                   SqrtStretch, LogStretch, LinearStretch)
+                                   SqrtStretch, LinearStretch)
 from astropy.time import Time
 import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
 import numpy as np
 
 
@@ -305,7 +307,10 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
         elif scale == 'sqrt':
             norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch())
         elif scale == 'log':
-            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LogStretch())
+            # To use log scale we need to guarantee that vmin > 0, so that
+            # we avoid division by zero and/or negative values.
+            norm = LogNorm(vmin=max(vmin, sys.float_info.epsilon), vmax=vmax,
+                           clip=True)
         else:
             raise ValueError("scale {} is not available.".format(scale))
 


### PR DESCRIPTION
Hi y'all!

This PR slightly improves the appearance of the color bar in TargetPixelFile.plot().

Before this PRF:
![screen shot 2018-07-09 at 10 56 59 am](https://user-images.githubusercontent.com/13077051/42454799-d812f1b8-8366-11e8-88b4-635f8ea17cfc.png)


After this PR:
![screen shot 2018-07-09 at 10 54 17 am](https://user-images.githubusercontent.com/13077051/42454702-90bedfe8-8366-11e8-8c90-1729f875ef42.png)

Code snippet:
```
from lightkurve import KeplerTargetPixelFile
tpf = KeplerTargetPixelFile.from_archive(211416749, campaign=5, cadence='long')
tpf.plot(scale='log', aperture_mask=tpf.pipeline_mask)
```
