### PR TITLE
Intelligently read in fits files

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -645,8 +645,19 @@ def _filter_products(products, campaign=None, quarter=None, month=None,
 
 def open(path):
     """
-    Opens a fits file, detects its type, and returns the appopriate
-    `KeplerTargetPixelFile` or `TessTargetPixelFile`.
+    Opens a fits file, detects its type, and returns the appopriate object.
+
+    Parameters
+    ----------
+    path : str
+        Path or URL of a FITS file.
+
+    Returns
+    -------
+    data : :class:`TargetPixelFile` or :class:`LightCurveFile` object
+        `KeplerTargetPixelFile`, `TessTargetPixelFile`, `KeplerLightCurveFile` or
+        `TessLightCurveFile` object corresponding to datatype of given fits file.
+
     """
     hdulist = fits.open(path)
     try:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -661,6 +661,7 @@ def open(path):
     """
     hdulist = fits.open(path)
     try:
+        # use `telescop` keyword to determine mission and `creator` to determine tpf or lc
         mission = hdulist[0].header['telescop']
         creator = hdulist[0].header['creator']
         if mission == 'Kepler':
@@ -673,6 +674,7 @@ def open(path):
                 return TessTargetPixelFile(path)
             elif 'Flux' in creator:
                 return TessLightCurveFile(path)
+    # if these keywords don't exist, raise `ValueError`
     except KeyError:
         pass
     raise ValueError('Given fits file not recognized as Kepler or TESS observation.')

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -648,11 +648,12 @@ def open(path_or_url):
     """Opens a Kepler or TESS data product.
 
     This function will automatically detect the type of the data product,
-    and return the appropriate object. File types currently supported are:
-    * `KeplerTargetPixelFile` (typical suffix "-targ.fits.gz");
-    * `KeplerLightCurveFile` (typical suffix "llc.fits");
-    * `TessTargetPixelFile` (typical suffix "_tp.fits");
-    * `TessLightCurveFile` (typical suffix "_lc.fits").
+    and return the appropriate object. File types currently supported are::
+
+        * `KeplerTargetPixelFile` (typical suffix "-targ.fits.gz");
+        * `KeplerLightCurveFile` (typical suffix "llc.fits");
+        * `TessTargetPixelFile` (typical suffix "_tp.fits");
+        * `TessLightCurveFile` (typical suffix "_lc.fits").
 
     The function will detect the file type by looking at both the TELESCOP and
     CREATOR keywords in the first extension of the FITS file.
@@ -676,10 +677,9 @@ def open(path_or_url):
 
     Examples
     --------
-    To open a target pixel file using its URL, simply use:
+    To open a target pixel file using its path or URL, simply use:
 
-        >>> tpf = open("https://archive.stsci.edu/missions/kepler/target_pixel_files/" \
-                       + "0119/011904151/kplr011904151-2010009091648_lpd-targ.fits.gz")
+        >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
     hdulist = fits.open(path_or_url)
     try:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -678,8 +678,8 @@ def open(path_or_url):
     --------
     To open a target pixel file using its URL, simply use:
 
-        >>> tpf = open("https://archive.stsci.edu/missions/kepler/target_pixel_files/"
-                       "0119/011904151/kplr011904151-2010009091648_lpd-targ.fits.gz")
+        >>> tpf = open("https://archive.stsci.edu/missions/kepler/target_pixel_files/" \
+                       + "0119/011904151/kplr011904151-2010009091648_lpd-targ.fits.gz")
     """
     hdulist = fits.open(path_or_url)
     try:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -583,13 +583,6 @@ class TargetPixelFile(object):
         return show_interact_widget(self, lc=lc, notebook_url=notebook_url,
                                     max_cadences=max_cadences)
 
-    def open(self, path):
-        """
-        Opens a fits file, detects its type, and returns the appopriate
-        `KeplerTargetPixelFile` or `TessTargetPixelFile`.
-        """
-        pass
-
 
 class KeplerTargetPixelFile(TargetPixelFile):
     """
@@ -1401,3 +1394,28 @@ class TessTargetPixelFile(TargetPixelFile):
                               flux=np.nansum(self.flux_bkg[:, aperture_mask], axis=1),
                               flux_err=flux_bkg_err,
                               **keys)
