### PR TITLE
Suppressed the scipy warning on lc.flatten()

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -318,7 +318,7 @@ class LightCurve(object):
             else:
                 # Scipy outputs a warning here that is not useful, will be fixed in version 1.2
                 with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
+                    warnings.simplefilter('ignore', FutureWarning)
                     trend_signal[l:h] = signal.savgol_filter(x=lc_clean.flux[l:h],
                                                              window_length=window_length,
                                                              polyorder=polyorder,

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -323,7 +323,6 @@ class LightCurve(object):
                                                              window_length=window_length,
                                                              polyorder=polyorder,
                                                              **kwargs)
-        return(0)
 
         trend_signal = np.interp(self.time, lc_clean.time, trend_signal)
         flatten_lc = self.copy()

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -312,13 +312,19 @@ class LightCurve(object):
             # Reduce `window_length` and `polyorder` for short segments;
             # this prevents `savgol_filter` from raising an exception
             # If the segment is too short, just take the median
+
             if np.any([window_length > (h - l), (h - l) < break_tolerance]):
                 trend_signal[l:h] = np.nanmedian(lc_clean.flux[l:h])
             else:
-                trend_signal[l:h] = signal.savgol_filter(x=lc_clean.flux[l:h],
-                                                         window_length=window_length,
-                                                         polyorder=polyorder,
-                                                         **kwargs)
+                # Scipy outputs a warning here that is not useful, will be fixed in version 1.2
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    trend_signal[l:h] = signal.savgol_filter(x=lc_clean.flux[l:h],
+                                                             window_length=window_length,
+                                                             polyorder=polyorder,
+                                                             **kwargs)
+        return(0)
+
         trend_signal = np.interp(self.time, lc_clean.time, trend_signal)
         flatten_lc = self.copy()
         with warnings.catch_warnings():


### PR DESCRIPTION
`lc.flatten()` had a gross error message from scipy.savgol_filter which will apparently be fixed in scipy v1.2.0, until then I've just suppressed it because it is gross.

![image](https://user-images.githubusercontent.com/14965634/47742994-27941f00-dc3b-11e8-8948-b37fe451bd33.png)
