### PR TITLE
add notebooks directive to docs/Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,6 +19,9 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+notebooks:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D nbsphinx_execute='always'
+
 # ghp-import can be installed with pip as pip install ghp-import
 upload:
 	ghp-import -m "Update docs" $(BUILDDIR)/html

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -66,16 +66,32 @@ Building documentation
 
 .. note::
 
-    In general, building the documentation is not necessary unless you are
+    Building the documentation is not necessary unless you are
     writing new documentation or do not have internet access, because the
     latest version of lightkurve's documentation is available online at
-    `lightkurve.keplerscience.org/ <http://lightkurve.keplerscience.org/>`_ .
+    `lightkurve.keplerscience.org <http://lightkurve.keplerscience.org/>`_ .
 
-.. note::
-    **lightkurve** documentation requires the `numpydoc sphinx extension <https://github.com/numpy/numpydoc>`_
-    which can be installed with ``pip install numpydoc``.
+Building the **lightkurve** documentation requires a few extra packages:
 
-To build the documentation to HTML format, you can do::
+- sphinx
+- sphinx-automodapi
+- nbsphinx
+- `numpydoc <https://github.com/numpy/numpydoc>`_
+
+These packages can be installed using `conda` or `pip`.
+
+To build the documentation in HTML format, you can do::
 
     cd docs
     make html
+
+This will save the documentation website in the `../../lightkurve-docs` directory
+on your system.  The notebook-based tutorials will not be recompiled by default
+because they take some time to build.  To recompile the notebooks, type::
+
+    make notebooks
+
+Finally, if you have write permission to lightkurve's GitHub repository,
+you can upload the documentation using::
+
+    make upload


### PR DESCRIPTION
I'm adding the directive ``notebooks``, so that we can run ``make notebooks`` whenever we would like to execute all the notebooks in the documentation.

I think we could discuss at some point whether this should be the default behavior. 
Having this as default is particularly interesting as the number of tutorials increases and some of them might be affect by backwards-incompatible changes. The downside is the time it takes to run all notebooks.