### PR TITLE
Deprecate the `from_fits()` static methods in favor of `lightkurve.open()`

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -76,24 +76,13 @@ class LightCurveFile(object):
 
     @classmethod
     def from_fits(cls, path_or_url, **kwargs):
-        """Open a Light Curve File using the path or url of a FITS file.
+        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
 
-        This is identical to opening a Light Curve File via the constructor.
-        This method was added because many tutorials use the `from_archive`
-        method, therefore users may expect a `from_fits` equivalent.
-
-        Parameters
-        ----------
-        path_or_url : str
-            Path or URL of a FITS file.
-        **kwargs : dict
-            Keyword arguments that will be passed to the constructor.
-
-        Returns
-        -------
-        tpf : LightCurveFile object
-            The loaded light curve file.
+        Please use `lightkurve.open()` instead.
         """
+        warnings.warn('`LightCurveFile.from_fits()` is deprecated and will be '
+                      'removed soon, please use `lightkurve.open()` instead.',
+                      LightkurveWarning)
         return cls(path_or_url, **kwargs)
 
     def _flux_types(self):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -228,24 +228,13 @@ class TargetPixelFile(object):
 
     @classmethod
     def from_fits(cls, path_or_url, **kwargs):
-        """Open a Target Pixel File using the path or url of a FITS file.
+        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
 
-        This is identical to opening a Target Pixel File via the constructor.
-        This method was added because many tutorials use the `from_archive`
-        method, therefore users may expect a `from_fits` equivalent.
-
-        Parameters
-        ----------
-        path_or_url : str
-            Path or URL of a FITS file.
-        **kwargs : dict
-            Keyword arguments that will be passed to the constructor.
-
-        Returns
-        -------
-        tpf : TargetPixelFile object
-            The loaded target pixel file.
+        Please use `lightkurve.open()` instead.
         """
+        warnings.warn('`TargetPixelFile.from_fits()` is deprecated and will be '
+                      'removed soon, please use `lightkurve.open()` instead.',
+                      LightkurveWarning)
         return cls(path_or_url, **kwargs)
 
     def get_coordinates(self, cadence='all'):


### PR DESCRIPTION
In the spirit of reducing the number of ways the same operation can be achieved, I propose deprecating the `from_fits()` methods in `TargetPixelFile` and `LightCurveFile` in favor of the new and generic `lightkurve.open()` function.

Moreover, `from_fits()` was only really introduced to provide an easy-to-discover counterpart to `from_archive()`, but the latter method was recently deprecated in favor of the `search_targetpixelfile()` and `search_lightcurvefile()` functions which support more powerful searches.