### PR TITLE
Add Periodogram.smooth() function

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -322,7 +322,7 @@ class Periodogram(object):
         binned_pg.power = binned_power
         return binned_pg
 
-    def smooth(self, filter_width = 0.1):
+    def smooth(self, filter_width = 0.1/u.day):
         """Smooths the power spectrum using a simple one dimensional smoothing
         filter. This method requires a Periodogram class built using an evenly
         spaced grid of periods.
@@ -337,14 +337,18 @@ class Periodogram(object):
 
         Returns
         -------
-        smoothed_periodogram : a `Periodogram` object
+        smoothed_pg : a `Periodogram` object
             Returns a new `Periodogram` object which has been smoothed.
         """
         # Input validation
         if filter_width <= 0.:
             raise ValueError('Filter width must be larger than 0')
 
-        filter_width = u.Quantity(filter_width, self.frequency.unit)
+        try:
+            filter_width = u.Quantity(filter_width, self.frequency.unit)
+        except u.UnitConversionError:
+            raise ValueError('filter_width must be in units of frequency.')
+
         fs = np.mean(np.diff(self.frequency))
 
         #Check to see if we have a grid of evenly spaced periods instead.

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -323,8 +323,8 @@ class Periodogram(object):
         return binned_pg
 
     def smooth(self, filter_width = 0.1/u.day):
-        """Smooths the power spectrum using a simple one dimensional smoothing
-        filter. This method requires a Periodogram class built using an evenly
+        """Smooths the power spectrum by convolving with a numpy Box1DKernel.
+        This method requires a Periodogram class built using an evenly
         spaced grid of periods.
 
         Parameters
@@ -360,7 +360,7 @@ class Periodogram(object):
             smooth_pg = copy.deepcopy(self)
             smooth_pg.power = smooth_power
         else:
-            raise NotImplementedError("This smoothing function is not yet compatible with a grid of unevenly spaced frequencies.")
+            raise NotImplementedError("The smooth() function requires a grid of evently spaced frequencies at this time.")
         return smooth_pg
 
 

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -81,21 +81,22 @@ def test_bin():
 def test_smooth():
     '''Test if you can smooth the periodogram and check any pitfalls'''
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
-    p = lc.periodogram()
-    assert p.smooth().frequency == p.frequency
+    p = lc.to_periodogram()
+    assert all(p.smooth().frequency == p.frequency)
     assert p.smooth().power.unit == p.power.unit
 
     #Can't pass filter_width below 0.
     with pytest.raises(ValueError) as err:
         p.smooth(filter_width=-5.)
     #Can't pass a filter_width in the wrong units
-    with pytest.raises(UnitConversionError) as err:
-        p.smooth(filter_width=5.*u.Msol)
+    with pytest.raises(ValueError) as err:
+        p.smooth(filter_width=5.*u.day)
+    assert err.value.args[0] == 'filter_width must be in units of frequency.'
+
     #Can't (yet) use a periodogram with a non-evenly spaced frqeuencies
     with pytest.raises(NotImplementedError) as err:
         p = np.arange(100)
-        pow = np.arange(100)
-        p = Periodogram(1./p, pow)
+        p = lc.to_periodogram(period=p)
         p.smooth()
 
 def test_index():

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -60,8 +60,8 @@ def test_periodogram_slicing():
     assert np.sum(p.power) == 0
 
 def test_assign_periods():
-    ''' Test if you can assign periods and frequencies
-    '''
+    """ Test if you can assign periods and frequencies
+    """
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
     periods = np.arange(0, 100) * u.day
     p = lc.to_periodogram(period=periods)
@@ -72,14 +72,15 @@ def test_assign_periods():
     assert np.isclose(np.sum(frequency - p.frequency).value, 0, rtol=1e-14)
 
 def test_bin():
-    ''' Test if you can bin the periodogram
-    '''
+    """ Test if you can bin the periodogram
+    """
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
     p = lc.to_periodogram()
     assert len(p.bin(binsize=10).frequency) == len(p.frequency)//10
 
 def test_smooth():
-    '''Test if you can smooth the periodogram and check any pitfalls'''
+    """Test if you can smooth the periodogram and check any pitfalls
+    """
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
     p = lc.to_periodogram()
     assert all(p.smooth().frequency == p.frequency)
@@ -100,16 +101,16 @@ def test_smooth():
         p.smooth()
 
 def test_index():
-    '''Test if you can mask out periodogram
-    '''
+    """Test if you can mask out periodogram
+    """
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
     p = lc.to_periodogram()
     mask = (p.frequency > 0.1*(1/u.day)) & (p.frequency < 0.2*(1/u.day))
     assert len(p[mask].frequency) == mask.sum()
 
 def test_error_messages():
-    '''Test periodogram raises reasonable errors
-    '''
+    """Test periodogram raises reasonable errors
+    """
     # Fake, noisy data
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
 


### PR DESCRIPTION
At T'DA5 there as a very strong user case for this function to be included (and not doing so from the offset was a major oversight on my part). 

I have included in this pr:
Periodogram.smooth() with keyword argument `filter_width` in units of frequency. It returns a `smoothed_periodogram`, e.g. in the sense that the command:

`lc.to_periodogram().smooth().plot()`

works as expected. I've also added a unit test.

The function as it stands only works for Periodogram objects with evenly spaced grids of frequency, and making sure it can do so for evenly spaced grids of period will require a bit more thought.

![image](https://user-images.githubusercontent.com/22291663/46822647-dfbb5f80-cd40-11e8-9ea6-a510d739a383.png)
