### PR TITLE
Fix Issue #200 - make tpf.get_model robust for NaN background flux

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -12,7 +12,6 @@ from matplotlib import patches
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
-from astropy.stats import sigma_clip
 
 from . import PACKAGEDIR
 from .lightcurve import KeplerLightCurve, TessLightCurve, LightCurve

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -926,8 +926,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
             if np.all(np.isnan(self.flux_bkg)):  # If TargetPixelFile has no background flux data
                 # Use the median of the lower half of flux as an estimate for flux_bkg
                 clipped_flux = np.ma.masked_where(self.flux > np.percentile(self.flux,50), self.flux)
-                flux_prior = GaussianPrior(mean=np.ma.nanmedian(clipped_flux),
-                                           var=np.ma.nanstd(clipped_flux)**2)
+                flux_prior = GaussianPrior(mean=np.ma.median(clipped_flux),
+                                           var=np.ma.std(clipped_flux)**2)
             else:
                 flux_prior = GaussianPrior(mean=np.nanmedian(self.flux_bkg),
                                            var=np.nanstd(self.flux_bkg)**2)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -924,10 +924,10 @@ class KeplerTargetPixelFile(TargetPixelFile):
             kwargs['prfmodel'] = self.get_prf_model()
         if 'background_prior' not in kwargs:
             if np.all(np.isnan(self.flux_bkg)):  # If TargetPixelFile has no background flux data
-                # 5 sigma clip the flux until convergence, and use as an estimate for flux_bkg
-                clipped_flux = sigma_clip(self.flux, sigma=5, iters=None)
-                flux_prior = GaussianPrior(mean=np.nanmedian(clipped_flux),
-                                           var=np.nanstd(clipped_flux)**2)
+                # Use the median of the lower half of flux as an estimate for flux_bkg
+                clipped_flux = np.ma.masked_where(self.flux > np.percentile(self.flux,50), self.flux)
+                flux_prior = GaussianPrior(mean=np.ma.nanmedian(clipped_flux),
+                                           var=np.ma.nanstd(clipped_flux)**2)
             else:
                 flux_prior = GaussianPrior(mean=np.nanmedian(self.flux_bkg),
                                            var=np.nanstd(self.flux_bkg)**2)


### PR DESCRIPTION
Makes tpf.get_model() robust for TPFs with an all NaN background flux, e.g. from Campaign 0. 
If background flux is all NaNs, sets it to the median of flux, which has been 5 sigma clipped until convergence. 