### PR TITLE
Fixes issue #260: lc.to_pandas() takes index label as argument, no custom index by default.

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -750,7 +750,7 @@ class LightCurve(object):
                      names=('time', 'flux', 'flux_err'),
                      meta=self.meta)
 
-    def to_pandas(self, columns=['time', 'flux', 'flux_err']):
+    def to_pandas(self, columns=['time', 'flux', 'flux_err'], index=''):
         """Export the LightCurve as a Pandas DataFrame.
 
         Parameters
@@ -759,11 +759,16 @@ class LightCurve(object):
             List of columns to include in the DataFrame.  The names must match
             attributes of the `LightCurve` object (e.g. `time`, `flux`).
 
+        index : str
+            Name of the column to be set as the DataFrame's indices. The name
+            must match attributes of the `LightCurve` object (e.g. `time`,
+            `flux`). If no argument is passed no custom index is set.
+
         Returns
         -------
         dataframe : `pandas.DataFrame` object
-            A dataframe indexed by `time` and containing the columns `flux`
-            and `flux_err`.
+            A dataframe containing the columns `time`,
+             `flux`, and `flux_err`, and indexed by a column of choice.
         """
         try:
             import pandas as pd
@@ -775,8 +780,15 @@ class LightCurve(object):
         for col in columns:
             if hasattr(self, col):
                 data[col] = vars(self)[col]
-        df = pd.DataFrame(data=data, index=self.time, columns=columns)
-        df.index.name = 'time'
+        if index == '':
+            df = pd.DataFrame(data=data,columns=columns)
+        else:
+            try:
+                df = pd.DataFrame(data=data, index=vars(self)[index], columns=columns)
+                df.index.name = index
+            except KeyError:
+                log.warning('Label "{}" is not a LightCurve attribute.\nNo custom indices set.'.format(index))
+                df = pd.DataFrame(data=data,columns=columns)
         return df
 
     def to_csv(self, path_or_buf=None, **kwargs):
@@ -1080,7 +1092,7 @@ class KeplerLightCurve(LightCurve):
         return new_lc
 
     def to_pandas(self, columns=['time', 'flux', 'flux_err', 'quality',
-                                 'centroid_col', 'centroid_row']):
+                                 'centroid_col', 'centroid_row'], index=''):
         """Export the LightCurve as a Pandas DataFrame.
 
         Parameters
@@ -1089,13 +1101,18 @@ class KeplerLightCurve(LightCurve):
             List of columns to include in the DataFrame.  The names must match
             attributes of the `LightCurve` object (e.g. `time`, `flux`).
 
+        index : str
+            Name of the column to be set as the DataFrame's indices. The name
+            must match attributes of the `LightCurve` object (e.g. `time`,
+            `flux`). If no argument is passed no custom index is set.
+
         Returns
         -------
         dataframe : `pandas.DataFrame` object
-            A dataframe indexed by `time` and containing the columns `flux`
-            and `flux_err`.
+            A dataframe containing the columns `time`,
+             `flux`, and `flux_err`, and indexed by a column of choice.
         """
-        return super(KeplerLightCurve, self).to_pandas(columns=columns)
+        return super(KeplerLightCurve, self).to_pandas(columns=columns, index=index)
 
     def to_fits(self, path=None, overwrite=False, **extra_data):
         """Export the KeplerLightCurve as an astropy.io.fits object.


### PR DESCRIPTION
Adapted LightCurve.to_pandas() to set no custom index as default so that the dataframe can be manipulated in the same manner as a numpy array. If the user wants data as the index they can now choose from the LightCurve attributes as an argument.

 Examples:



```python
from lightkurve import KeplerTargetPixelFile
tpf = KeplerTargetPixelFile.from_archive("Kepler-10", quarter=3)
lc = tpf.to_lightcurve()
```
```python
lc.to_pandas().head(5)
```




<div>
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>time</th>
      <th>flux</th>
      <th>flux_err</th>
      <th>quality</th>
      <th>centroid_col</th>
      <th>centroid_row</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>0</th>
      <td>260.224211</td>
      <td>514172.06250</td>
      <td>19.571688</td>
      <td>0</td>
      <td>655.672099</td>
      <td>246.837306</td>
    </tr>
    <tr>
      <th>1</th>
      <td>260.244644</td>
      <td>514219.21875</td>
      <td>19.572435</td>
      <td>0</td>
      <td>655.672361</td>
      <td>246.837262</td>
    </tr>
    <tr>
      <th>2</th>
      <td>260.265077</td>
      <td>514238.65625</td>
      <td>19.572802</td>
      <td>0</td>
      <td>655.672272</td>
      <td>246.837468</td>
    </tr>
    <tr>
      <th>3</th>
      <td>260.285510</td>
      <td>514224.75000</td>
      <td>19.572598</td>
      <td>0</td>
      <td>655.672434</td>
      <td>246.837360</td>
    </tr>
    <tr>
      <th>4</th>
      <td>260.305943</td>
      <td>514273.62500</td>
      <td>19.573376</td>
      <td>0</td>
      <td>655.672427</td>
      <td>246.837655</td>
    </tr>
  </tbody>
</table>
</div>




```python
lc.to_pandas(index='time',columns=['flux', 'flux_err']).head(5)
```




<div>
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>flux</th>
      <th>flux_err</th>
    </tr>
    <tr>
      <th>time</th>
      <th></th>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>260.224211</th>
      <td>514172.06250</td>
      <td>19.571688</td>
    </tr>
    <tr>
      <th>260.244644</th>
      <td>514219.21875</td>
      <td>19.572435</td>
    </tr>
    <tr>
      <th>260.265077</th>
      <td>514238.65625</td>
      <td>19.572802</td>
    </tr>
    <tr>
      <th>260.285510</th>
      <td>514224.75000</td>
      <td>19.572598</td>
    </tr>
    <tr>
      <th>260.305943</th>
      <td>514273.62500</td>
      <td>19.573376</td>
    </tr>
  </tbody>
</table>
</div>




```python
lc.to_pandas(index='fulx_err').head(5)
```

    Label "fulx_err" is not an available data column.
    No custom indices set.





<div>
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>time</th>
      <th>flux</th>
      <th>flux_err</th>
      <th>quality</th>
      <th>centroid_col</th>
      <th>centroid_row</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>0</th>
      <td>260.224211</td>
      <td>514172.06250</td>
      <td>19.571688</td>
      <td>0</td>
      <td>655.672099</td>
      <td>246.837306</td>
    </tr>
    <tr>
      <th>1</th>
      <td>260.244644</td>
      <td>514219.21875</td>
      <td>19.572435</td>
      <td>0</td>
      <td>655.672361</td>
      <td>246.837262</td>
    </tr>
    <tr>
      <th>2</th>
      <td>260.265077</td>
      <td>514238.65625</td>
      <td>19.572802</td>
      <td>0</td>
      <td>655.672272</td>
      <td>246.837468</td>
    </tr>
    <tr>
      <th>3</th>
      <td>260.285510</td>
      <td>514224.75000</td>
      <td>19.572598</td>
      <td>0</td>
      <td>655.672434</td>
      <td>246.837360</td>
    </tr>
    <tr>
      <th>4</th>
      <td>260.305943</td>
      <td>514273.62500</td>
      <td>19.573376</td>
      <td>0</td>
      <td>655.672427</td>
      <td>246.837655</td>
    </tr>
  </tbody>
</table>
</div>


```