### PR TITLE
Detect filetype and provide informative warnings

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -378,15 +378,15 @@ class TessLightCurveFile(LightCurveFile):
         elif filetype is None:
             warnings.warn("Given fits file not recognized as Kepler or TESS "
                           "observation.", LightkurveWarning)
-        try:
-            self.quality_bitmask = quality_bitmask
-            self.quality_mask = TessQualityFlags.create_quality_mask(
-                                    quality_array=self.hdu[1].data['QUALITY'],
-                                    bitmask=quality_bitmask)
-            # Early TESS releases had cadences with time=NaN (i.e. missing data)
-            # which were not flagged by a QUALITY flag yet; the line below prevents
-            # these cadences from being used. They would break most methods!
-            self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
+
+        self.quality_bitmask = quality_bitmask
+        self.quality_mask = TessQualityFlags.create_quality_mask(
+                                quality_array=self.hdu[1].data['QUALITY'],
+                                bitmask=quality_bitmask)
+        # Early TESS releases had cadences with time=NaN (i.e. missing data)
+        # which were not flagged by a QUALITY flag yet; the line below prevents
+        # these cadences from being used. They would break most methods!
+        self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
 
         try:
             self.targetid = self.header()['TICID']

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -156,14 +156,14 @@ class KeplerLightCurveFile(LightCurveFile):
                           "`KeplerLightCurveFile` class. "
                           "Please use `TessLightCurveFile` instead.",
                           LightkurveWarning)
+        elif filetype is None:
+            warnings.warn("Given fits file not recognized as Kepler or TESS "
+                          "observation.", LightkurveWarning)
         elif "TargetPixelFile" in filetype:
             warnings.warn("A `TargetPixelFile` object is being opened as a "
                           "`KeplerLightCurveFile`. To avoid errors in the "
                           "future, please use `KeplerTargetPixelFile` instead.",
                           LightkurveWarning)
-        elif filetype is None:
-            warnings.warn("Given fits file not recognized as Kepler or TESS "
-                          "observation.", LightkurveWarning)
 
         self.quality_bitmask = quality_bitmask
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
@@ -370,14 +370,14 @@ class TessLightCurveFile(LightCurveFile):
                           "`TessLightCurveFile` class. "
                           "Please use `KeplerLightCurveFile` instead.",
                           LightkurveWarning)
+        elif filetype is None:
+            warnings.warn("Given fits file not recognized as Kepler or TESS "
+                          "observation.", LightkurveWarning)
         elif "TargetPixelFile" in filetype:
             warnings.warn("A `TargetPixelFile` object is being opened as a "
                           "`TessLightCurveFile`. To avoid errors in the "
                           "future, please use `TessTargetPixelFile` instead.",
                           LightkurveWarning)
-        elif filetype is None:
-            warnings.warn("Given fits file not recognized as Kepler or TESS "
-                          "observation.", LightkurveWarning)
 
         self.quality_bitmask = quality_bitmask
         self.quality_mask = TessQualityFlags.create_quality_mask(

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -12,7 +12,7 @@ from matplotlib import pyplot as plt
 from astropy.io import fits as pyfits
 
 from .utils import (bkjd_to_astropy_time, KeplerQualityFlags, TessQualityFlags,
-                    LightkurveWarning)
+                    LightkurveWarning, detect_filetype)
 
 from . import MPLSTYLE
 