+
+def open_fits(path):
+    """
+    Opens a fits file, detects its type, and returns the appopriate
+    `KeplerTargetPixelFile` or `TessTargetPixelFile`.
+    """
+    if isinstance(path, fits.HDUList):
+        hdu = path
+    else:
+        hdu = fits.open(path)
+
+    try:
+        mission = hdu[0].header['telescop']
+        if mission == 'Kepler':
+            return KeplerTargetPixelFile(path)
+        elif mission == 'TESS':
+            return TessTargetPixelFile(path)
+        else:
+            warnings.warn('Mission not recognized as Kepler or TESS. '
+                          'A `KeplerTargetPixelFile` has been returned.')
+            return KeplerTargetPixelFile(path)
+    except:
+        warnings.warn('Mission not recognized as Kepler or TESS. '
+                      'A `KeplerTargetPixelFile` has been returned.')
+        return KeplerTargetPixelFile(path)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1419,7 +1419,7 @@ class TessTargetPixelFile(TargetPixelFile):
                               flux_err=flux_bkg_err,
                               **keys)
 
-def open_fits(path):
+def open(path):
     """
     Opens a fits file, detects its type, and returns the appopriate
     `KeplerTargetPixelFile` or `TessTargetPixelFile`.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1407,7 +1407,6 @@ def open_fits(path):
             return KeplerTargetPixelFile(path)
         elif mission == 'TESS':
             return TessTargetPixelFile(path)
-    except:
-        warnings.warn('Mission not recognized as Kepler or TESS. '
-                      'A `KeplerTargetPixelFile` has been returned.')
-        return KeplerTargetPixelFile(path)
+    except KeyError:
+        pass
+    raise ValueError('Given fits file not recognized as Kepler or TESS observation.')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -622,13 +622,18 @@ class KeplerTargetPixelFile(TargetPixelFile):
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['QUALITY'],
                                 bitmask=quality_bitmask)
-        try:
-            mission = fits.open(path)[0].header['telescop']
-            if mission == 'TESS':
-                warnings.warn('The provided file path appears to be a TESS observation. '
-                              'Please instantiate as a `TessTargetPixelFile`.')
-        except KeyError:
-            warnings.warn('The provided file path not recognized as Kepler observation.')
+        if isinstance(path, str):
+            try:
+                mission = fits.open(path)[0].header['telescop']
+                if mission == 'TESS':
+                    warnings.warn('The provided file path appears to be a TESS observation. '
+                                  'Please instantiate as a `TessTargetPixelFile`.')
+                elif mission == 'Kepler':
+                    pass
+                else:
+                    raise KeyError
+            except KeyError:
+                warnings.warn('The provided file path not recognized as Kepler observation.')
         if self.targetid is None:
             try:
                 self.targetid = self.header['KEPLERID']
@@ -1286,13 +1291,18 @@ class TessTargetPixelFile(TargetPixelFile):
         # which were not flagged by a QUALITY flag yet; the line below prevents
         # these cadences from being used. They would break most methods!
         self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
-        try:
-            mission = fits.open(path)[0].header['telescop']
-            if mission == 'Kepler':
-                warnings.warn('The provided file path appears to be a Kepler observation. '
-                              'Please instantiate as a `KeplerTargetPixelFile`.')
-        except KeyError:
-            warnings.warn('The provided file path not recognized as TESS observation.')
+        if isinstance(path, str):
+            try:
+                mission = fits.open(path)[0].header['telescop']
+                if mission == 'Kepler':
+                    warnings.warn('The provided file path appears to be a Kepler observation. '
+                                  'Please instantiate as a `KeplerTargetPixelFile`.')
+                elif mission == 'TESS':
+                    pass
+                else:
+                    raise KeyError
+            except KeyError:
+                warnings.warn('The provided file path not recognized as TESS observation.')
         try:
             self.targetid = self.header['TICID']
         except KeyError:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -583,6 +583,13 @@ class TargetPixelFile(object):
         return show_interact_widget(self, lc=lc, notebook_url=notebook_url,
                                     max_cadences=max_cadences)
 
+    def open(self, path):
+        """
+        Opens a fits file, detects its type, and returns the appopriate
+        `KeplerTargetPixelFile` or `TessTargetPixelFile`.
+        """
+        pass
+
 
 class KeplerTargetPixelFile(TargetPixelFile):
     """

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1418,19 +1418,3 @@ class TessTargetPixelFile(TargetPixelFile):
                               flux=np.nansum(self.flux_bkg[:, aperture_mask], axis=1),
                               flux_err=flux_bkg_err,
                               **keys)
