### PR TITLE
Support `targetid` in favor of `keplerid` & `ticid`

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1008,16 +1008,16 @@ class KeplerLightCurve(LightCurve):
         Mission name
     cadenceno : array-like
         Cadence numbers corresponding to every time measurement
-    keplerid : int
+    targetid : int
         Kepler ID number
     """
     def __init__(self, time=None, flux=None, flux_err=None, time_format=None, time_scale=None,
                  centroid_col=None, centroid_row=None, quality=None, quality_bitmask=None,
                  channel=None, campaign=None, quarter=None, mission=None,
-                 cadenceno=None, keplerid=None, ra=None, dec=None, label=None, meta={}):
+                 cadenceno=None, targetid=None, ra=None, dec=None, label=None, meta={}):
         super(KeplerLightCurve, self).__init__(time=time, flux=flux, flux_err=flux_err,
                                                time_format=time_format, time_scale=time_scale,
-                                               targetid=keplerid, label=label, meta=meta)
+                                               targetid=targetid, label=label, meta=meta)
         self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
         self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
         self.quality = self._validate_array(quality, name='quality')
@@ -1040,20 +1040,7 @@ class KeplerLightCurve(LightCurve):
         return lc
 
     def __repr__(self):
-        if self.mission is None:
-            return('KeplerLightCurve(ID: {})'.format(self.keplerid))
-        elif self.mission.lower() == 'kepler':
-            return('KeplerLightCurve(KIC: {})'.format(self.keplerid))
-        elif self.mission.lower() == 'k2':
-            return('KeplerLightCurve(EPIC: {})'.format(self.keplerid))
-
-    @property
-    def keplerid(self):
-        return self.targetid
-
-    @keplerid.setter
-    def keplerid(self, value):
-        self.targetid = value
+        return('KeplerLightCurve(ID: {})'.format(self.targetid))
 
     def correct(self, method='sff', **kwargs):
         """Corrects a lightcurve for motion-dependent systematic errors.