@@ -148,6 +148,23 @@ class KeplerLightCurveFile(LightCurveFile):
     """
     def __init__(self, path, quality_bitmask='default', **kwargs):
         super(KeplerLightCurveFile, self).__init__(path, **kwargs)
+
+        # check to make sure the correct filetype has been provided
+        filetype = detect_filetype(self.header())
+        if filetype == 'TessLightCurveFile':
+            warnings.warn("A TESS data product is being opened using the "
+                          "`KeplerLightCurveFile` class. "
+                          "Please use `TessLightCurveFile` instead.",
+                          LightkurveWarning)
+        elif "TargetPixelFile" in filetype:
+            warnings.warn("A `TargetPixelFile` object is being opened as a "
+                          "`KeplerLightCurveFile`. To avoid errors in the "
+                          "future, please use `KeplerTargetPixelFile` instead.",
+                          LightkurveWarning)
+        elif filetype is None:
+            warnings.warn("Given fits file not recognized as Kepler or TESS "
+                          "observation.", LightkurveWarning)
+
         self.quality_bitmask = quality_bitmask
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['SAP_QUALITY'],
@@ -345,14 +362,32 @@ class TessLightCurveFile(LightCurveFile):
     """
     def __init__(self, path, quality_bitmask='default', **kwargs):
         super(TessLightCurveFile, self).__init__(path, **kwargs)
-        self.quality_bitmask = quality_bitmask
-        self.quality_mask = TessQualityFlags.create_quality_mask(
-                                quality_array=self.hdu[1].data['QUALITY'],
-                                bitmask=quality_bitmask)
-        # Early TESS releases had cadences with time=NaN (i.e. missing data)
-        # which were not flagged by a QUALITY flag yet; the line below prevents
-        # these cadences from being used. They would break most methods!
-        self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
+
+        # check to make sure the correct filetype has been provided
+        filetype = detect_filetype(self.header())
+        if filetype == 'KeplerLightCurveFile':
+            warnings.warn("A Kepler data product is being opened using the "
+                          "`TessLightCurveFile` class. "
+                          "Please use `KeplerLightCurveFile` instead.",
+                          LightkurveWarning)
+        elif "TargetPixelFile" in filetype:
+            warnings.warn("A `TargetPixelFile` object is being opened as a "
+                          "`TessLightCurveFile`. To avoid errors in the "
+                          "future, please use `TessTargetPixelFile` instead.",
+                          LightkurveWarning)
+        elif filetype is None:
+            warnings.warn("Given fits file not recognized as Kepler or TESS "
+                          "observation.", LightkurveWarning)
+        try:
+            self.quality_bitmask = quality_bitmask
+            self.quality_mask = TessQualityFlags.create_quality_mask(
+                                    quality_array=self.hdu[1].data['QUALITY'],
+                                    bitmask=quality_bitmask)
+            # Early TESS releases had cadences with time=NaN (i.e. missing data)
+            # which were not flagged by a QUALITY flag yet; the line below prevents
+            # these cadences from being used. They would break most methods!
+            self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
+
         try:
             self.targetid = self.header()['TICID']
         except KeyError:

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -161,8 +161,8 @@ class KeplerLightCurveFile(LightCurveFile):
                           "observation.", LightkurveWarning)
         elif "TargetPixelFile" in filetype:
             warnings.warn("A `TargetPixelFile` object is being opened as a "
-                          "`KeplerLightCurveFile`. To avoid errors in the "
-                          "future, please use `KeplerTargetPixelFile` instead.",
+                          "`KeplerLightCurveFile`. "
+                          "Please use `KeplerTargetPixelFile` instead.",
                           LightkurveWarning)
 
         self.quality_bitmask = quality_bitmask
@@ -375,8 +375,8 @@ class TessLightCurveFile(LightCurveFile):
                           "observation.", LightkurveWarning)
         elif "TargetPixelFile" in filetype:
             warnings.warn("A `TargetPixelFile` object is being opened as a "
-                          "`TessLightCurveFile`. To avoid errors in the "
-                          "future, please use `TessTargetPixelFile` instead.",
+                          "`TessLightCurveFile`. "
+                          "Please use `TessTargetPixelFile` instead.",
                           LightkurveWarning)
 
         self.quality_bitmask = quality_bitmask

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -4,7 +4,6 @@ import os
 import logging
 import numpy as np
 import warnings
-import importlib
 
 from astropy.table import join, Table, Row
 from astropy.coordinates import SkyCoord