-
-def open(path):
-    """
-    Opens a fits file, detects its type, and returns the appopriate
-    `KeplerTargetPixelFile` or `TessTargetPixelFile`.
-    """
-    hdulist = fits.open(path)
-    try:
-        mission = hdulist[0].header['telescop']
-        if mission == 'Kepler':
-            return KeplerTargetPixelFile(path)
-        elif mission == 'TESS':
-            return TessTargetPixelFile(path)
-    except KeyError:
-        pass
-    raise ValueError('Given fits file not recognized as Kepler or TESS observation.')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -627,13 +627,15 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 mission = fits.open(path)[0].header['telescop']
                 if mission == 'TESS':
                     warnings.warn('The provided file path appears to be a TESS observation. '
-                                  'Please instantiate as a `TessTargetPixelFile`.')
+                                  'Please instantiate as a `TessTargetPixelFile`.',
+                                  LightkurveWarning)
                 elif mission == 'Kepler':
                     pass
                 else:
                     raise KeyError
             except KeyError:
-                warnings.warn('The provided file path not recognized as Kepler observation.')
+                warnings.warn('The provided file path not recognized as Kepler observation.',
+                              LightkurveWarning)
         if self.targetid is None:
             try:
                 self.targetid = self.header['KEPLERID']
@@ -1296,13 +1298,15 @@ class TessTargetPixelFile(TargetPixelFile):
                 mission = fits.open(path)[0].header['telescop']
                 if mission == 'Kepler':
                     warnings.warn('The provided file path appears to be a Kepler observation. '
-                                  'Please instantiate as a `KeplerTargetPixelFile`.')
+                                  'Please instantiate as a `KeplerTargetPixelFile`.',
+                                  LightkurveWarning)
                 elif mission == 'TESS':
                     pass
                 else:
                     raise KeyError
             except KeyError:
