### PR TITLE
fix error in 3-line summary of commands

### DIFF
--- a/docs/source/tutorials/how-to-recover-the-first-tess-candidate.ipynb
+++ b/docs/source/tutorials/how-to-recover-the-first-tess-candidate.ipynb
@@ -869,7 +869,7 @@
    ],
    "source": [
     "lc = tpf.to_lightcurve(aperture_mask=aperture_mask).flatten(window_length=1001)\n",
-    "lc = lc[(flat_lc.time < 1346) | (flat_lc.time > 1350)]\n",
+    "lc = lc[(lc.time < 1346) | (lc.time > 1350)]\n",
     "lc.remove_outliers(sigma=6).fold(period=6.27, phase=0.4).bin(binsize=10).errorbar();"
    ]
   },


### PR DESCRIPTION
In demonstration of how a folded light curve can be produced in three lines, there was a reference to a byproduct of an intermediate step, flat_lc, that was not created in the condensed, 3-line version.