### PR TITLE
Ensure every `LightCurve`, `LightCurveFile`, and `TargetPixelFile` object has a generic targetid

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -869,12 +869,13 @@ class KeplerLightCurve(LightCurve):
     keplerid : int
         Kepler ID number
     """
-    def __init__(self, time, flux=None, flux_err=None, time_format=None, time_scale=None,
+    def __init__(self, time=None, flux=None, flux_err=None, time_format=None, time_scale=None,
                  centroid_col=None, centroid_row=None, quality=None, quality_bitmask=None,
                  channel=None, campaign=None, quarter=None, mission=None,
-                 cadenceno=None, keplerid=None, ra=None, dec=None):
+                 cadenceno=None, keplerid=None, ra=None, dec=None, meta={}):
         super(KeplerLightCurve, self).__init__(time=time, flux=flux, flux_err=flux_err,
-                                               time_format=time_format, time_scale=time_scale)
+                                               time_format=time_format, time_scale=time_scale,
+                                               targetid=keplerid, meta=meta)
         self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
         self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
         self.quality = self._validate_array(quality, name='quality')
@@ -884,7 +885,6 @@ class KeplerLightCurve(LightCurve):
         self.campaign = campaign
         self.quarter = quarter
         self.mission = mission
-        self.keplerid = keplerid
         self.ra = ra
         self.dec = dec
 
@@ -904,6 +904,14 @@ class KeplerLightCurve(LightCurve):
             return('KeplerLightCurve(KIC: {})'.format(self.keplerid))
         elif self.mission.lower() == 'k2':
             return('KeplerLightCurve(EPIC: {})'.format(self.keplerid))
+
+    @property
+    def keplerid(self):
+        return self.targetid
+
+    @keplerid.setter
+    def keplerid(self, value):
+        self.targetid = value
 
     def correct(self, method='sff', **kwargs):
         """Corrects a lightcurve for motion-dependent systematic errors.
@@ -1025,12 +1033,13 @@ class TessLightCurve(LightCurve):
     ticid : int
         Tess Input Catalog ID number
     """
-    def __init__(self, time, flux=None, flux_err=None, time_format=None, time_scale=None,
+    def __init__(self, time=None, flux=None, flux_err=None, time_format=None, time_scale=None,
                  centroid_col=None, centroid_row=None, quality=None, quality_bitmask=None,
                  cadenceno=None, sector=None, camera=None, ccd=None,
-                 ticid=None, ra=None, dec=None):
+                 ticid=None, ra=None, dec=None, meta={}):
         super(TessLightCurve, self).__init__(time=time, flux=flux, flux_err=flux_err,
-                                             time_format=time_format, time_scale=time_scale)
+                                             time_format=time_format, time_scale=time_scale,
+                                             targetid=ticid, meta=meta)
         self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
         self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
         self.quality = self._validate_array(quality, name='quality')
@@ -1040,7 +1049,6 @@ class TessLightCurve(LightCurve):
         self.sector = sector
         self.camera = camera
         self.ccd = ccd
-        self.ticid = ticid
         self.ra = ra
         self.dec = dec
 
@@ -1055,6 +1063,14 @@ class TessLightCurve(LightCurve):
 
     def __repr__(self):
         return('TessLightCurve(TICID: {})'.format(self.ticid))
+
+    @property
+    def ticid(self):
+        return self.targetid
+
+    @ticid.setter
+    def ticid(self, value):
+        self.targetid = value
 
 
 def iterative_box_period_search(lc, niters=2, min_period=0.5, max_period=30,

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -277,6 +277,10 @@ class KeplerLightCurveFile(LightCurveFile):
         return self.header(ext=0)['KEPLERID']
 
     @property
+    def targetid(self):
+        return self.keplerid
+
+    @property
     def obsmode(self):
         return self.header()['OBSMODE']
 
@@ -388,6 +392,10 @@ class TessLightCurveFile(LightCurveFile):
     @property
     def ticid(self):
         return self.header(ext=0)['TICID']
+
+    @property
+    def targetid(self):
+        return self.ticid
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -471,7 +471,21 @@ def test_from_fits():
     lcf = KeplerLightCurveFile.from_fits(TABBY_Q8)
     assert isinstance(lcf, KeplerLightCurveFile)
     assert lcf.keplerid == KeplerLightCurveFile(TABBY_Q8).keplerid
+    assert lcf.keplerid == lcf.targetid
     # Execute the same test for TESS
     lcf = TessLightCurveFile.from_fits(TESS_SIM)
     assert isinstance(lcf, TessLightCurveFile)
     assert lcf.ticid == TessLightCurveFile(TESS_SIM).ticid
+    assert lcf.ticid == lcf.targetid
+
+
+def test_targetid():
+    """Is a generic targetid available on each type of LighCurve object?"""
+    lc = LightCurve(time=[], targetid=5)
+    lc.targetid == 5
+    lc = KeplerLightCurve(time=[], keplerid=10)
+    lc.targetid == 10
+    lc.keplerid == 10
+    lc = TessLightCurve(time=[], ticid=20)
+    lc.targetid == 20
+    lc.ticid == 20

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -482,10 +482,23 @@ def test_from_fits():
 def test_targetid():
     """Is a generic targetid available on each type of LighCurve object?"""
     lc = LightCurve(time=[], targetid=5)
-    lc.targetid == 5
+    assert lc.targetid == 5
+    # Can we assign a new value?
+    lc.targetid = 99
+    assert lc.targetid == 99
+    # Does it work for Kepler?
     lc = KeplerLightCurve(time=[], keplerid=10)
-    lc.targetid == 10
-    lc.keplerid == 10
+    assert lc.targetid == 10
+    assert lc.keplerid == 10
+    # Can we assign a new value?
+    lc.keplerid = 99
+    assert lc.keplerid == 99
+    assert lc.targetid == 99
+    # Does it work for TESS?
     lc = TessLightCurve(time=[], ticid=20)
-    lc.targetid == 20
-    lc.ticid == 20
+    assert lc.targetid == 20
+    assert lc.ticid == 20
+    # Can we assign a new value?
+    lc.targetid = 99
+    assert lc.ticid == 99
+    assert lc.targetid == 99

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -247,10 +247,12 @@ def test_from_fits():
     tpf = KeplerTargetPixelFile.from_fits(filename_tpf_one_center)
     assert isinstance(tpf, KeplerTargetPixelFile)
     assert tpf.keplerid == KeplerTargetPixelFile(filename_tpf_one_center).keplerid
+    assert tpf.keplerid == tpf.targetid
     # Execute the same test for TESS
     tpf = TessTargetPixelFile.from_fits(filename_tpf_one_center)
     assert isinstance(tpf, TessTargetPixelFile)
     assert tpf.ticid == TessTargetPixelFile(filename_tpf_one_center).ticid
+    assert tpf.ticid == tpf.targetid
 
 
 def test_get_models():


### PR DESCRIPTION
This PR ensures that every `LightCurve` object, i.e. be it a `KeplerLightCurve` or `TessLightCurve`, has a generic `targetid` attribute that returns either the `keplerid` or `ticid`.

This enables tools to print an object's identifier without having to worry about the mission the data came from.

The same change is made for `LightCurveFile` and `TargetPixelFile` objects.

Assigning to @johnnyzhang295 to review!