### PR TITLE
document how to remove outliers asymmetrically

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Direct contributions to the code base:
 - `Emma Turtelboom <https://github.com/Emmavt>`_
 - `Jeff Coughlin <https://github.com/JeffLCoughlin>`_
 - `Zachory K. Berta-Thompson <https://github.com/zkbt>`_
+- `Anand Sundaram <https://github.com/anand-sundaram-zocdoc>`_
 
 
 Comments, corrections & suggestions:

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -420,6 +420,15 @@ class LightCurve(object):
         are removed if they are separated from the mean flux by `sigma` times
         the standard deviation.
 
+        Examples
+        --------
+        >>> lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
+        >>> lc_clean = lc.remove_outliers(sigma=1, sigma_lower=float('inf'), sigma_upper=1)
+        >>> lc_clean.time
+        [1, 2, 4, 5, 6, 7, 8]
+        >>> lc_clean.flux
+        [1, 1, 1, 1, -1000, 1, 1])
+
         Parameters
         ----------
         sigma : float
@@ -428,18 +437,18 @@ class LightCurve(object):
         return_mask : bool
             Whether or not to return the mask indicating which data points
             were removed. Entries marked as `True` are considered outliers.
+        sigma_lower: float
+            The number of standard deviations to use for clipping outliers
+            which are less than the median. Can be set to float('inf') in order
+            to avoid clipping outliers below the median at all.
+            (part of **kwargs passed to sigma_clip)
+        sigma_upper: float
+            The number of standard deviations to use for clipping outliers
+            which are greater than the median. Can be set to float('inf') in order
+            to avoid clipping outliers above the median at all.
+            (part of **kwargs passed to sigma_clip)
         **kwargs : dict
             Dictionary of arguments to be passed to `astropy.stats.sigma_clip`.
-            Examples:
-            ---------
-            sigma_lower: float
-                The number of standard deviations to use for clipping outliers
-                which are less than the median. Can be set to float('inf') in order
-                to avoid clipping outliers below the median at all.
-            sigma_upper: float
-                The number of standard deviations to use for clipping outliers
-                which are greater than the median. Can be set to float('inf') in order
-                to avoid clipping outliers above the median at all.
 
         Returns
         -------

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -430,6 +430,16 @@ class LightCurve(object):
             were removed. Entries marked as `True` are considered outliers.
         **kwargs : dict
             Dictionary of arguments to be passed to `astropy.stats.sigma_clip`.
+            Examples:
+            ---------
+            sigma_lower: float
+                The number of standard deviations to use for clipping outliers
+                which are less than the median. Can be set to math.inf in order
+                to avoid clipping outliers below the median at all.
+            sigma_upper: float
+                The number of standard deviations to use for clipping outliers
+                which are greater than the median. Can be set to math.inf in order
+                to avoid clipping outliers above the median at all.
 
         Returns
         -------

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -425,9 +425,9 @@ class LightCurve(object):
         >>> lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
         >>> lc_clean = lc.remove_outliers(sigma=1, sigma_lower=float('inf'), sigma_upper=1)
         >>> lc_clean.time
-        [1, 2, 4, 5, 6, 7, 8]
+        array([1, 2, 4, 5, 6, 7, 8])
         >>> lc_clean.flux
-        [1, 1, 1, 1, -1000, 1, 1])
+        array([1, 1, 1, 1, -1000, 1, 1])
 
         Parameters
         ----------

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -434,11 +434,11 @@ class LightCurve(object):
             ---------
             sigma_lower: float
                 The number of standard deviations to use for clipping outliers
-                which are less than the median. Can be set to math.inf in order
+                which are less than the median. Can be set to float('inf') in order
                 to avoid clipping outliers below the median at all.
             sigma_upper: float
                 The number of standard deviations to use for clipping outliers
-                which are greater than the median. Can be set to math.inf in order
+                which are greater than the median. Can be set to float('inf') in order
                 to avoid clipping outliers above the median at all.
 
         Returns

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -414,51 +414,89 @@ class LightCurve(object):
         return nlc
 
     def remove_outliers(self, sigma=5., return_mask=False, **kwargs):
