### PR TITLE
Mitigate 60 warnings triggered by the unit tests

### DIFF
--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -3,11 +3,11 @@ from __future__ import division, print_function
 from astropy.io import fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import pyplot as plt
 
 from numpy.testing import (assert_almost_equal, assert_array_equal,
                            assert_allclose)
 import pytest
+import warnings
 
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
@@ -80,8 +80,9 @@ def test_rmath_operators():
 @pytest.mark.parametrize("path, mission", [(TABBY_Q8, "Kepler"), (K2_C08, "K2")])
 def test_KeplerLightCurveFile(path, mission):
     lcf = KeplerLightCurveFile(path, quality_bitmask=None)
-    hdu = pyfits.open(path)
-    lc = lcf.get_lightcurve('SAP_FLUX')
+    # The liberal bitmask will cause the lightcurve to contain NaN times
+    with pytest.warns(LightkurveWarning, match='NaN times'):
+        lc = lcf.get_lightcurve('SAP_FLUX')
 
     assert lc.channel == lcf.channel
     assert lc.mission.lower() == mission.lower()
@@ -91,11 +92,13 @@ def test_KeplerLightCurveFile(path, mission):
     elif lc.mission.lower() == 'k2':
         assert lc.campaign == 8
         assert lc.quarter is None
-    assert lc.label == hdu[0].header['OBJECT']
     assert lc.time_format == 'bkjd'
     assert lc.time_scale == 'tdb'
     assert lc.astropy_time.scale == 'tdb'
 
+    # Does the data match what one would obtain using pyfits.open?
+    hdu = pyfits.open(path)
+    assert lc.label == hdu[0].header['OBJECT']
     assert_array_equal(lc.time, hdu[1].data['TIME'])
     assert_array_equal(lc.flux, hdu[1].data['SAP_FLUX'])
 
@@ -134,7 +137,10 @@ def test_TessLightCurveFile(quality_bitmask):
 def test_bitmasking(quality_bitmask, answer):
     """Test whether the bitmasking behaves like it should"""
     lcf = KeplerLightCurveFile(TABBY_Q8, quality_bitmask=quality_bitmask)
-    flux = lcf.get_lightcurve('SAP_FLUX').flux
+    with warnings.catch_warnings():
+        # Ignore "LightCurve contains NaN times" warnings triggered by liberal masks
+        warnings.simplefilter("ignore", LightkurveWarning)
+        flux = lcf.get_lightcurve('SAP_FLUX').flux
     assert len(flux) == answer
 
 
@@ -560,12 +566,6 @@ def test_flatten_robustness():
     assert_allclose(flat_lc.flux, expected_result)
 
 
-@pytest.mark.remote_data
-def test_from_archive_should_accept_path():
-    """If a url is passed to `from_archive` it should still just work."""
-    KeplerLightCurveFile.from_archive(TABBY_Q8)
-
-
 def test_fill_gaps():
     lc = LightCurve([1,2,3,4,6,7,8], [1,1,1,1,1,1,1])
     nlc = lc.fill_gaps()
@@ -579,17 +579,6 @@ def test_fill_gaps():
     assert(np.any(nlc.time == 5))
     assert(np.all(nlc.flux == 1))
     assert(np.all(np.isfinite(nlc.flux)))
-
-@pytest.mark.remote_data
-def test_from_fits():
-    """Does the lcf.from_fits() method work like the constructor?"""
-    lcf = KeplerLightCurveFile.from_fits(TABBY_Q8)
-    assert isinstance(lcf, KeplerLightCurveFile)
-    assert lcf.targetid == KeplerLightCurveFile(TABBY_Q8).targetid
-    # Execute the same test for TESS
-    lcf = TessLightCurveFile.from_fits(TESS_SIM)
-    assert isinstance(lcf, TessLightCurveFile)
-    assert lcf.targetid == TessLightCurveFile(TESS_SIM).targetid
 
 
 def test_targetid():

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -61,22 +61,22 @@ def test_periodogram_slicing():
 
 
 def test_assign_periods():
