### PR TITLE
[WIP] Add a simple `FullFrameImage` class

### DIFF
--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -21,3 +21,4 @@ from .convenience import *
 from .periodogram import *
 from .collections import *
 from .search import *
+from .ffi import *

--- a/lightkurve/ffi.py
+++ b/lightkurve/ffi.py
@@ -1,0 +1,34 @@
+"""Tools to interact more easily with Full Frame Image files."""
+from __future__ import division, print_function
+
+from astropy.io import fits
+from astropy.wcs import WCS
+
+__all__ = ['FullFrameImage']
+
+
+def FullFrameImage(object):
+
+    def __init__(self, path_or_url, **kwargs):
+        self.path = path_or_url
+        if isinstance(path_or_url, fits.HDUList):
+            self.hdulist = path_or_url
+        else:
+            self.hdulist = fits.open(self.path, **kwargs)
+
+    def skycoord_to_pixel(self, ra, dec):
+        """Converts ra, dec to channel, x, y"""
+        for channel in range(1, 85):
+            hdr = self.hdulist[channel].header
+            wcs = WCS(hdr)
+            (col, row) = wcs.all_world2pix([ra], [dec], 0)
+            if (col > 0) and (col < hdr['NAXIS1']) and (row > 0) and (row < hdr['NAXIS2']):
+                return channel, col, row
+        return None, None, None
+
+    def plot_cutout(self, coord, size=10):
+        pass
+
+    def plot():
+        """Show all channels."""
+        pass

--- a/lightkurve/ffi.py
+++ b/lightkurve/ffi.py
@@ -4,10 +4,12 @@ from __future__ import division, print_function
 from astropy.io import fits
 from astropy.wcs import WCS
 
+from .utils import plot_image
+
 __all__ = ['FullFrameImage']
 
 
-def FullFrameImage(object):
+class FullFrameImage(object):
 
     def __init__(self, path_or_url, **kwargs):
         self.path = path_or_url
@@ -16,19 +18,29 @@ def FullFrameImage(object):
         else:
             self.hdulist = fits.open(self.path, **kwargs)
 
-    def skycoord_to_pixel(self, ra, dec):
-        """Converts ra, dec to channel, x, y"""
+    def skycoord_to_pixel(self, skycoord):
+        """Converts an (ra, dec) sky coordinate to a (channel, column, row) tuple."""
         for channel in range(1, 85):
             hdr = self.hdulist[channel].header
+            if 'CTYPE1' not in hdr:
+                continue  # dead module
             wcs = WCS(hdr)
-            (col, row) = wcs.all_world2pix([ra], [dec], 0)
+            (col, row) = wcs.all_world2pix([skycoord.ra.deg], [skycoord.dec.deg], 0)
+            col, row = col[0], row[0]
+            # Dide the coordinate gall within the channel footprint?
             if (col > 0) and (col < hdr['NAXIS1']) and (row > 0) and (row < hdr['NAXIS2']):
                 return channel, col, row
         return None, None, None
 
-    def plot_cutout(self, coord, size=10):
-        pass
+    def plot_cutout(self, skycoord, size=10, **kwargs):
+        """Plots a small part of an FFI around a sky coordinate."""
+        channel, col, row = self.skycoord_to_pixel(skycoord)
+        extent = (int(col-size/2), int(col+size/2),
+                  int(row-size/2), int(row+size/2))
+        img = self.hdulist[channel].data[extent[2]: extent[3],
+                                         extent[0]: extent[1]]
+        plot_image(img, extent=extent, **kwargs)
 
-    def plot():
-        """Show all channels."""
+    def plot(self):
+        """Plot all channels on a grid."""
         pass

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -366,7 +366,7 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
 
 def plot_image(image, ax=None, scale='linear', origin='lower',
                xlabel='Pixel Column Number', ylabel='Pixel Row Number',
-               clabel='Flux ($e^{-}s^{-1}$)', title=None, show_colorbar=True,
+               clabel='Flux ($e^{-}s^{-1}$)', title='', show_colorbar=True,
                **kwargs):
     """Utility function to plot a 2D image
 


### PR DESCRIPTION
While diagnosing a target with a funny lightcurve, I experienced the need to inspect the area surrounding the target in the FFI data.  So I built a simple `FullFrameImage` class that makes it easy to display an FFI cutout given a sky coordinate.

We will want to reflect carefully about if and how such a class might belong in Lightkurve, so I'm just opening this PR as a demo.  Code from #125 could find a home in this PR too.

Demo:

```Python
from lightkurve import FullFrameImage
ffi = FullFrameImage("https://archive.stsci.edu/pub/kepler/ffi/kplr2012121122500_ffi-cal.fits")
ffi.plot_cutout(skycoord)
```
![screenshot from 2018-11-19 15-46-28](https://user-images.githubusercontent.com/817669/48742115-630a8380-ec12-11e8-9664-b1cb13c7d74b.png)
