### PR TITLE
update mast download directory

### DIFF
--- a/lightkurve/mast.py
+++ b/lightkurve/mast.py
@@ -38,7 +38,16 @@ def download_products(products):
     # Note: by default, MAST will only let us download "Minimum Recommended
     # Products" (MRPs), which do not include e.g. Target Pixel Files.
     # We need to set `mrp=False` to ensure MAST downloads whatever we want.
-    dl = Observations.download_products(products, mrp_only=False)
+
+    # check if download directory exists
+    if not os.path.isdir(os.path.expanduser('~')+'/.astropy'):
+        os.mkdir(os.path.expanduser('~')+'/.astropy')
+
+    # download to astropy cache (~/.astropy)
+    download_dir = os.path.expanduser('~')+'/.astropy'
+
+    dl = Observations.download_products(products, mrp_only=False,
+                                        download_dir=download_dir)
     return dl['Local Path']
 
 

--- a/lightkurve/mast.py
+++ b/lightkurve/mast.py
@@ -39,12 +39,20 @@ def download_products(products):
     # Products" (MRPs), which do not include e.g. Target Pixel Files.
     # We need to set `mrp=False` to ensure MAST downloads whatever we want.
 
-    # check if download directory exists
-    if not os.path.isdir(os.path.expanduser('~')+'/.astropy'):
-        os.mkdir(os.path.expanduser('~')+'/.astropy')
-
-    # download to astropy cache (~/.astropy)
-    download_dir = os.path.expanduser('~')+'/.astropy'
+    # check if download directory exists (~/.lightkurve-cache)
+    cache_dir = os.path.join(os.path.expanduser('~'), '.lightkurve-cache')
+    if os.path.isdir(cache_dir):
+        download_dir = cache_dir
+    else:
+        # if it doesn't exist, make a new cache directory
+        try:
+            os.mkdir(cache_dir)
+            download_dir = cache_dir
+        # downloads locally if OS error occurs
+        except OSError:
+            log.warning('Warning: unable to create astropy cache directory. '
+                        'Downloading MAST files to local directory.')
+            download_dir = '.'
 
     dl = Observations.download_products(products, mrp_only=False,
                                         download_dir=download_dir)

--- a/lightkurve/mast.py
+++ b/lightkurve/mast.py
@@ -50,7 +50,7 @@ def download_products(products):
             download_dir = cache_dir
         # downloads locally if OS error occurs
         except OSError:
-            log.warning('Warning: unable to create astropy cache directory. '
+            log.warning('Warning: unable to create .lightkurve-cache directory. '
                         'Downloading MAST files to local directory.')
             download_dir = '.'
 


### PR DESCRIPTION
resolve #283: `from_archive()` should download to the astropy cache in user's home directory, and not make a new mastDownload directory every time it's called