-    """ Test if you can assign periods and frequencies
-    """
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
-    periods = np.arange(0, 100) * u.day
+    """Test if you can assign periods and frequencies."""
+    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
+                    flux_err=np.zeros(1000) + 0.1)
+    periods = np.arange(1, 100) * u.day
     p = lc.to_periodogram(period=periods)
     # Get around the floating point error
     assert np.isclose(np.sum(periods - p.period).value, 0, rtol=1e-14)
-    frequency = np.arange(0, 100) * u.Hz
+    frequency = np.arange(1, 100) * u.Hz
     p = lc.to_periodogram(frequency=frequency)
     assert np.isclose(np.sum(frequency - p.frequency).value, 0, rtol=1e-14)
 
 
 def test_bin():
-    """ Test if you can bin the periodogram
-    """
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000), flux_err=np.zeros(1000)+0.1)
+    """Test if you can bin the periodogram."""
+    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
+                    flux_err=np.zeros(1000) + 0.1)
     p = lc.to_periodogram()
     assert len(p.bin(binsize=10).frequency) == len(p.frequency)//10
 
@@ -102,9 +102,9 @@ def test_smooth():
         p.smooth(method='boxkernel', filter_width=5.*u.day)
     assert err.value.args[0] == 'the `filter_width` parameter must have frequency units.'
 
-    # Can't (yet) use a periodogram with a non-evenly spaced frqeuencies
+    # Can't (yet) use a periodogram with a non-evenly spaced frequencies
     with pytest.raises(ValueError) as err:
-        p = np.arange(100)
+        p = np.arange(1, 100)
         p = lc.to_periodogram(period=p)
         p.smooth()
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -11,6 +11,7 @@ import os
 import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
+import warnings
 
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -117,7 +118,9 @@ def test_collections():
     # if fewer targets are found than targetlimit, should still download all available
     assert(len(search_targetpixelfile(205998445, radius=900, limit=6).table) == 4)
     # if download() is used when multiple files are available, should only download 1
-    assert(isinstance(search_targetpixelfile(205998445, radius=900).download(), KeplerTargetPixelFile))
+    with pytest.warns(LightkurveWarning, match='4 files available to download'):
+        assert(isinstance(search_targetpixelfile(205998445, radius=900).download(),
+                          KeplerTargetPixelFile))
 
 
 @pytest.mark.remote_data
@@ -160,34 +163,40 @@ def test_empty_searchresult():
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore:Query returned no results')
 def test_kepler_tpf_from_archive_DEPRECATED():
-    # Request an object name that does not exist
-    with pytest.raises(ValueError):
-        KeplerTargetPixelFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
-    # Request an EPIC ID that was not observed
-    with pytest.raises(ValueError):
-        KeplerTargetPixelFile.from_archive(246000000)
-    KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11)
-    KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, cadence='short')
-    KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
-    # If we request 2 quarters it should give a list of two TPFs, ordered by quarter
-    tpfs = KeplerTargetPixelFile.from_archive(5728079, cadence='long', quarter=[1, 2])
-    assert(isinstance(tpfs, TargetPixelFileCollection))
-    assert(isinstance(tpfs[0], KeplerTargetPixelFile))
-    assert(tpfs[0].quarter == 1)
+    # Ignore all deprecation warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LightkurveWarning)
+        # Request an object name that does not exist
+        with pytest.raises(ValueError):
+            KeplerTargetPixelFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
+        # Request an EPIC ID that was not observed
+        with pytest.raises(ValueError):
+            KeplerTargetPixelFile.from_archive(246000000)
+        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11)
+        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, cadence='short')
+        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
+        # If we request 2 quarters it should give a list of two TPFs, ordered by quarter
+        tpfs = KeplerTargetPixelFile.from_archive(5728079, cadence='long', quarter=[1, 2])
+        assert(isinstance(tpfs, TargetPixelFileCollection))
+        assert(isinstance(tpfs[0], KeplerTargetPixelFile))
+        assert(tpfs[0].quarter == 1)
 
 
 @pytest.mark.remote_data
 @pytest.mark.filterwarnings('ignore:Query returned no results')
 def test_kepler_lightcurve_from_archive_DEPRECATED():