-                warnings.warn('The provided file path not recognized as TESS observation.')
+                warnings.warn('The provided file path not recognized as TESS observation.',
+                              LightkurveWarning)
         try:
             self.targetid = self.header['TICID']
         except KeyError:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1400,21 +1400,13 @@ def open_fits(path):
     Opens a fits file, detects its type, and returns the appopriate
     `KeplerTargetPixelFile` or `TessTargetPixelFile`.
     """
-    if isinstance(path, fits.HDUList):
-        hdu = path
-    else:
-        hdu = fits.open(path)
-
+    hdulist = fits.open(path)
     try:
-        mission = hdu[0].header['telescop']
+        mission = hdulist[0].header['telescop']
         if mission == 'Kepler':
             return KeplerTargetPixelFile(path)
         elif mission == 'TESS':
             return TessTargetPixelFile(path)
-        else:
-            warnings.warn('Mission not recognized as Kepler or TESS. '
-                          'A `KeplerTargetPixelFile` has been returned.')
-            return KeplerTargetPixelFile(path)
     except:
         warnings.warn('Mission not recognized as Kepler or TESS. '
                       'A `KeplerTargetPixelFile` has been returned.')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -622,6 +622,13 @@ class KeplerTargetPixelFile(TargetPixelFile):
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['QUALITY'],
                                 bitmask=quality_bitmask)
+        try:
+            mission = fits.open(path)[0].header['telescop']
+            if mission == 'TESS':
+                warnings.warn('The provided file path appears to be a TESS observation. '
+                              'Please instantiate as a `TessTargetPixelFile`.')
+        except KeyError:
+            warnings.warn('The provided file path not recognized as Kepler observation.')
         if self.targetid is None:
             try:
                 self.targetid = self.header['KEPLERID']
@@ -1279,6 +1286,13 @@ class TessTargetPixelFile(TargetPixelFile):
         # which were not flagged by a QUALITY flag yet; the line below prevents
         # these cadences from being used. They would break most methods!
         self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
+        try:
+            mission = fits.open(path)[0].header['telescop']
+            if mission == 'Kepler':
+                warnings.warn('The provided file path appears to be a Kepler observation. '
+                              'Please instantiate as a `KeplerTargetPixelFile`.')
+        except KeyError:
+            warnings.warn('The provided file path not recognized as TESS observation.')
         try:
             self.targetid = self.header['TICID']
         except KeyError:

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -16,7 +16,7 @@ import astropy.units as u
 from astropy.table import Table
 
 from ..utils import LightkurveWarning
-from ..search import search_lightcurvefile, search_targetpixelfile, SearchResult
+from ..search import search_lightcurvefile, search_targetpixelfile, SearchResult, open
 from .. import KeplerLightCurveFile, KeplerTargetPixelFile, TargetPixelFileCollection
 
 
@@ -195,3 +195,19 @@ def test_source_confusion_DEPRECATED():
     desired_target = 6507433
     tpf = KeplerTargetPixelFile.from_archive(desired_target, quarter=8)
     assert tpf.targetid == desired_target
+
+
+def test_open():
+    k2_path = os.path.dirname(os.path.abspath(__file__)) + '/data/test-tpf-star.fits'
+    tess_path = os.path.dirname(os.path.abspath(__file__)) + '/data/tess25155310-s01-first-cadences.fits.gz'
+    k2tpf = open(k2_path)
+    assert isinstance(k2tpf, KeplerTargetPixelFile)
+    tesstpf = open(tess_path)
+    assert isinstance(tesstpf, TessTargetPixelFile)
+    try:
+        open(os.path.dirname(os.path.abspath(__file__)) +
+                  '/data/test_factory0.fits')
+    except ValueError:
+        pass
+    assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)
+    assert isinstance(TessTargetPixelFile(k2_path), TessTargetPixelFile)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -21,6 +21,8 @@ from ..search import search_lightcurvefile, search_targetpixelfile, SearchResult
 from .. import KeplerLightCurveFile
 from .. import KeplerTargetPixelFile, TessTargetPixelFile, TargetPixelFileCollection
 
+from .. import PACKAGEDIR
+
 
 @pytest.mark.remote_data
 def test_search_targetpixelfile():
@@ -200,14 +202,14 @@ def test_source_confusion_DEPRECATED():
 
 
 def test_open():
-    k2_path = os.path.dirname(os.path.abspath(__file__)) + '/data/test-tpf-star.fits'
-    tess_path = os.path.dirname(os.path.abspath(__file__)) + '/data/tess25155310-s01-first-cadences.fits.gz'
+    k2_path = PACKAGEDIR + '/tests/data/test-tpf-star.fits'
+    tess_path = PACKAGEDIR + '/tests/data/tess25155310-s01-first-cadences.fits.gz'
     k2tpf = open(k2_path)
     assert isinstance(k2tpf, KeplerTargetPixelFile)
     tesstpf = open(tess_path)
     assert isinstance(tesstpf, TessTargetPixelFile)
     try:
-        open(os.path.dirname(os.path.abspath(__file__)) + '/data/test_factory0.fits')
+        open(PACKAGEDIR + '/tests/data/test_factory0.fits')
     except ValueError:
         pass
     assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -7,6 +7,7 @@ if no internet connection is available.
 """
 from __future__ import division, print_function
 