@@ -683,8 +682,7 @@ def open(path_or_url):
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:
-        lk_module = importlib.import_module("lightkurve")
-        return getattr(lk_module, filetype)(path_or_url)
+        return getattr(__import__('lightkurve'), filetype)(path_or_url)
     else:
         # if these keywords don't exist, raise `ValueError`
         raise ValueError('Given fits file not recognized as Kepler or TESS '

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -685,5 +685,5 @@ def open(path_or_url):
         return getattr(__import__('lightkurve'), filetype)(path_or_url)
     else:
         # if these keywords don't exist, raise `ValueError`
-        raise ValueError('Given fits file not recognized as Kepler or TESS '
-                         'observation.')
+        raise ValueError("Given fits file not recognized as Kepler or TESS "
+                         "observation.")

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -685,5 +685,5 @@ def open(path_or_url):
         return getattr(__import__('lightkurve'), filetype)(path_or_url)
     else:
         # if these keywords don't exist, raise `ValueError`
-        raise ValueError("Given fits file not recognized as Kepler or TESS "
-                         "observation.")
+        raise ValueError("Not recognized as a Kepler or TESS data product: "
+                         "{}".format(path_or_url))

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -4,6 +4,7 @@ import os
 import logging
 import numpy as np
 import warnings
+import importlib
 
 from astropy.table import join, Table, Row
 from astropy.coordinates import SkyCoord
@@ -16,7 +17,7 @@ from astroquery.exceptions import ResolverError
 from .lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
 from .targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
 from .collections import TargetPixelFileCollection, LightCurveFileCollection
-from .utils import suppress_stdout, LightkurveWarning
+from .utils import suppress_stdout, LightkurveWarning, detect_filetype
 from . import PACKAGEDIR
 
 log = logging.getLogger(__name__)
@@ -647,18 +648,14 @@ def _filter_products(products, campaign=None, quarter=None, month=None,
 def open(path_or_url):
     """Opens a Kepler or TESS data product.
 
-    This function will automatically detect the type of the data product,
-    and return the appropriate object. File types currently supported are::
+    This function will use the `detect_filetype()` function to
+    automatically detect the type of the data product, and return the
+    appropriate object. File types currently supported are::
 
         * `KeplerTargetPixelFile` (typical suffix "-targ.fits.gz");
         * `KeplerLightCurveFile` (typical suffix "llc.fits");
         * `TessTargetPixelFile` (typical suffix "_tp.fits");
         * `TessLightCurveFile` (typical suffix "_lc.fits").
-
-    The function will detect the file type by looking at both the TELESCOP and
-    CREATOR keywords in the first extension of the FITS file.
-    If the file is not recognized as a Kepler or TESS data product,
-    a `ValueError` is raised.
 
     Parameters
     ----------
@@ -681,23 +678,14 @@ def open(path_or_url):
 
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
-    hdulist = fits.open(path_or_url)
-    try:
-        # use `telescop` keyword to determine mission
-        # and `creator` to determine tpf or lc
-        telescop = hdulist[0].header['telescop']
-        creator = hdulist[0].header['creator']
-        if telescop == 'Kepler':
-            if 'TargetPixel' in creator:
-                return KeplerTargetPixelFile(path_or_url)
-            elif 'Flux' in creator:
-                return KeplerLightCurveFile(path_or_url)
-        elif telescop == 'TESS':
-            if 'TargetPixel' in creator:
-                return TessTargetPixelFile(path_or_url)
-            elif 'Flux' in creator:
-                return TessLightCurveFile(path_or_url)
-    # if these keywords don't exist, raise `ValueError`
-    except KeyError:
-        pass
-    raise ValueError('Given fits file not recognized as Kepler or TESS observation.')
+    # pass header into `detect_filetype()`
+    filetype = detect_filetype(fits.open(path_or_url)[0].header)
+
+    # if the filetype is recognized, instantiate a class of that name
+    if filetype is not None:
+        lk_module = importlib.import_module("lightkurve")
+        return getattr(lk_module, filetype)(path_or_url)
+    else:
+        # if these keywords don't exist, raise `ValueError`
+        raise ValueError('Given fits file not recognized as Kepler or TESS '
+                         'observation.')

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -2,15 +2,19 @@ from __future__ import division, print_function
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+from astropy.io import fits
 import pytest
 import warnings
+import os
 
 from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
 from ..utils import running_mean
 from ..utils import LightkurveWarning
+from ..utils import detect_filetype
 from ..lightcurve import LightCurve
 
+from .. import PACKAGEDIR
 
 def test_channel_to_module_output():
     assert channel_to_module_output(1) == (2, 1)
@@ -82,3 +86,10 @@ def test_lightkurve_warning():
         flux = np.array([1, 2, 3, 4])
         lc = LightCurve(time=time, flux=flux)
         assert len(warns) == 0
+
+def test_detect_filetype():
+    """Can we detect the correct filetype?"""
+    k2_path = os.path.join(PACKAGEDIR, "tests", "data", "test-tpf-star.fits")
+    tess_path = os.path.join(PACKAGEDIR, "tests", "data", "tess25155310-s01-first-cadences.fits.gz")
+    assert detect_filetype(fits.open(k2_path)[0].header) == 'KeplerTargetPixelFile'
+    assert detect_filetype(fits.open(tess_path)[0].header) == 'TessTargetPixelFile'

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -462,7 +462,15 @@ def detect_filetype(header):
     Detects filetype of a given header.
 
     This function will detect the file type by looking at both the TELESCOP and
-    CREATOR keywords in the first extension of the FITS header.
+    CREATOR keywords in the first extension of the FITS header. If the file is
+    recognized as a Kepler or TESS data product, one of the following strings
+    will be returned:
+
+        * `'KeplerTargetPixelFile'`
+        * `'TessTargetPixelFile'`
+        * `'KeplerLightCurveFile'`
+        * `'TessLightCurveFile'`
+
     If the file is not recognized as a Kepler or TESS data product,
     `None` will be returned.
 

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -5,6 +5,7 @@ import sys
 import os
 import warnings
 
+from astropy.io import fits
 from astropy.visualization import (PercentileInterval, ImageNormalize,
                                    SqrtStretch, LinearStretch)
 from astropy.time import Time
@@ -455,3 +456,43 @@ def suppress_stdout(f, *args, **kwargs):
             finally:
                 sys.stdout = old_out
     return wrapper
+
+def detect_filetype(header):
+    """
+    Detects filetype of a given header.
+
+    This function will detect the file type by looking at both the TELESCOP and
+    CREATOR keywords in the first extension of the FITS header.
+    If the file is not recognized as a Kepler or TESS data product,
+    `None` will be returned.
+
+    Parameters
+    ----------
+    header :
+        The `header` for the first index of a fits file's hdulist.
+
+    Returns
+    -------
+    filetype : str or None
+        A string describing the detected filetype. If the filetype is not
+        recognized, `None` will be returned.
+    """
+
+    try:
+        # use `telescop` keyword to determine mission
+        # and `creator` to determine tpf or lc
+        telescop = header['telescop']
+        creator = header['creator']
+        if telescop == 'Kepler':
+            if 'TargetPixel' in creator:
+                return 'KeplerTargetPixelFile'
+            elif 'Flux' in creator:
+                return 'KeplerLightCurveFile'
+        elif telescop == 'TESS':
+            if 'TargetPixel' in creator:
+                return 'TessTargetPixelFile'
+            elif 'Flux' in creator:
+                return 'TessLightCurveFile'
+    # if these keywords don't exist, raise `ValueError`
+    except KeyError:
+        return None


### PR DESCRIPTION
A new `detect_filetype()` function has been added to the `utils` module, which takes a header and returns a string describing the filetype of the fits file. This allows for:

- a simpler `lightkurve.open()` function
- checks on filetype when instantiation `TargetPixelFile` or `LightCurveFile` objects

Lightkurve warnings have been added to address the concern in #318.