-    # Request an object name that does not exist
-    with pytest.raises(ValueError):
-        KeplerLightCurveFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
-    # Request an EPIC ID that was not observed
-    with pytest.raises(ValueError):
-        KeplerLightCurveFile.from_archive(246000000)
-    KeplerLightCurveFile.from_archive('Kepler-10', quarter=11)
-    KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, cadence='short')
-    KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
+    # Ignore all deprecation warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LightkurveWarning)
+        # Request an object name that does not exist
+        with pytest.raises(ValueError):
+            KeplerLightCurveFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
+        # Request an EPIC ID that was not observed
+        with pytest.raises(ValueError):
+            KeplerLightCurveFile.from_archive(246000000)
+        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11)
+        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, cadence='short')
+        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
 
 
 @pytest.mark.remote_data
@@ -196,9 +205,12 @@ def test_source_confusion_DEPRECATED():
     # When obtaining the TPF for target 6507433, @benmontet noticed that
     # a target 4 arcsec away was returned instead.
     # See https://github.com/KeplerGO/lightkurve/issues/148
-    desired_target = 6507433
-    tpf = KeplerTargetPixelFile.from_archive(desired_target, quarter=8)
-    assert tpf.targetid == desired_target
+    # Ignore all deprecation warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LightkurveWarning)
+        desired_target = 6507433
+        tpf = KeplerTargetPixelFile.from_archive(desired_target, quarter=8)
+        assert tpf.targetid == desired_target
 
 
 def test_open():
@@ -212,5 +224,5 @@ def test_open():
         open(os.path.join(PACKAGEDIR, "tests", "data", "test_factory0.fits"))
     except ValueError:
         pass
-    assert isinstance(KeplerTargetPixelFile(tess_path), KeplerTargetPixelFile)
-    assert isinstance(TessTargetPixelFile(k2_path), TessTargetPixelFile)
+    assert isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile)
+    assert isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 import tempfile
+import warnings
 
 from ..targetpixelfile import KeplerTargetPixelFile, KeplerTargetPixelFileFactory
 from ..targetpixelfile import TessTargetPixelFile
@@ -39,20 +40,28 @@ def test_load_bad_file():
 
 def test_tpf_shapes():
     """Are the data array shapes of the TargetPixelFile object consistent?"""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpfs = [KeplerTargetPixelFile(filename_tpf_all_zeros),
+                TessTargetPixelFile(filename_tpf_all_zeros)]
+    for tpf in tpfs:
         assert tpf.quality_mask.shape == tpf.hdu[1].data['TIME'].shape
         assert tpf.flux.shape == tpf.flux_err.shape
 
 
 def test_tpf_plot():
     """Sanity check to verify that tpf plotting works"""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]:
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpfs = [KeplerTargetPixelFile(filename_tpf_one_center),
+                TessTargetPixelFile(filename_tpf_one_center)]
+    for tpf in tpfs:
         ax = tpf.plot()
         tpf.plot(aperture_mask=tpf.pipeline_mask)
         tpf.plot(aperture_mask='all')
-        tpf.plot(frame=5)
+        tpf.plot(frame=3)
         with pytest.raises(ValueError):
             tpf.plot(frame=999999)
         tpf.plot(cadenceno=125250)
