### PR TITLE
Combined p._estimate_background() & p.smooth() | p.estimate_snr() is now p.flatten()

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -322,18 +322,34 @@ class Periodogram(object):
         binned_pg.power = binned_power
         return binned_pg
 
-    def smooth(self, filter_width = 0.1/u.day):
-        """Smooths the power spectrum by convolving with a numpy Box1DKernel.
-        This method requires a Periodogram class built using an evenly
-        spaced grid of periods.
+    def smooth(self, method='boxkernel', filter_width = 0.1):
+        """Smooths the power spectrum using one of two methods.
+
+        If method = `boxkernel`, smooths the power spectrum by convolving with a
+        numpy Box1DKernel with a width of `filter_width`, where `filter width` is
+        in units of frequency. This is best for filtering out noise but maintaining
+        seismic mode peaks. This method requires a Periodogram class built using
+        an evenly spaced grid of periods.
+
+        If method = `logmedian`, smooths the power spectrum using a moving median
+        moves across the power spectrum in a steps of
+
+        log10(x0) + 0.5 * filter_width
+
+        where `filter width` is in log10(frequency) space. This is best for
+        estimating the noise background, as it filters over the seismic peaks.
 
         Parameters
         ----------
+        method : str
+            {'boxkernel', 'logmedian'}. Default 'boxkernel'.
+
         filter_width : float
-            The width of the smoothing filter in units of frequency. If given
-            astropy units of frequency, will convert to the same units as the
-            Periodogram frequency attribute. If unitless, will be given same
-            units as the Periodogram frequency attribute.
+            If method = `boxkernel`, the width of the smoothing filter in units
+            of frequency. Will convert to the same units as the Periodogram
+            frequency attribute.
+            If method = `logmedian`, the width of the smoothing filter in log10
+            space.
 
         Returns
         -------
