### PR TITLE
Ensure time=nan cadences are masked out in `TessLightCurveFile` and `TessTargetPixelFile`

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -374,6 +374,10 @@ class TessLightCurveFile(LightCurveFile):
         self.quality_mask = TessQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['QUALITY'],
                                 bitmask=quality_bitmask)
+        # Early TESS releases had cadences with time=NaN (i.e. missing data)
+        # which were not flagged by a QUALITY flag yet; the line below prevents
+        # these cadences from being used. They would break most methods!
+        self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
 
     def __repr__(self):
         return('TessLightCurveFile(TICID: {})'.format(self.ticid))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -97,12 +97,8 @@ def test_KeplerLightCurveFile(path, mission):
                           1, 100, 2096639])
 def test_TessLightCurveFile(quality_bitmask):
     tess_file = TessLightCurveFile(TESS_SIM, quality_bitmask=quality_bitmask)
-    hdu = pyfits.open(TESS_SIM)
     tlc = tess_file.SAP_FLUX
-
     assert tlc.mission.lower() == 'tess'
-    assert_array_equal(tlc.time, hdu[1].data['TIME'])
-    assert_array_equal(tlc.flux, hdu[1].data['SAP_FLUX'])
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -99,6 +99,8 @@ def test_TessLightCurveFile(quality_bitmask):
     tess_file = TessLightCurveFile(TESS_SIM, quality_bitmask=quality_bitmask)
     tlc = tess_file.SAP_FLUX
     assert tlc.mission.lower() == 'tess'
+    # Regression test for https://github.com/KeplerGO/lightkurve/pull/236
+    assert np.isnan(tlc.time).sum() == 0
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -277,3 +277,5 @@ def test_tess_simulation():
     assert tpf.flux.shape == tpf.flux_err.shape
     tpf.wcs
     col, row = tpf.centroids()
+    # Regression test for https://github.com/KeplerGO/lightkurve/pull/236
+    assert np.isnan(tpf.time).sum() == 0


### PR DESCRIPTION
It looks like early TESS data products contain cadences with time=NaN (i.e. missing data) which are not flagged by a QUALITY flag yet (in Kepler they would trigger the `NO DATA` quality flag).  This PR forces these cadences to be masked out for now, because they would break many methods!  If this issue is fixed in the data products in the future, we may want to remove this line.