### PR TITLE
New function to estimate local background flux for a TPF

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -892,7 +892,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         """ Returns an estimate of the local background flux for a given
         TargetPixelFile as an array of the same dimensions as the TargetPixelFile.
         """
-        # 5 sigma clip the TargetPixelFile flux until convergence
+        # Mask the upper half of the flux data to exclude star fluxes from bkg estimate
         clipped_flux = np.ma.masked_where(self.flux > np.percentile(self.flux, 50), self.flux)
         bkg_est = []
         for cadence in clipped_flux:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -834,7 +834,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
         try:
             return self.header(ext=0)['MISSION']
         except KeyError:
-            return None        
+            return None
 
     def aperture_photometry(self, aperture_mask='pipeline'):
         """Returns a LightCurve obtained using aperture photometry.
@@ -887,6 +887,19 @@ class KeplerTargetPixelFile(TargetPixelFile):
                           time_scale='tdb',
                           flux=np.nansum(self.flux_bkg[:, aperture_mask], axis=1),
                           flux_err=self.flux_bkg_err)
+
+    def get_local_bkg_est(self):
+        """ Returns an estimate of the local background flux for a given
+        TargetPixelFile as an array of the same dimensions as the TargetPixelFile.
+        """
+        # 5 sigma clip the TargetPixelFile flux until convergence
+        clipped_flux = sigma_clip(self.flux, sigma=5, iters=None)
+        bkg_est = []
+        for cadence in clipped_flux:
+            # Set background flux as the median of the clipped flux for each cadence
+            cadence_bkg = bkg_est.append(np.full(self.shape[1:],np.ma.median(cadence))
+        local_bkg_est = np.stack(bkg_est, axis=0)
+        return local_bkg_est
 
     def get_model(self, star_priors=None, **kwargs):
         """Returns a default `TPFModel` object for PRF fitting.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -893,11 +893,11 @@ class KeplerTargetPixelFile(TargetPixelFile):
         TargetPixelFile as an array of the same dimensions as the TargetPixelFile.
         """
         # 5 sigma clip the TargetPixelFile flux until convergence
-        clipped_flux = sigma_clip(self.flux, sigma=5, iters=None)
+        clipped_flux = np.ma.masked_where(self.flux > np.percentile(self.flux, 50), self.flux)
         bkg_est = []
         for cadence in clipped_flux:
             # Set background flux as the median of the clipped flux for each cadence
-            cadence_bkg = bkg_est.append(np.full(self.shape[1:],np.ma.median(cadence))
+            cadence_bkg = bkg_est.append(np.full(self.shape[1:],np.ma.median(cadence)))
         local_bkg_est = np.stack(bkg_est, axis=0)
         return local_bkg_est
 


### PR DESCRIPTION
This function estimates the local background flux for a TPF, unlike the pipeline which gives global background flux. Estimates the local background flux by clipping the TPF flux over 5 sigma, and then takes the median of the remaining fluxes. For each cadence, sets the local bkg flux estimate as this median for the whole cadence. Returns an array with the same dimensions as the TPF containing the estimated local bkg fluxes for each cadence.