### PR TITLE
Add Time = NaN warnings to LightCurve and TargetPixelFile

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -61,6 +61,9 @@ class LightCurve(object):
             self.time = np.arange(len(flux))
         else:
             self.time = np.asarray(time)
+            # Trigger warning if time=NaN are present
+            if np.isnan(self.time).any():
+                log.warning('Warning: NaN times are present in LightCurve')
         self.flux = self._validate_array(flux, name='flux')
         self.flux_err = self._validate_array(flux_err, name='flux_err')
         self.time_format = time_format

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -41,9 +41,6 @@ class TargetPixelFile(object):
             self.hdu = fits.open(self.path, **kwargs)
         self.quality_bitmask = quality_bitmask
         self.targetid = targetid
-        # Trigger warning if time=NaN are present
-        if np.isnan(self.hdu[1].data['TIME']).any():
-                log.warning('Warning: NaN times are present in TargetPixelFile')
 
     @property
     def hdu(self):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -41,6 +41,9 @@ class TargetPixelFile(object):
             self.hdu = fits.open(self.path, **kwargs)
         self.quality_bitmask = quality_bitmask
         self.targetid = targetid
+        # Trigger warning if time=NaN are present
+        if np.isnan(self.hdu[1].data['TIME']).any():
+                log.warning('Warning: NaN times are present in TargetPixelFile')
 
     @property
     def hdu(self):


### PR DESCRIPTION
Resolves #252 by adding time = NaN warnings to `TargetPixelFile` and `LightCurve` initializers. 