+import os
 import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -17,7 +18,8 @@ from astropy.table import Table
 
 from ..utils import LightkurveWarning
 from ..search import search_lightcurvefile, search_targetpixelfile, SearchResult, open
-from .. import KeplerLightCurveFile, KeplerTargetPixelFile, TargetPixelFileCollection
+from .. import KeplerLightCurveFile
+from .. import KeplerTargetPixelFile, TessTargetPixelFile, TargetPixelFileCollection
 
 
 @pytest.mark.remote_data
@@ -205,8 +207,7 @@ def test_open():
     tesstpf = open(tess_path)
     assert isinstance(tesstpf, TessTargetPixelFile)
     try:
-        open(os.path.dirname(os.path.abspath(__file__)) +
-                  '/data/test_factory0.fits')
+        open(os.path.dirname(os.path.abspath(__file__)) + '/data/test_factory0.fits')
     except ValueError:
         pass
     assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -202,14 +202,14 @@ def test_source_confusion_DEPRECATED():
 
 
 def test_open():
-    k2_path = PACKAGEDIR + '/tests/data/test-tpf-star.fits'
-    tess_path = PACKAGEDIR + '/tests/data/tess25155310-s01-first-cadences.fits.gz'
+    k2_path = os.path.join(PACKAGEDIR, "tests", "data", "test-tpf-star.fits")
+    tess_path = os.path.join(PACKAGEDIR, "tests", "data", "tess25155310-s01-first-cadences.fits.gz")
     k2tpf = open(k2_path)
     assert isinstance(k2tpf, KeplerTargetPixelFile)
     tesstpf = open(tess_path)
     assert isinstance(tesstpf, TessTargetPixelFile)
     try:
-        open(PACKAGEDIR + '/tests/data/test_factory0.fits')
+        open(os.path.join(PACKAGEDIR, "tests", "data", "test_factory0.fits"))
     except ValueError:
         pass
     assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -428,14 +428,16 @@ def test_tpf_slicing():
 
 
 def test_open_fits():
-    k2tpf = open_fits(os.path.dirname(os.path.abspath(__file__)) +
-                      '/data/test-tpf-star.fits')
+    k2_path = os.path.dirname(os.path.abspath(__file__)) + '/data/test-tpf-star.fits'
+    tess_path = os.path.dirname(os.path.abspath(__file__)) + '/data/tess25155310-s01-first-cadences.fits.gz'
+    k2tpf = open_fits(k2_path)
     assert isinstance(k2tpf, KeplerTargetPixelFile)
-    tesstpf = open_fits(os.path.dirname(os.path.abspath(__file__)) +
-                        '/data/tess25155310-s01-first-cadences.fits.gz')
+    tesstpf = open_fits(tess_path)
     assert isinstance(tesstpf, TessTargetPixelFile)
     try:
         open_fits(os.path.dirname(os.path.abspath(__file__)) +
                   '/data/test_factory0.fits')
     except ValueError:
         pass
+    assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)
+    assert isinstance(TessTargetPixelFile(k2_path), TessTargetPixelFile)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -9,7 +9,7 @@ import pytest
 import tempfile
 
 from ..targetpixelfile import KeplerTargetPixelFile, KeplerTargetPixelFileFactory
-from ..targetpixelfile import TessTargetPixelFile
+from ..targetpixelfile import TessTargetPixelFile, open_fits
 from ..lightcurve import TessLightCurve
 from ..utils import LightkurveWarning
 
@@ -398,7 +398,7 @@ def test_threshold_aperture_mask():
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux == 1).all()
 
-    
+
 def test_tpf_tess():
     """Does a TESS Sector 1 TPF work?"""
     tpf = TessTargetPixelFile(filename_tess, quality_bitmask=None)
@@ -417,7 +417,7 @@ def test_tpf_tess():
     tpf.wcs
     col, row = tpf.estimate_centroids()
 
