### PR TITLE
Deal more gracefully with an empty SearchResult

### DIFF
--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -6,8 +6,10 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from astropy.table import Table
 
-from ..search import search_lightcurvefile, search_targetpixelfile, SearchError
+from ..utils import LightkurveWarning
+from ..search import search_lightcurvefile, search_targetpixelfile, SearchResult, SearchError
 from ..targetpixelfile import KeplerTargetPixelFile
 
 
@@ -125,3 +127,14 @@ def test_source_confusion():
     desired_target = 6507433
     tpf = search_targetpixelfile(desired_target, quarter=8).download()
     assert tpf.targetid == desired_target
+
+
+def test_empty_searchresult():
+    """Does an empty SearchResult behave gracefully?"""
+    sr = SearchResult(Table())
+    assert len(sr) == 0
+    str(sr)
+    with pytest.warns(LightkurveWarning, match='empty search'):
+        sr.download()
+    with pytest.warns(LightkurveWarning, match='empty search'):
+        sr.download_all()


### PR DESCRIPTION
This PR ensures Lightkurve fails more gracefully when `search_targetpixelfile` or `search_lightcurvefile` return no results.

Before:

![screenshot from 2018-11-10 12-44-19](https://user-images.githubusercontent.com/817669/48305822-87fe4880-e4e6-11e8-8ac2-b85ea6bcafed.png)

After:

![screenshot from 2018-11-10 12-42-54](https://user-images.githubusercontent.com/817669/48305825-8c2a6600-e4e6-11e8-9c99-8da4be037800.png)