-        """Removes outlier flux values using sigma-clipping.
+        """Removes outlier data points using sigma-clipping.
 
-        This method returns a new LightCurve object from which flux values
-        are removed if they are separated from the mean flux by `sigma` times
-        the standard deviation.
+        This method returns a new :class:`LightCurve` object from which data
+        points are removed if their flux values are greater or smaller than
+        the median flux by at least ``sigma`` times the standard deviation.
 
-        Examples
-        --------
-        >>> lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
-        >>> lc_clean = lc.remove_outliers(sigma=1, sigma_lower=float('inf'), sigma_upper=1)
-        >>> lc_clean.time
-        array([1, 2, 4, 5, 6, 7, 8])
-        >>> lc_clean.flux
-        array([    1,     1,     1,     1, -1000,     1,     1])
+        Sigma-clipping works by iterating over data points, each time rejecting
+        values that are discrepant by more than a specified number of standard
+        deviations from a center value. If the data contains invalid values
+        (NaNs or infs), they are automatically masked before performing the
+        sigma clipping.
+
+        .. note::
+            This function is a convenience wrapper around
+            `astropy.stats.sigma_clip
+            <http://docs.astropy.org/en/stable/api/astropy.stats.sigma_clip.html>`_
+            and provides the same functionality.
 
         Parameters
         ----------
         sigma : float
-            The number of standard deviations to use for clipping outliers.
-            Defaults to 5.
+            The number of standard deviations to use for both the lower and
+            upper clipping limit. These limits are overridden by
+            ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 5.
+        sigma_lower : float or `None`
+            The number of standard deviations to use as the lower bound for
+            the clipping limit. Can be set to float('inf') in order to avoid
+            clipping outliers below the median at all. If `None` then the
+            value of ``sigma`` is used. Defaults to `None`.
+        sigma_upper : float or `None`
+            The number of standard deviations to use as the upper bound for
+            the clipping limit. Can be set to float('inf') in order to avoid
+            clipping outliers above the median at all. If `None` then the
+            value of ``sigma`` is used. Defaults to `None`.
         return_mask : bool
-            Whether or not to return the mask indicating which data points
-            were removed. Entries marked as `True` are considered outliers.
-        sigma_lower: float
-            The number of standard deviations to use for clipping outliers
-            which are less than the median. Can be set to float('inf') in order
-            to avoid clipping outliers below the median at all.
-            (part of **kwargs passed to sigma_clip)
-        sigma_upper: float
-            The number of standard deviations to use for clipping outliers
-            which are greater than the median. Can be set to float('inf') in order
-            to avoid clipping outliers above the median at all.
-            (part of **kwargs passed to sigma_clip)
+            Whether or not to return a mask (i.e. a boolean array) indicating
+            which data points were removed. Entries marked as `True` in the
+            mask are considered outliers. Defaults to `True`.
+        iters : int or `None`
+            The number of iterations to perform sigma clipping, or `None` to
+            clip until convergence is achieved (i.e., continue until the
+            last iteration clips nothing). Defaults to 5.
+        cenfunc : callable
+            The function used to compute the center for the clipping. Must
+            be a callable that takes in a masked array and outputs the
+            central value. Defaults to the median (`numpy.ma.median`).
         **kwargs : dict
             Dictionary of arguments to be passed to `astropy.stats.sigma_clip`.
 
         Returns
         -------
