### PR TITLE
Add UserWarning for time=NaN warning in LightCurve and added tests

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -63,6 +63,7 @@ class LightCurve(object):
             self.time = np.asarray(time)
             # Trigger warning if time=NaN are present
             if np.isnan(self.time).any():
+                warnings.warn('Warning: NaN times are present in LightCurve', UserWarning)
                 log.warning('Warning: NaN times are present in LightCurve')
         self.flux = self._validate_array(flux, name='flux')
         self.flux_err = self._validate_array(flux_err, name='flux_err')

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -20,7 +20,7 @@ from astropy.time import Time
 from astropy import units as u
 from . import PACKAGEDIR, MPLSTYLE
 
-from .utils import running_mean, bkjd_to_astropy_time, btjd_to_astropy_time
+from .utils import running_mean, bkjd_to_astropy_time, btjd_to_astropy_time, LightkurveWarning
 
 __all__ = ['LightCurve', 'KeplerLightCurve', 'TessLightCurve',
            'FoldedLightCurve']
@@ -63,7 +63,7 @@ class LightCurve(object):
             self.time = np.asarray(time)
             # Trigger warning if time=NaN are present
             if np.isnan(self.time).any():
-                warnings.warn('Warning: NaN times are present in LightCurve', UserWarning)
+                warnings.warn('Warning: NaN times are present in LightCurve', LightkurveWarning)
         self.flux = self._validate_array(flux, name='flux')
         self.flux_err = self._validate_array(flux_err, name='flux_err')
         self.time_format = time_format

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -64,7 +64,6 @@ class LightCurve(object):
             # Trigger warning if time=NaN are present
             if np.isnan(self.time).any():
                 warnings.warn('Warning: NaN times are present in LightCurve', UserWarning)
-                log.warning('Warning: NaN times are present in LightCurve')
         self.flux = self._validate_array(flux, name='flux')
         self.flux_err = self._validate_array(flux_err, name='flux_err')
         self.time_format = time_format

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -63,7 +63,7 @@ class LightCurve(object):
             self.time = np.asarray(time)
             # Trigger warning if time=NaN are present
             if np.isnan(self.time).any():
-                warnings.warn('Warning: NaN times are present in LightCurve', LightkurveWarning)
+                warnings.warn('LightCurve object contains NaN times', LightkurveWarning)
         self.flux = self._validate_array(flux, name='flux')
         self.flux_err = self._validate_array(flux_err, name='flux_err')
         self.time_format = time_format

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -44,6 +44,13 @@ def test_empty_lightcurve():
     assert err_string == err.value.args[0]
 
 
+def test_lc_nan_time():
+    time = np.array([1, 2, 3, np.nan])
+    flux = np.array([1, 2, 3, 4])
+    with pytest.warns(UserWarning, match='Warning: NaN times are present in LightCurve'):
+        lc = LightCurve(time=time, flux=flux)
+
+
 def test_math_operators():
     lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
     lc_add = lc + 1

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -48,7 +48,7 @@ def test_empty_lightcurve():
 def test_lc_nan_time():
     time = np.array([1, 2, 3, np.nan])
     flux = np.array([1, 2, 3, 4])
-    with pytest.warns(LightkurveWarning, match='Warning: NaN times are present in LightCurve'):
+    with pytest.warns(LightkurveWarning, match='contains NaN times'):
         lc = LightCurve(time=time, flux=flux)
 
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -11,6 +11,7 @@ import pytest
 
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
+from ..utils import LightkurveWarning
 
 # 8th Quarter of Tabby's star
 TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
@@ -47,7 +48,7 @@ def test_empty_lightcurve():
 def test_lc_nan_time():
     time = np.array([1, 2, 3, np.nan])
     flux = np.array([1, 2, 3, 4])
-    with pytest.warns(UserWarning, match='Warning: NaN times are present in LightCurve'):
+    with pytest.warns(LightkurveWarning, match='Warning: NaN times are present in LightCurve'):
         lc = LightCurve(time=time, flux=flux)
 
 

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -4,12 +4,12 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
 import warnings
-from lightkurve.lightcurve import LightCurve
 
 from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
 from ..utils import running_mean
 from ..utils import LightkurveWarning
+from ..lightcurve import LightCurve
 
 
 def test_channel_to_module_output():

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -3,10 +3,13 @@ from __future__ import division, print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
+import warnings
+from lightkurve.lightcurve import LightCurve
 
 from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
 from ..utils import running_mean
+from ..utils import LightkurveWarning
 
 
 def test_channel_to_module_output():
@@ -69,3 +72,13 @@ def test_quality_mask():
     with pytest.raises(ValueError) as err:
         KeplerQualityFlags.create_quality_mask(quality, bitmask='invalidoption')
     assert "not supported" in err.value.args[0]
+
+
+def test_lightkurve_warning():
+    """Can we ignore Lightkurve warnings?"""
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter('ignore', LightkurveWarning)
+        time = np.array([1, 2, 3, np.nan])
+        flux = np.array([1, 2, 3, 4])
+        lc = LightCurve(time=time, flux=flux)
+        assert len(warns) == 0

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -427,3 +427,10 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
         cbar.ax.yaxis.set_tick_params(tick1On=False, tick2On=False)
         cbar.ax.minorticks_off()
     return ax
+
+
+class LightkurveWarning(Warning):
+    """
+    The base warning class for all Lightkurve warnings.
+    """
+    pass

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -430,7 +430,5 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 
 
 class LightkurveWarning(Warning):
-    """
-    The base warning class for all Lightkurve warnings.
-    """
+    """Class for all Lightkurve warnings."""
     pass


### PR DESCRIPTION
Added a `UserWarning` to the time=NaN warning portion of the LightCurve constructor in lightcurve.py so that tests could be added to test_lightcurve.py