@@ -69,7 +78,10 @@ def test_tpf_plot():
 def test_tpf_zeros():
     """Does the LightCurve of a zero-flux TPF make sense?"""
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros, quality_bitmask=None)
-    lc = tpf.to_lightcurve()
+    with warnings.catch_warnings():
+        # Ignore "LightCurve contains NaN times" warnings triggered by the liberal mask
+        warnings.simplefilter("ignore", LightkurveWarning)
+        lc = tpf.to_lightcurve()
     # If you don't mask out bad data, time contains NaNs
     assert np.any(lc.time != tpf.time)  # Using the property that NaN does not equal NaN
     # When you do mask out bad data everything should work.
@@ -85,8 +97,12 @@ def test_tpf_zeros():
 
 def test_tpf_ones():
     """Does the LightCurve of a one-flux TPF make sense?"""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]:
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpfs = [KeplerTargetPixelFile(filename_tpf_one_center),
+                TessTargetPixelFile(filename_tpf_one_center)]
+    for tpf in tpfs:
         lc = tpf.to_lightcurve(aperture_mask='all')
         assert np.all(lc.flux == 1)
         assert np.all((lc.centroid_col < tpf.column+tpf.shape[1]).all()
@@ -100,17 +116,19 @@ def test_tpf_ones():
                                                     ('hard', 1101), ('hardest', 1101),
                                                     (1, 1290), (100, 1278), (2096639, 1101)])
 def test_bitmasking(quality_bitmask, answer):
-    '''Test whether the bitmasking behaves like it should'''
+    """Test whether the bitmasking behaves like it should"""
     tpf = KeplerTargetPixelFile(filename_tpf_one_center, quality_bitmask=quality_bitmask)
-    lc = tpf.to_lightcurve()
-    flux = lc.flux
-    assert len(flux) == answer
+    with warnings.catch_warnings():
+        # Ignore "LightCurve contains NaN times" warnings triggered by liberal masks
+        warnings.simplefilter("ignore", LightkurveWarning)
+        lc = tpf.to_lightcurve()
+    assert len(lc.flux) == answer
 
 
 def test_wcs():
     """Test the wcs property."""
     for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]:
+                TessTargetPixelFile(filename_tess)]:
         w = tpf.wcs
         ra, dec = tpf.get_coordinates()
         assert ra.shape == tpf.shape
@@ -135,7 +153,7 @@ def test_wcs_tabby():
 def test_astropy_time():
     '''Test the lc.date() function'''
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         astropy_time = tpf.astropy_time
         assert astropy_time.scale == 'tdb'
         assert len(astropy_time.iso) == len(tpf.time)
@@ -161,14 +179,14 @@ def test_properties():
 def test_repr():
     """Do __str__ and __repr__ work?"""
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         str(tpf)
         repr(tpf)
 
 
 def test_to_lightcurve():
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         tpf.to_lightcurve()
         tpf.to_lightcurve(aperture_mask=None)
         tpf.to_lightcurve(aperture_mask='all')
@@ -179,7 +197,7 @@ def test_to_lightcurve():
 
 def test_bkg_lightcurve():
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         lc = tpf.get_bkg_lightcurve()
         lc = tpf.get_bkg_lightcurve(aperture_mask=None)
         lc = tpf.get_bkg_lightcurve(aperture_mask='all')
@@ -190,7 +208,7 @@ def test_bkg_lightcurve():
 
 def test_aperture_photometry():
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         tpf.extract_aperture_photometry()
         tpf.extract_aperture_photometry(aperture_mask=None)
         tpf.extract_aperture_photometry(aperture_mask='all')
@@ -199,7 +217,7 @@ def test_aperture_photometry():
 def test_tpf_to_fits():
     """Can we write a TPF back to a fits file?"""
     for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]:
+                TessTargetPixelFile(filename_tess)]:
         # `delete=False` is necessary to enable writing to the file on Windows
         # but it means we have to clean up the tmp file ourselves
         tmp = tempfile.NamedTemporaryFile(delete=False)