-        clean_lightcurve : LightCurve object
-            A new ``LightCurve`` in which outliers have been removed.
+        clean_lc : LightCurve object
+            A new :class:`LightCurve` from which outlier data points have been
+            removed.
+
+        Examples
+        --------
+        This example generates a new LightCurve in which all points
+        that are more than 1 standard deviation from the median are removed::
+
+            >>> lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
+            >>> lc_clean = lc.remove_outliers(sigma=1)
+            >>> lc_clean.time
+            array([1, 3, 5])
+            >>> lc_clean.flux
+            array([1, 1, 1])
+
+        This example removes only points where the flux is larger than 1
+        standard deviation from the median, but leaves negative outliers
+        in place::
+
+            >>> lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
+            >>> lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
+            >>> lc_clean.time
+            array([1, 3, 4, 5])
+            >>> lc_clean.flux
+            array([    1,     1, -1000,     1])
         """
+        # First, we create the outlier mask using AstroPy's sigma_clip function
         with warnings.catch_warnings():  # Ignore warnings due to NaNs or Infs
             warnings.simplefilter("ignore")
             outlier_mask = sigma_clip(data=self.flux, sigma=sigma, **kwargs).mask
-
+        # Second, we return the masked lightcurve and optionally the mask itself
         if return_mask:
             return self[~outlier_mask], outlier_mask
         return self[~outlier_mask]

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -427,7 +427,7 @@ class LightCurve(object):
         >>> lc_clean.time
         array([1, 2, 4, 5, 6, 7, 8])
         >>> lc_clean.flux
-        array([1, 1, 1, 1, -1000, 1, 1])
+        array([    1,     1,     1,     1, -1000,     1,     1])
 
         Parameters
         ----------

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -9,8 +9,6 @@ from numpy.testing import (assert_almost_equal, assert_array_equal,
                            assert_allclose)
 import pytest
 
-from math import inf
-
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
 
@@ -441,7 +439,7 @@ def test_remove_outliers():
     assert(outlier_mask.sum() == 1)
     # Test asymmetric outlier removal
     lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
-    lc_clean = lc.remove_outliers(sigma=1, sigma_lower=inf, sigma_upper=1)
+    lc_clean = lc.remove_outliers(sigma=1, sigma_lower=float('inf'), sigma_upper=1)
     assert_array_equal(lc_clean.time, [1, 2, 4, 5, 6, 7, 8])
     assert_array_equal(lc_clean.flux, [1, 1, 1, 1, -1000, 1, 1])
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -9,6 +9,8 @@ from numpy.testing import (assert_almost_equal, assert_array_equal,
                            assert_allclose)
 import pytest
 
+from math import inf
+
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
 
@@ -437,6 +439,11 @@ def test_remove_outliers():
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
     assert(len(outlier_mask) == len(lc.flux))
     assert(outlier_mask.sum() == 1)
+    # Test asymmetric outlier removal
+    lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
+    lc_clean = lc.remove_outliers(sigma=1, sigma_lower=inf, sigma_upper=1)
+    assert_array_equal(lc_clean.time, [1, 2, 4, 5, 6, 7, 8])
+    assert_array_equal(lc_clean.flux, [1, 1, 1, 1, -1000, 1, 1])
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -437,11 +437,6 @@ def test_remove_outliers():
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
     assert(len(outlier_mask) == len(lc.flux))
     assert(outlier_mask.sum() == 1)
-    # Test asymmetric outlier removal
-    lc = LightCurve([1, 2, 3, 4, 5, 6, 7, 8], [1, 1, 1000, 1, 1, -1000, 1, 1])
-    lc_clean = lc.remove_outliers(sigma=1, sigma_lower=float('inf'), sigma_upper=1)
-    assert_array_equal(lc_clean.time, [1, 2, 4, 5, 6, 7, 8])
-    assert_array_equal(lc_clean.flux, [1, 1, 1, 1, -1000, 1, 1])
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -437,6 +437,11 @@ def test_remove_outliers():
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
     assert(len(outlier_mask) == len(lc.flux))
     assert(outlier_mask.sum() == 1)
+    # Can we set sigma_lower and sigma_upper?
+    lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
+    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
+    assert_array_equal(lc_clean.time, [1, 3, 4, 5])
+    assert_array_equal(lc_clean.flux, [1, 1, -1000, 1])
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This is my attempt to address https://github.com/KeplerGO/lightkurve/issues/221. I updated the docstring for remove_outliers to explicitly describe usage of the relevant members of the **kwargs passed to sigma_clip and updated the tests for the remove_outliers function as a way to include an example of this kind of usage and demonstrate that it achieves the intended goal described in the issue.