@@ -341,28 +357,50 @@ class Periodogram(object):
             Returns a new `Periodogram` object which has been smoothed.
         """
         # Input validation
-        if filter_width <= 0.:
-            raise ValueError('Filter width must be larger than 0')
+        if method == 'boxkernel':
+            if filter_width <= 0.:
+                raise ValueError('Filter width must be larger than 0 for `boxkernel` method.')
+            try:
+                filter_width = u.Quantity(filter_width, self.frequency.unit)
 
-        try:
-            filter_width = u.Quantity(filter_width, self.frequency.unit)
-        except u.UnitConversionError:
-            raise ValueError('filter_width must be in units of frequency.')
+            except u.UnitConversionError:
+                raise ValueError('filter_width must be in units of frequency.')
 
-        fs = np.mean(np.diff(self.frequency))
+            fs = np.mean(np.diff(self.frequency))
 
-        #Check to see if we have a grid of evenly spaced periods instead.
-        if np.isclose(np.median(np.diff(self.frequency.value)), fs.value):
-            box_kernel = Box1DKernel(np.ceil(filter_width/fs))
-            smooth_power = convolve(self.power.value, box_kernel)
-            smooth_power = u.Quantity(smooth_power, self.power.unit)
+            #Check to see if we have a grid of evenly spaced periods instead.
+            if np.isclose(np.median(np.diff(self.frequency.value)), fs.value):
+                box_kernel = Box1DKernel(np.ceil(filter_width/fs))
+                smooth_power = convolve(self.power.value, box_kernel)
+                smooth_power = u.Quantity(smooth_power, self.power.unit)
+
+                smooth_pg = copy.deepcopy(self)
+                smooth_pg.power = smooth_power
+                return smooth_pg
+
+            else:
+                raise NotImplementedError("The `boxkernel` method requires a grid of evently spaced frequencies at this time.")
+
+        if method == 'logmedian':
+            if isinstance(filter_width, astropy.units.quantity.Quantity):
+                raise ValueError('When using the `logmedian` method, please pass a dimensionless width in log10() space.')
+
+            count = np.zeros(len(self.frequency.value), dtype=int)
+            bkg = np.zeros_like(self.frequency.value)
+            x0 = np.log10(self.frequency[0].value)
+            while x0 < np.log10(self.frequency[-1].value):
+                m = np.abs(np.log10(self.frequency.value) - x0) < filter_width
+                if len(bkg[m] > 0):
+                    bkg[m] += np.nanmedian(self.power[m].value)
+                    count[m] += 1
+                x0 += 0.5 * filter_width
+            bkg /= count
+            bkg = u.Quantity(bkg, self.power.unit)
 
             smooth_pg = copy.deepcopy(self)
-            smooth_pg.power = smooth_power
-        else:
-            raise NotImplementedError("The smooth() function requires a grid of evently spaced frequencies at this time.")
-        return smooth_pg
+            smooth_pg.power = bkg
 
+            return smooth_pg
 
     def plot(self, scale='linear', ax=None, xlabel=None, ylabel=None, title='',
              style='lightkurve', format='frequency', unit=None, **kwargs):
@@ -440,61 +478,29 @@ class Periodogram(object):
             ax.set_title(title)
         return ax
 
-    def _estimate_background(self, log_width=0.01):
-        """Estimates the background noise of the power spectrum.
-
-        This method uses a moving filter in log10 space. The filter defines
-        a bin centered at a value x0 with a spread of ``log_width`` either side.
-        The median of the power in this bin will be added to all indices
-        within the bin in an empty array, `bkg`.
-        The bin then moves along in a step of x0 + 0.5 * log_width. This means
-        that each index will contain the sum of multiple medians of bins that
-        index is included in. To normalize this, we divide the background value
-        in each index by the number of median values that were added to that
-        index.
-
-        Parameters
-        ----------
-        log_width : float
-            Default 0.01. The width of the filter in log10 space.
-
-        Returns
-        -------
-        bkg : array-like
-            An estimate of the noise background of the power spectrum. Has the
-            same units as the `power` attribute.
-        """
-        if isinstance(self.frequency, astropy.units.quantity.Quantity):
-            f = self.frequency.value
-        else:
-            f = self.frequency
-        if isinstance(self.power, astropy.units.quantity.Quantity):
-            p = self.power.value
-        else:
-            p = self.power
-
-        count = np.zeros(len(f), dtype=int)
-        bkg = np.zeros_like(f)
-        x0 = np.log10(f[0])
-        while x0 < np.log10(f[-1]):
-            m = np.abs(np.log10(f) - x0) < log_width
-            if len(bkg[m] > 0):
-                bkg[m] += np.nanmedian(p[m])
-                count[m] += 1
-            x0 += 0.5 * log_width
-        return bkg / count
-
-    def estimate_snr(self, log_width=0.01, return_trend=False):
-        """Estimates the Signal-To-Noise (SNR) spectrum.
+    def flatten(self, method='logmedian', filter_width=0.01, return_trend=False):
+        """Estimates the Signal-To-Noise (SNR) spectrum by dividing out an
+        estimate of the noise background.
 
         This method divides the power spectrum by a background estimated
-        using a moving filter in log10 space.
+        using a moving filter in log10 space by default. For details on the
+        keyword arguments, see `Periodogram.smooth()`
+
+        Dividing the power through by the noise background produces a spectrum
+        with no units of power. Since the signal is divided through by a a measure
+        of the noise, we refer to this as a `Signal-To-Noise` spectrum.
 
         Parameters
         ----------
-        log_width : float
-            Default 0.01. The width of the filter in log10 space. Kwarg for the
-            Periodogram.estimate_background() function.
+        method : str
+            {'boxkernel', 'logmedian'}. Default 'logmedian'.
+
+        filter_width : float
+            If method = `boxkernel`, the width of the smoothing filter in units
+            of frequency. Will convert to the same units as the Periodogram
+            frequency attribute.
+            If method = `logmedian`, the width of the smoothing filter in log10
+            space.
 
         Returns
         -------
@@ -503,15 +509,12 @@ class Periodogram(object):
             signal-to-noise of the spectrum, assuming a simple estimate of the
             noise background using a moving filter in log10 space.
         """
-        bkg = u.Quantity(self._estimate_background(log_width=log_width), self.power.unit)
-        snr_pg = self / bkg
+        bkg = self.smooth(method=method, filter_width=filter_width)
+        snr_pg = self / bkg.power
         snr = SNRPeriodogram(snr_pg.frequency, snr_pg.power,
                              nyquist=self.nyquist, targetid=self.targetid,
                              label=self.label, meta=self.meta)
         if return_trend:
-            bkg = Periodogram(snr_pg.frequency, bkg,
-                              nyquist=self.nyquist, targetid=self.targetid,
-                              label=self.label, meta=self.meta)
             return snr, bkg
         return snr
 


### PR DESCRIPTION
In order to allow the user to interact more with how the Signal-To-Noise spectrum is generated, p.smooth() now contains a keyword 'method', which is either `boxkernel` for smoothing through convolution with a numpy Box1D kernel, or `logmedian`, for a moving median in log10 space. 

p.estimate_snr() is functionally the same, but renamed to p.flatten() to match lightkurve nomenclature, and takes keyword arguments for p.smooth().

Added unit tests for all changes.

![image](https://user-images.githubusercontent.com/22291663/46896977-d8757e00-ce34-11e8-9fb5-a035806d6a68.png)
![image](https://user-images.githubusercontent.com/22291663/46896980-e3301300-ce34-11e8-888d-fa84563aea6e.png)