@@ -228,14 +246,16 @@ def test_tpf_factory():
     with pytest.warns(LightkurveWarning, match='identical TIME values'):
         tpf = factory.get_tpf()
     [factory.add_cadence(frameno=i, flux=flux_0,
-                        header={'TSTART': i*10, 'TSTOP': (i*10)+10})  for i in np.arange(2, 9)]
+                         header={'TSTART': i*10, 'TSTOP': (i*10)+10})
+     for i in np.arange(2, 9)]
 
     # This should fail because the time stamps of the images are not in order...
     with pytest.warns(LightkurveWarning, match='chronological order'):
         tpf = factory.get_tpf()
 
     [factory.add_cadence(frameno=i, flux=flux_0,
-                         header={'TSTART': i*10, 'TSTOP': (i*10)+10})  for i in np.arange(1, 9)]
+                         header={'TSTART': i*10, 'TSTOP': (i*10)+10})
+     for i in np.arange(1, 9)]
 
     # This should pass
     tpf = factory.get_tpf()
@@ -264,13 +284,10 @@ def test_tpf_factory():
 
 def test_tpf_from_images():
     """Basic tests of tpf.from_fits_images()"""
-    from glob import glob
-
     from astropy.io import fits
     from astropy import wcs
     import astropy.units as u
     from astropy.coordinates import SkyCoord
-    from lightkurve.targetpixelfile import FactoryError
 
     # Can we read in a load of images?
     header = fits.Header()
@@ -334,8 +351,8 @@ def test_tpf_from_images():
 
     # Should be able to run with a list of HDUlists
     tpf_hdus = KeplerTargetPixelFile.from_fits_images(hdus,
-                                                        size=(3, 3),
-                                                        position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
+                                                      size=(3, 3),
+                                                      position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
 
 
 def test_properties2(capfd):
@@ -350,25 +367,9 @@ def test_properties2(capfd):
 def test_interact():
     """Test the Jupyter notebook interact() widget."""
     for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]:
+                TessTargetPixelFile(filename_tess)]:
         tpf.interact()
         tpf.interact(lc=tpf.to_lightcurve(aperture_mask='all'))
-
-
-def test_from_archive_should_accept_path():
-    """If a path is accidentally passed to `from_archive` it should still just work."""
-    KeplerTargetPixelFile.from_archive(filename_tpf_all_zeros)
-
-
-def test_from_fits():
-    """Does the tpf.from_fits() method work like the constructor?"""
-    tpf = KeplerTargetPixelFile.from_fits(filename_tpf_one_center)
-    assert isinstance(tpf, KeplerTargetPixelFile)
-    assert tpf.targetid == KeplerTargetPixelFile(filename_tpf_one_center).targetid
-    # Execute the same test for TESS
-    tpf = TessTargetPixelFile.from_fits(filename_tpf_one_center)
-    assert isinstance(tpf, TessTargetPixelFile)
-    assert tpf.targetid == TessTargetPixelFile(filename_tpf_one_center).targetid
 
 
 def test_get_models():
@@ -393,7 +394,7 @@ def test_tess_simulation():
 
 def test_threshold_aperture_mask():
     """Does the threshold mask work?"""
-    tpf = KeplerTargetPixelFile.from_fits(filename_tpf_one_center)
+    tpf = KeplerTargetPixelFile(filename_tpf_one_center)
     tpf.plot(aperture_mask='threshold')
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux == 1).all()

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -15,7 +15,8 @@ from functools import wraps
 
 log = logging.getLogger(__name__)
 
-__all__ = ['KeplerQualityFlags', 'TessQualityFlags',
+__all__ = ['LightkurveWarning',
+           'KeplerQualityFlags', 'TessQualityFlags',
            'bkjd_to_astropy_time', 'btjd_to_astropy_time',
            'channel_to_module_output', 'module_output_to_channel',
            'running_mean']


### PR DESCRIPTION
This PR catches or avoids approximately 60 warnings of various types (mostly `LightkurveWarning`) that were being raised by various unit tests.

To remain sensitive to any unexpected warnings appearing, it is important that we explicitly deal with or silence all harmless warnings.