### PR TITLE
Suppress printed output statements

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -15,6 +15,7 @@ from astroquery.exceptions import ResolverError
 from .lightcurvefile import KeplerLightCurveFile
 from .targetpixelfile import KeplerTargetPixelFile
 from .collections import TargetPixelFileCollection, LightCurveFileCollection
+from .utils import suppress
 from . import PACKAGEDIR
 
 log = logging.getLogger(__name__)
@@ -85,6 +86,7 @@ class SearchResult(object):
         """Returns an array of dec values for targets in search"""
         return self.table['s_dec'].data.data
 
+    @suppress
     def download(self, quality_bitmask='default', download_dir=None):
         """Returns a single `KeplerTargetPixelFile` or `KeplerLightCurveFile` object.
 
@@ -139,6 +141,7 @@ class SearchResult(object):
         elif any(file in self.table['productFilename'][0] for file in lcf_files):
             return KeplerLightCurveFile(path[0], quality_bitmask=quality_bitmask)
 
+    @suppress
     def download_all(self, quality_bitmask='default', download_dir=None):
         """Returns a `TargetPixelFileCollection or `LightCurveFileCollection`.
 

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -2,6 +2,7 @@
 from __future__ import division, print_function
 import logging
 import sys
+import os
 import warnings
 
 from astropy.visualization import (PercentileInterval, ImageNormalize,
@@ -436,3 +437,31 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 class LightkurveWarning(Warning):
     """Class for all Lightkurve warnings."""
     pass
+
+
+def suppress(f, **kwargs):
+    '''
+    A simple decorator to suppress function print outputs.
+
+    Parameters
+    ----------
+    f : function
+        A function that outputs undesired print statements
+    kwargs : dict
+        Keyword arguments passed into function `f`
+
+    Returns
+    -------
+    call : function
+        A function call wrapper that includes suppressed outputs
+    '''
+    def call(*args):
+        # redirect output to `null`
+        with open(os.devnull, 'w') as devnull:
+            sys.stdout = devnull
+            try:
+                yield
+            finally:
+                sys.stdout = sys.__stdout__
+
+    return call


### PR DESCRIPTION
In response to #165: added a decorator to `utils` module which redirects printed outputs from a function to `null`, and then restores to default.