### PR TITLE
Make bokeh and ipywidgets optional dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include README.rst AUTHORS.rst LICENSE
+include README.rst AUTHORS.rst CONTRIBUTING.md LICENSE
 include lightkurve/data/*
+include lightkurve/prf/*

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -484,6 +484,11 @@ class TargetPixelFile(object):
         the lightcurve shown is obtained by calling the `to_lightcurve()` method,
         unless the user supplies a custom `LightCurve` object.
 
+        This feature requires two optional dependencies:
+        - bokeh>=0.12.15
+        - ipywidgets>=7.2.0
+        These can be installed using e.g. `conda install bokeh ipywidgets`.
+
         Note: at this time, this feature only works inside an active Jupyter
         Notebook, and tends to be too slow when more than ~30,000 cadences
         are contained in the TPF (e.g. short cadence data).
@@ -494,7 +499,6 @@ class TargetPixelFile(object):
             An optional pre-processed lightcurve object to show.
         """
         try:
-            from ipywidgets import interact
             import ipywidgets as widgets
             from bokeh.io import push_notebook, show, output_notebook
             from bokeh.plotting import figure, ColumnDataSource
@@ -504,8 +508,9 @@ class TargetPixelFile(object):
             from IPython.display import display
             output_notebook()
         except ImportError:
-            raise ImportError('The quicklook tool requires Bokeh and ipywidgets. '
-                              'See the .interact() tutorial')
+            log.error("The interact() tool requires `bokeh` and `ipywidgets` to be installed. "
+                      "These can be installed using `conda install bokeh ipywidgets`.")
+            return None
 
         ytitle = 'Flux'
         if lc is None:
@@ -649,9 +654,8 @@ class TargetPixelFile(object):
             try:
                 push_notebook()
             except AttributeError:
-                log.error('Interact tool must be run in a Jupyter Notebook.\n')
+                log.error('ERROR: interact() can only be used inside a Jupyter Notebook.\n')
                 return None
-
 
         # Define the widgets that enable the interactivity
         play = widgets.Play(interval=10, value=min_cadence, min=min_cadence,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,4 @@ oktopus
 bs4
 requests
 tqdm
-bokeh>=0.12.15
-ipywidgets>=7.2.0
 pandas

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 # Prepare and send a new release to PyPI
 if "release" in sys.argv[-1]:
@@ -28,9 +28,7 @@ setup(name='lightkurve',
       packages=['lightkurve', 'lightkurve.prf'],
       install_requires=['numpy>=1.11', 'astropy>=1.3', 'scipy>=0.19.0',
                         'matplotlib>=1.5.3', 'tqdm', 'oktopus', 'bs4',
-                        'requests', 'astroquery>=0.3.7',
-                        'bokeh>=0.12.15', 'ipywidgets>=7.2.0',
-                        'pandas'],
+                        'requests', 'astroquery>=0.3.7', 'pandas'],
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'pytest-cov', 'pytest-remotedata'],
       include_package_data=True,
@@ -42,4 +40,4 @@ setup(name='lightkurve',
           "Intended Audience :: Science/Research",
           "Topic :: Scientific/Engineering :: Astronomy",
           ],
-    )
+      )


### PR DESCRIPTION
I have seen some users struggle with installing the `bokeh` and `ipywidgets` packages.  Because these are only required by `interact()`, and because it is important to keep the barrier low while we are trying to attract users, I propose we make these optional dependencies for now and print a nice message if they are not installed.

Assigning to @gully to review and merge.