-    
+
 def test_tpf_slicing():
     tpf = KeplerTargetPixelFile(filename_tpf_one_center)
     assert tpf[0].time == tpf.time[0]
@@ -425,3 +425,17 @@ def test_tpf_slicing():
     assert tpf[5:10].shape == tpf.flux[5:10].shape
     assert tpf[0].targetid == tpf.targetid
     assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])
+
+
+def test_open_fits():
+    k2tpf = open_fits(os.path.dirname(os.path.abspath(__file__)) +
+                      '/data/test-tpf-star.fits')
+    assert isinstance(k2tpf, KeplerTargetPixelFile)
+    tesstpf = open_fits(os.path.dirname(os.path.abspath(__file__)) +
+                        '/data/tess25155310-s01-first-cadences.fits.gz')
+    assert isinstance(tesstpf, TessTargetPixelFile)
+    try:
+        open_fits(os.path.dirname(os.path.abspath(__file__)) +
+                  '/data/test_factory0.fits')
+    except ValueError:
+        pass

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -9,7 +9,7 @@ import pytest
 import tempfile
 
 from ..targetpixelfile import KeplerTargetPixelFile, KeplerTargetPixelFileFactory
-from ..targetpixelfile import TessTargetPixelFile, open_fits
+from ..targetpixelfile import TessTargetPixelFile, open
 from ..lightcurve import TessLightCurve
 from ..utils import LightkurveWarning
 
@@ -427,15 +427,15 @@ def test_tpf_slicing():
     assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])
 
 
-def test_open_fits():
+def test_open():
     k2_path = os.path.dirname(os.path.abspath(__file__)) + '/data/test-tpf-star.fits'
     tess_path = os.path.dirname(os.path.abspath(__file__)) + '/data/tess25155310-s01-first-cadences.fits.gz'
-    k2tpf = open_fits(k2_path)
+    k2tpf = open(k2_path)
     assert isinstance(k2tpf, KeplerTargetPixelFile)
-    tesstpf = open_fits(tess_path)
+    tesstpf = open(tess_path)
     assert isinstance(tesstpf, TessTargetPixelFile)
     try:
-        open_fits(os.path.dirname(os.path.abspath(__file__)) +
+        open(os.path.dirname(os.path.abspath(__file__)) +
                   '/data/test_factory0.fits')
     except ValueError:
         pass

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -9,7 +9,7 @@ import pytest
 import tempfile
 
 from ..targetpixelfile import KeplerTargetPixelFile, KeplerTargetPixelFileFactory
-from ..targetpixelfile import TessTargetPixelFile, open
+from ..targetpixelfile import TessTargetPixelFile
 from ..lightcurve import TessLightCurve
 from ..utils import LightkurveWarning
 
@@ -425,19 +425,3 @@ def test_tpf_slicing():
     assert tpf[5:10].shape == tpf.flux[5:10].shape
     assert tpf[0].targetid == tpf.targetid
     assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])
-
-
-def test_open():
-    k2_path = os.path.dirname(os.path.abspath(__file__)) + '/data/test-tpf-star.fits'
-    tess_path = os.path.dirname(os.path.abspath(__file__)) + '/data/tess25155310-s01-first-cadences.fits.gz'
-    k2tpf = open(k2_path)
-    assert isinstance(k2tpf, KeplerTargetPixelFile)
-    tesstpf = open(tess_path)
-    assert isinstance(tesstpf, TessTargetPixelFile)
-    try:
-        open(os.path.dirname(os.path.abspath(__file__)) +
-                  '/data/test_factory0.fits')
-    except ValueError:
-        pass
-    assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)
-    assert isinstance(TessTargetPixelFile(k2_path), TessTargetPixelFile)


### PR DESCRIPTION
#316: Make sure that fits files are read in as the correct type. Add a `targetpixelfile.open()` function to check Kepler or TESS specific keywords and correspondingly open either a `KeplerTargetPixelFile` or `TessTargetPixelFile`.