### PR TITLE
Avoid downloading PRF files on the first import

### DIFF
--- a/lightkurve/prf/tpfmodel.py
+++ b/lightkurve/prf/tpfmodel.py
@@ -406,8 +406,10 @@ class TPFModel(object):
                  background_prior=BackgroundPrior(),
                  focus_prior=FocusPrior(),
                  motion_prior=MotionPrior(),
-                 prfmodel=KeplerPRF(1, shape=(10, 10), column=0, row=0),
+                 prfmodel=None,
                  fit_background=True, fit_focus=False, fit_motion=False):
+        if prfmodel is None:
+            prfmodel = KeplerPRF(1, shape=(10, 10), column=0, row=0)
         self.star_priors = star_priors
         self.background_prior = background_prior
         self.focus_prior = focus_prior


### PR DESCRIPTION
Currently, the first time you execute `import lightkurve` after a fresh install, a PRF file will be downloaded because one of the default arguments in the `tpfmodel` module is a `KeplerPRF` object, i.e. this happens:
```
$ python -c "import lightkurve"
Downloading http://archive.stsci.edu/missions/kepler/fpc/prf/extracted/kplr02.1_2011265_prf.fits
|>-----------------------------------------| 131k/6.0M ( 2.16%) ETA    12s^C
```

This is bad because we don't want to require an internet connection to run `lightkurve` for the first time.  This PR fixes the issue!