@@ -1131,8 +1118,8 @@ class KeplerLightCurve(LightCurve):
         kepler_specific_data = {
             'TELESCOP': "KEPLER",
             'INSTRUME': "Kepler Photometer",
-            'OBJECT': '{}'.format(self.keplerid),
-            'KEPLERID': self.keplerid,
+            'OBJECT': '{}'.format(self.targetid),
+            'KEPLERID': self.targetid,
             'CHANNEL': self.channel,
             'MISSION': self.mission,
             'RA_OBJ': self.ra,
@@ -1172,16 +1159,16 @@ class TessLightCurve(LightCurve):
         Bitmask specifying quality flags of cadences that should be ignored
     cadenceno : array-like
         Cadence numbers corresponding to every time measurement
-    ticid : int
+    targetid : int
         Tess Input Catalog ID number
     """
     def __init__(self, time=None, flux=None, flux_err=None, time_format=None, time_scale=None,
                  centroid_col=None, centroid_row=None, quality=None, quality_bitmask=None,
                  cadenceno=None, sector=None, camera=None, ccd=None,
-                 ticid=None, ra=None, dec=None, label=None, meta={}):
+                 targetid=None, ra=None, dec=None, label=None, meta={}):
         super(TessLightCurve, self).__init__(time=time, flux=flux, flux_err=flux_err,
                                              time_format=time_format, time_scale=time_scale,
-                                             targetid=ticid, label=label, meta=meta)
+                                             targetid=targetid, label=label, meta=meta)
         self.centroid_col = self._validate_array(centroid_col, name='centroid_col')
         self.centroid_row = self._validate_array(centroid_row, name='centroid_row')
         self.quality = self._validate_array(quality, name='quality')
@@ -1204,15 +1191,7 @@ class TessLightCurve(LightCurve):
         return lc
 
     def __repr__(self):
-        return('TessLightCurve(TICID: {})'.format(self.ticid))
-
-    @property
-    def ticid(self):
-        return self.targetid
-
-    @ticid.setter
-    def ticid(self, value):
-        self.targetid = value
+        return('TessLightCurve(TICID: {})'.format(self.targetid))
 
 
 def iterative_box_period_search(lc, niters=2, min_period=0.5, max_period=30,

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -156,6 +156,10 @@ class KeplerLightCurveFile(LightCurveFile):
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['SAP_QUALITY'],
                                 bitmask=quality_bitmask)
+        try:
+            self.targetid = self.header()['KEPLERID']
+        except KeyError:
+            self.targetid = None
 
     @staticmethod
     def from_archive(target, cadence='long', quarter=None, month=None,
@@ -231,12 +235,7 @@ class KeplerLightCurveFile(LightCurveFile):
                 for p in path]
 
     def __repr__(self):
-        if self.mission is None:
-            return('KeplerLightCurveFile(ID: {})'.format(self.keplerid))
-        elif self.mission.lower() == 'kepler':
-            return('KeplerLightCurveFile(KIC: {})'.format(self.keplerid))
-        elif self.mission.lower() == 'k2':
-            return('KeplerLightCurveFile(EPIC: {})'.format(self.keplerid))
+        return('KeplerLightCurveFile(ID: {})'.format(self.targetid))
 
     @property
     def astropy_time(self):
@@ -262,7 +261,7 @@ class KeplerLightCurveFile(LightCurveFile):
                 quarter=self.quarter,
                 mission=self.mission,
                 cadenceno=self.cadenceno,
-                keplerid=self.keplerid,
+                targetid=self.targetid,
                 label=self.hdu[0].header['OBJECT'],
                 ra=self.ra,
                 dec=self.dec)
@@ -274,14 +273,6 @@ class KeplerLightCurveFile(LightCurveFile):
     def channel(self):
         """Kepler CCD channel number. ('CHANNEL' header keyword)"""
         return self.header(ext=0)['CHANNEL']
-
-    @property
-    def keplerid(self):
-        return self.header(ext=0)['KEPLERID']
-
-    @property
-    def targetid(self):
-        return self.keplerid
 
     @property
     def obsmode(self):
@@ -379,17 +370,13 @@ class TessLightCurveFile(LightCurveFile):
         # which were not flagged by a QUALITY flag yet; the line below prevents
         # these cadences from being used. They would break most methods!
         self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
+        try:
+            self.targetid = self.header()['TICID']
+        except KeyError:
+            self.targetid = None
 
     def __repr__(self):
-        return('TessLightCurveFile(TICID: {})'.format(self.ticid))
-
-    @property
-    def ticid(self):
-        return self.header(ext=0)['TICID']
-
-    @property
-    def targetid(self):
-        return self.ticid
+        return('TessLightCurveFile(TICID: {})'.format(self.targetid))
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():
@@ -406,7 +393,7 @@ class TessLightCurveFile(LightCurveFile):
                 quality=self.hdu[1].data['QUALITY'][self.quality_mask],
                 quality_bitmask=self.quality_bitmask,
                 cadenceno=self.cadenceno,
-                ticid=self.ticid,
+                targetid=self.targetid,
                 label=self.hdu[0].header['OBJECT'])
         else:
             raise KeyError("{} is not a valid flux type. Available types are: {}".

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -566,13 +566,13 @@ class TargetPixelFile(object):
         # Provide extra metadata in the title
         if self.mission == 'K2':
             title = "Quicklook lightcurve for EPIC {} (K2 Campaign {})".format(
-                self.keplerid, self.campaign)
+                self.targetid, self.campaign)
         elif self.mission == 'Kepler':
             title = "Quicklook lightcurve for KIC {} (Kepler Quarter {})".format(
-                self.keplerid, self.quarter)
+                self.targetid, self.quarter)
         elif self.mission == 'TESS':
             title = "Quicklook lightcurve for TIC {} (TESS Sector {})".format(
-                self.ticid, self.sector)
+                self.targetid, self.sector)
         else:
             title = "Quicklook lightcurve for target {}".format(self.targetid)
 
@@ -723,7 +723,10 @@ class KeplerTargetPixelFile(TargetPixelFile):
                                 quality_array=self.hdu[1].data['QUALITY'],
                                 bitmask=quality_bitmask)
         if self.targetid is None:
-            self.targetid = self.header()['KEPLERID']
+            try:
+                self.targetid = self.header()['KEPLERID']
+            except KeyError:
+                pass
 
     @staticmethod
     def from_archive(target, cadence='long', quarter=None, month=None,
@@ -794,7 +797,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 for p in path]
 
     def __repr__(self):
-        return('KeplerTargetPixelFile Object (ID: {})'.format(self.keplerid))
+        return('KeplerTargetPixelFile Object (ID: {})'.format(self.targetid))
 
     def get_prf_model(self):
         """Returns an object of KeplerPRF initialized using the
@@ -807,10 +810,6 @@ class KeplerTargetPixelFile(TargetPixelFile):
 
         return KeplerPRF(channel=self.channel, shape=self.shape[1:],
                          column=self.column, row=self.row)
-
-    @property
-    def keplerid(self):
-        return self.targetid
 
     @property
     def obsmode(self):
@@ -897,7 +896,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 'cadenceno': self.cadenceno,
                 'ra': self.ra,
                 'dec': self.dec,
-                'keplerid': self.keplerid}
+                'targetid': self.targetid}
         return KeplerLightCurve(time=self.time,
                                 time_format='bkjd',
                                 time_scale='tdb',
@@ -919,7 +918,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 'cadenceno': self.cadenceno,
                 'ra': self.ra,
                 'dec': self.dec,
-                'keplerid': self.keplerid}
+                'targetid': self.targetid}
         return KeplerLightCurve(time=self.time,
                                 time_format='bkjd',
                                 time_scale='tdb',
@@ -1010,7 +1009,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 'cadenceno': self.cadenceno,
                 'ra': self.ra,
                 'dec': self.dec,
-                'keplerid': self.keplerid}
+                'targetid': self.targetid}
         return KeplerLightCurve(time=self.time,
                                 flux=lc.flux,
                                 time_format='bkjd',
@@ -1349,11 +1348,7 @@ class TessTargetPixelFile(TargetPixelFile):
             self.targetid = None
 
     def __repr__(self):
-        return('TessTargetPixelFile(TICID: {})'.format(self.ticid))
-
-    @property
-    def ticid(self):
-        return self.targetid
+        return('TessTargetPixelFile(TICID: {})'.format(self.targetid))
 
     @property
     def sector(self):
@@ -1418,7 +1413,7 @@ class TessTargetPixelFile(TargetPixelFile):
                 'cadenceno': self.cadenceno,
                 'ra': self.ra,
                 'dec': self.dec,
-                'ticid': self.ticid}
+                'targetid': self.targetid}
         return TessLightCurve(time=self.time,
                               time_format='btjd',
                               time_scale='tdb',
@@ -1439,7 +1434,7 @@ class TessTargetPixelFile(TargetPixelFile):
                 'cadenceno': self.cadenceno,
                 'ra': self.ra,
                 'dec': self.dec,
-                'ticid': self.ticid}
+                'targetid': self.targetid}
         return TessLightCurve(time=self.time,
                               time_format='btjd',
                               time_scale='tdb',

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -519,13 +519,11 @@ def test_from_fits():
     """Does the lcf.from_fits() method work like the constructor?"""
     lcf = KeplerLightCurveFile.from_fits(TABBY_Q8)
     assert isinstance(lcf, KeplerLightCurveFile)
-    assert lcf.keplerid == KeplerLightCurveFile(TABBY_Q8).keplerid
-    assert lcf.keplerid == lcf.targetid
+    assert lcf.targetid == KeplerLightCurveFile(TABBY_Q8).targetid
     # Execute the same test for TESS
     lcf = TessLightCurveFile.from_fits(TESS_SIM)
     assert isinstance(lcf, TessLightCurveFile)
-    assert lcf.ticid == TessLightCurveFile(TESS_SIM).ticid
-    assert lcf.ticid == lcf.targetid
+    assert lcf.targetid == TessLightCurveFile(TESS_SIM).targetid
 
 
 def test_targetid():
@@ -536,18 +534,11 @@ def test_targetid():
     lc.targetid = 99
     assert lc.targetid == 99
     # Does it work for Kepler?
-    lc = KeplerLightCurve(time=[], keplerid=10)
+    lc = KeplerLightCurve(time=[], targetid=10)
     assert lc.targetid == 10
-    assert lc.keplerid == 10
-    # Can we assign a new value?
-    lc.keplerid = 99
-    assert lc.keplerid == 99
-    assert lc.targetid == 99
-    # Does it work for TESS?
-    lc = TessLightCurve(time=[], ticid=20)
-    assert lc.targetid == 20
-    assert lc.ticid == 20
     # Can we assign a new value?
     lc.targetid = 99
-    assert lc.ticid == 99
     assert lc.targetid == 99
+    # Does it work for TESS?
+    lc = TessLightCurve(time=[], targetid=20)
+    assert lc.targetid == 20

--- a/lightkurve/tests/test_mast.py
+++ b/lightkurve/tests/test_mast.py
@@ -100,7 +100,7 @@ def test_kepler_tpf_from_archive():
     assert(isinstance(tpfs, list))
     assert(isinstance(tpfs[0], KeplerTargetPixelFile))
     assert(tpfs[0].campaign == tpfs[1].campaign)
-    assert(tpfs[0].keplerid != tpfs[1].keplerid)
+    assert(tpfs[0].targetid != tpfs[1].targetid)
 
 
 @pytest.mark.remote_data
@@ -137,7 +137,7 @@ def test_kepler_lightcurve_from_archive():
     assert(isinstance(lcfs, list))
     assert(isinstance(lcfs[0], KeplerLightCurveFile))
     assert(lcfs[0].quarter == lcfs[1].quarter)
-    assert(lcfs[0].keplerid != lcfs[1].keplerid)
+    assert(lcfs[0].targetid != lcfs[1].targetid)
 
 
 @pytest.mark.remote_data
@@ -165,4 +165,4 @@ def test_source_confusion():
     # See https://github.com/KeplerGO/lightkurve/issues/148
     desired_target = 6507433
     tpf = KeplerTargetPixelFile.from_archive(desired_target, quarter=8)
-    assert tpf.keplerid == desired_target
+    assert tpf.targetid == desired_target

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -248,17 +248,16 @@ def test_from_archive_should_accept_path():
     """If a path is accidentally passed to `from_archive` it should still just work."""
     KeplerTargetPixelFile.from_archive(filename_tpf_all_zeros)
 
+
 def test_from_fits():
     """Does the tpf.from_fits() method work like the constructor?"""
     tpf = KeplerTargetPixelFile.from_fits(filename_tpf_one_center)
     assert isinstance(tpf, KeplerTargetPixelFile)
-    assert tpf.keplerid == KeplerTargetPixelFile(filename_tpf_one_center).keplerid
-    assert tpf.keplerid == tpf.targetid
+    assert tpf.targetid == KeplerTargetPixelFile(filename_tpf_one_center).targetid
     # Execute the same test for TESS
     tpf = TessTargetPixelFile.from_fits(filename_tpf_one_center)
     assert isinstance(tpf, TessTargetPixelFile)
-    assert tpf.ticid == TessTargetPixelFile(filename_tpf_one_center).ticid
-    assert tpf.ticid == tpf.targetid
+    assert tpf.targetid == TessTargetPixelFile(filename_tpf_one_center).targetid
 
 
 def test_get_models():


### PR DESCRIPTION
I propose to store the KIC/EPIC/TIC ID of an object using the `targetid` attribute, rather than having separate `keplerid` and `ticid` attributes.  This simplifies the code and will make it easier to treat Kepler or TESS data objects in the same way.