### PR TITLE
Ensure default `column` and `row` parameters are defined

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -117,7 +117,11 @@ class TargetPixelFile(object):
             out = self.hdu[1].header['1CRV5P']
         except KeyError:
             out = 0
-        return out
+        # ensure output has a value
+        if isinstance(out, fits.card.Undefined):
+            return 0
+        else:
+            return out
 
     @property
     def row(self):
@@ -125,7 +129,11 @@ class TargetPixelFile(object):
             out = self.hdu[1].header['2CRV5P']
         except KeyError:
             out = 0
-        return out
+        # ensure output has a value
+        if isinstance(out, fits.card.Undefined):
+            return 0
+        else:
+            return out
 
     @property
     def pos_corr1(self):


### PR DESCRIPTION
When a `KeplerTargetPixelFile` is generated by the `KeplerTargetPixelFileFactory`, the default header has no defined value for column and row (it's set to `astropy.io.fits.card.Undefined`). 

This PR ensures that the output of the factory has the required header keywords to perform basic tasks like plotting.