### PR TITLE
Better windows default

### DIFF
--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -274,7 +274,7 @@ class SFFCorrector(object):
         pass
 
     def correct(self, time, flux, centroid_col, centroid_row,
-                polyorder=5, niters=3, bins=15, windows=1, sigma_1=3.,
+                polyorder=5, niters=3, bins=15, windows=10, sigma_1=3.,
                 sigma_2=5., restore_trend=False):
         """Returns a systematics-corrected LightCurve.
 

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -44,7 +44,7 @@ def test_sff_corrector():
     corrected_lc = sff.correct(time=time, flux=raw_flux,
                                centroid_col=centroid_col,
                                centroid_row=centroid_row,
-                               niters=1)
+                               niters=1, windows=1)
     # do hidden plots execute smoothly?
     ax = sff._plot_rotated_centroids()
     ax = sff._plot_normflux_arclength()
@@ -63,7 +63,7 @@ def test_sff_corrector():
     # test using KeplerLightCurve interface
     klc = KeplerLightCurve(time=time, flux=raw_flux, centroid_col=centroid_col,
                            centroid_row=centroid_row)
-    klc = klc.correct(niters=1)
+    klc = klc.correct(niters=1, windows=1)
     sff = klc.corrector
 
     assert_almost_equal(klc.flux*sff.bspline(time),


### PR DESCRIPTION
The default for windows in `lc.correct()` is useless, i've set it to 10 which is a reasonable default.