### PR TITLE
Allow `TargetPixelFile` to be indexed and sliced

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -45,7 +45,12 @@ class TargetPixelFile(object):
         self.targetid = targetid
 
     def __getitem__(self, key):
-        """Implements indexing and slicing."""
+        """Implements indexing and slicing.
+
+        Note: the implementation below cannot be be simplified using
+            `copy[1].data = copy[1].data[self.quality_mask][key]`
+        due to the complicated behavior of AstroPy's `FITS_rec`.
+        """
         # Step 1: determine the indexes of the data to return.
         # We start by determining the indexes of the good-quality cadences.
         quality_idx = np.where(self.quality_mask)[0]

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -44,6 +44,23 @@ class TargetPixelFile(object):
         self.quality_bitmask = quality_bitmask
         self.targetid = targetid
 
+    def __getitem__(self, key):
+        """Implements indexing and slicing."""
+        with warnings.catch_warnings():
+            # Ignore warnings about empty fields
+            warnings.simplefilter('ignore', UserWarning)
+            # AstroPy added `HDUList.copy()` in v3.1, but we don't want to make
+            # v3.1 a minimum requirement yet, so we copy in a funny way.
+            copy = fits.HDUList([myhdu.copy() for myhdu in self.hdu])
+            # The below ensures we always assign a `FITS_rec` instead of a `FITS_record`
+            if key == -1:
+                copy[1].data = copy[1].data[key:]
+            elif isinstance(key, int):
+                copy[1].data = copy[1].data[key:key+1]
+            else:
+                copy[1].data = copy[1].data[key]
+        return self.__class__(copy, quality_bitmask=self.quality_bitmask, targetid=self.targetid)
+
     @property
     def hdu(self):
         return self._hdu

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -401,3 +401,4 @@ def test_tpf_slicing():
     assert tpf[-1].time == tpf.time[-1]
     assert tpf[5:10].shape == tpf.flux[5:10].shape
     assert tpf[0].targetid == tpf.targetid
+    assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -393,3 +393,11 @@ def test_threshold_aperture_mask():
     tpf.plot(aperture_mask='threshold')
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux == 1).all()
+
+
+def test_tpf_slicing():
+    tpf = KeplerTargetPixelFile(filename_tpf_one_center)
+    assert tpf[0].time == tpf.time[0]
+    assert tpf[-1].time == tpf.time[-1]
+    assert tpf[5:10].shape == tpf.flux[5:10].shape
+    assert tpf[0].targetid == tpf.targetid


### PR DESCRIPTION
This PR enables `TargetPixelFile` objects to be indexed and sliced.

For example, this enables `interact()` to be run on a subset of the data:
```Python
from lightkurve import search_targetpixelfile
tpf = search_targetpixelfile('Kepler-10').download()
tpf[0:100].interact()
```

This will resolve #267, #57, #48.