### PR TITLE
Fixed flatten issue

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -278,6 +278,10 @@ class LightCurve(object):
         """
         if break_tolerance is None:
             break_tolerance = np.nan
+        if polyorder >= window_length:
+            polyorder = window_length - 1
+            log.warning("polyorder must be smaller than window_length, "
+                        "using polyorder={}.".format(polyorder))
         lc_clean = self.remove_nans()
         # Split the lightcurve into segments by finding large gaps in time
         dt = lc_clean.time[1:] - lc_clean.time[0:-1]
@@ -296,8 +300,9 @@ class LightCurve(object):
                 trend_signal[l:h] = np.nanmedian(lc_clean.flux[l:h])
             else:
                 trend_signal[l:h] = signal.savgol_filter(x=lc_clean.flux[l:h],
-                                                     window_length=window_length,
-                                                     polyorder=polyorder, **kwargs)
+                                                         window_length=window_length,
+                                                         polyorder=polyorder,
+                                                         **kwargs)
         trend_signal = np.interp(self.time, lc_clean.time, trend_signal)
         flatten_lc = copy.deepcopy(self)
         flatten_lc.flux = flatten_lc.flux / trend_signal

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -445,14 +445,14 @@ def test_flatten_robustness():
     assert_allclose(flat_lc.flux, expected_result)
     # flatten should work even if `window_length > len(flux)`
     flat_lc = lc.flatten(window_length=7, polyorder=1)
-    assert_allclose(flat_lc.flux, expected_result)
+    assert_allclose(flat_lc.flux, flat_lc.flux / np.median(flat_lc.flux))
     # flatten should work even if `polyorder >= window_length`
     flat_lc = lc.flatten(window_length=3, polyorder=3)
     assert_allclose(flat_lc.flux, expected_result)
     flat_lc = lc.flatten(window_length=3, polyorder=5)
     assert_allclose(flat_lc.flux, expected_result)
     # flatten should work even if `break_tolerance = None`
-    flat_lc = lc.flatten(break_tolerance=None)
+    flat_lc = lc.flatten(window_length=3, break_tolerance=None)
     assert_allclose(flat_lc.flux, expected_result)
 
 


### PR DESCRIPTION
There was a small issue in the current flatten implementation. 

We break the light curve into segments where there are breaks in time. If these segments were short we were just changing the flatten. Now if there are short segments we just take the median. 