### PR TITLE
Increase the speed of lc.bin()

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -559,19 +559,19 @@ class LightCurve(object):
 
         n_bins = self.flux.size // binsize
         binned_lc = self.copy()
-        binned_lc.time = np.array([methodf(a) for a in np.array_split(self.time, n_bins)])
-        binned_lc.flux = np.array([methodf(a) for a in np.array_split(self.flux, n_bins)])
+        indexes = np.array_split(np.arange(len(self.time)), n_bins)
+        binned_lc.time = np.array([methodf(a) for a in indexes])
+        binned_lc.flux = np.array([methodf(a) for a in indexes])
 
         if np.any(np.isfinite(self.flux_err)):
             # root-mean-square error
             binned_lc.flux_err = np.array(
                 [np.sqrt(np.nansum(a**2))
-                 for a in np.array_split(self.flux_err, n_bins)]
+                 for a in indexes]
             ) / binsize
         else:
-            # compute the standard deviation from the data
-            binned_lc.flux_err = np.array([np.nanstd(a)
-                                           for a in np.array_split(self.flux, n_bins)])
+            # Make them zeros.
+            binned_lc.flux_err = np.zeros(len(binned_lc.flux_err))
 
         if hasattr(binned_lc, 'quality'):
             binned_lc.quality = np.array(

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -560,13 +560,13 @@ class LightCurve(object):
         n_bins = self.flux.size // binsize
         binned_lc = self.copy()
         indexes = np.array_split(np.arange(len(self.time)), n_bins)
-        binned_lc.time = np.array([methodf(a) for a in indexes])
-        binned_lc.flux = np.array([methodf(a) for a in indexes])
+        binned_lc.time = np.array([methodf(self.time[a]) for a in indexes])
+        binned_lc.flux = np.array([methodf(self.flux[a]) for a in indexes])
 
         if np.any(np.isfinite(self.flux_err)):
             # root-mean-square error
             binned_lc.flux_err = np.array(
-                [np.sqrt(np.nansum(a**2))
+                [np.sqrt(np.nansum(self.flux_err[a]**2))
                  for a in indexes]
             ) / binsize
         else:

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -571,7 +571,7 @@ class LightCurve(object):
             ) / binsize
         else:
             # Make them zeros.
-            binned_lc.flux_err = np.zeros(len(binned_lc.flux_err))
+            binned_lc.flux_err = np.zeros(len(binned_lc.flux))
 
         if hasattr(binned_lc, 'quality'):
             binned_lc.quality = np.array(


### PR DESCRIPTION
`lc.bin()` was pretty slow for me so I've made some minor changes to increase speed.

1. When there were no errors we were calculating the standard deviation in each bin. I think this is bad form. We shouldn't be able to magic errors out of thin air. If there are no errors, there should continue to be no errors.
2. We kept calling `np.array_split()` which was becoming a little costly to do each time. 

This is a really minor speed increase of  ~ a factor 2. 