### PR TITLE
Changing BJD to JD in the astropy_time function

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -240,7 +240,9 @@ class KeplerLightCurveFile(LightCurveFile):
     @property
     def astropy_time(self):
         """Returns an AstroPy Time object for all good-quality cadences."""
-        return bkjd_to_astropy_time(bkjd=self.time)
+        timecorr = self.hdu[1].data['TIMECORR'][self.quality_mask]
+        return bkjd_to_astropy_time(bkjd=self.time, bkjdcorr=timecorr, 
+            timeslice=self.hdu[1].header['TIMSLICE'])
 
     def get_lightcurve(self, flux_type, centroid_type='MOM_CENTR'):
         if flux_type in self._flux_types():

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1215,6 +1215,18 @@ class TessTargetPixelFile(TargetPixelFile):
     def __repr__(self):
         return('TessTargetPixelFile(TICID: {})'.format(self.targetid))
 
+@property
+    def pipeline_mask(self):
+        """Returns the optimal aperture mask used by the TESS pipeline.
+         For details on how the mask is stored in a TPF, see Section 6 of the
+        Data Products documentation (EXP-TESS-ARC-ICD-TM-0014.pdf).
+        """
+        return self.hdu[2].data & 2 > 0
+     @property
+    def background_mask(self):
+        """Returns the background mask used by the TESS pipeline."""
+        return self.hdu[2].data & 4 > 0
+
     @property
     def sector(self):
         try:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -665,7 +665,9 @@ class KeplerTargetPixelFile(TargetPixelFile):
     @property
     def astropy_time(self):
         """Returns an AstroPy Time object for all good-quality cadences."""
-        return bkjd_to_astropy_time(bkjd=self.time)
+        timecorr = self.hdu[1].data['TIMECORR'][self.quality_mask]
+        return bkjd_to_astropy_time(bkjd=self.time, bkjdcorr=timecorr, 
+            timeslice=self.hdu[1].header['TIMSLICE'])
 
     @property
     def quarter(self):
@@ -1212,20 +1214,6 @@ class TessTargetPixelFile(TargetPixelFile):
 
     def __repr__(self):
         return('TessTargetPixelFile(TICID: {})'.format(self.targetid))
-
-    @property
-    def pipeline_mask(self):
-        """Returns the optimal aperture mask used by the TESS pipeline.
-
-        For details on how the mask is stored in a TPF, see Section 6 of the
-        Data Products documentation (EXP-TESS-ARC-ICD-TM-0014.pdf).
-        """
-        return self.hdu[2].data & 2 > 0
-
-    @property
-    def background_mask(self):
-        """Returns the background mask used by the TESS pipeline."""
-        return self.hdu[2].data & 4 > 0
 
     @property
     def sector(self):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1215,14 +1215,14 @@ class TessTargetPixelFile(TargetPixelFile):
     def __repr__(self):
         return('TessTargetPixelFile(TICID: {})'.format(self.targetid))
 
-@property
+    @property
     def pipeline_mask(self):
         """Returns the optimal aperture mask used by the TESS pipeline.
          For details on how the mask is stored in a TPF, see Section 6 of the
         Data Products documentation (EXP-TESS-ARC-ICD-TM-0014.pdf).
         """
         return self.hdu[2].data & 2 > 0
-     @property
+    @property
     def background_mask(self):
         """Returns the background mask used by the TESS pipeline."""
         return self.hdu[2].data & 4 > 0

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1255,7 +1255,9 @@ class TessTargetPixelFile(TargetPixelFile):
     @property
     def astropy_time(self):
         """Returns an AstroPy Time object for all good-quality cadences."""
-        return btjd_to_astropy_time(btjd=self.time)
+        timecorr = self.hdu[1].data['TIMECORR'][self.quality_mask]
+        return bkjd_to_astropy_time(bkjd=self.time, bkjdcorr=timecorr, 
+            timeslice=self.hdu[1].header['TIMSLICE'])
 
     def aperture_photometry(self, aperture_mask='pipeline'):
         """Performs aperture photometry.

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -305,21 +305,26 @@ def running_mean(data, window_size):
     return (cumsum[window_size:] - cumsum[:-window_size]) / float(window_size)
 
 
-def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
+def bkjd_to_astropy_time(bkjd, bkjdcorr, timeslice, bjdref=2454833.):
     """Converts BKJD time values to an `astropy.time.Time` object.
 
-    Kepler Barycentric Julian Day (BKJD) is a Julian day minus 2454833.0
-    (UTC=January 1, 2009 12:00:00) and corrected to the arrival times
+    The time recorded by Kepler is the Kepler Barycentric Julian Day (BKJD) minus
+    the Julian day 2454833.0 (UTC=January 1, 2009 12:00:00) and corrected to the arrival times
     at the barycenter of the Solar System.
     BKJD is the format in which times are recorded in the Kepler data products.
     The time is in the Barycentric Dynamical Time frame (TDB), which is a
     time system that is not affected by leap seconds.
-    See Section 2.3.2 in the Kepler Archive Manual for details.
+    To convert to JD and an astropy.time.Time object we must follow the procedure in
+    Section 2.3.2 in the Kepler Archive Manual. This procedure will convert BJD to JD.
 
     Parameters
     ----------
     bkjd : array of floats
         Barycentric Kepler Julian Day.
+    bkjdcorr : array of floats
+        The calculated barycenter correction factor.
+    timeslice : float
+        Time-slice readout sequence section.
     bjdref : float
         BJD reference date, for Kepler this is 2454833.
 
@@ -328,7 +333,7 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
     time : astropy.time.Time object
         Resulting time object
     """
-    jd = bkjd + bjdref
+    jd = bkjd + bjdref - bkjdcorr + (0.25 + 0.62 * (5 - timeslice)) / (86400)
     # Some data products have missing time values;
     # we need to set these to zero or `Time` cannot be instantiated.
     jd[~np.isfinite(jd)] = 0


### PR DESCRIPTION
The astropy_time function currently makes the BJD time an astropy.time.Time object with the type JD. These JD astropy times will be offset by the delay time to the barycentre, which although small, may be important for some cases. 

I changed the bkjd_to_astropy_time function in utils.py to input JD instead of BJD into astropy.time.Time, following the the procedure in Section 2.3.2 in the Kepler Archive Manual. The change introduced two new variables to the function bkjd_to_astropy_time, being the timeslice and timecorr, which are retrieved from the header and data entry respectively.  

The astropy_time properties were also changed in the targetpixelfile and lightcurvefile classes, to incorporate the two new variables introduced in bkjd_to_astropy_time.