### PR TITLE
Fix the pandas byteorder bug

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -862,6 +862,12 @@ class LightCurve(object):
         for col in columns:
             if hasattr(self, col):
                 data[col] = vars(self)[col]
+                # We need to ensure pandas gets the native byteorder.
+                # x86 uses little endian, so it is reasonable to assume that
+                # we always want little endian, even though FITS uses big endian!
+                # See https://github.com/KeplerGO/lightkurve/issues/188
+                if data[col].dtype.byteorder == '>':  # is big endian?
+                    data[col] = data[col].byteswap().newbyteorder()
         df = pd.DataFrame(data=data, index=self.time, columns=columns)
         df.index.name = 'time'
         return df

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -580,6 +580,15 @@ def test_fill_gaps():
     assert(np.all(nlc.flux == 1))
     assert(np.all(np.isfinite(nlc.flux)))
 
+    # Because fill_gaps() uses pandas, check that it works regardless of endianness
+    # For details see https://github.com/KeplerGO/lightkurve/issues/188
+    lc = LightCurve(np.array([1, 2, 3, 4, 6, 7, 8], dtype='>f8'),
+                    np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype='>f8'))
+    lc.fill_gaps()
+    lc = LightCurve(np.array([1, 2, 3, 4, 6, 7, 8], dtype='<f8'),
+                    np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype='<f8'))
+    lc.fill_gaps()
+
 
 def test_targetid():
     """Is a generic targetid available on each type of LighCurve object?"""

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -426,3 +426,9 @@ def test_tpf_slicing():
     assert tpf[5:10].shape == tpf.flux[5:10].shape
     assert tpf[0].targetid == tpf.targetid
     assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])
+
+
+def test_endianness():
+    """Regression test for https://github.com/KeplerGO/lightkurve/issues/188"""
+    tpf = KeplerTargetPixelFile(filename_tpf_one_center)
+    tpf.to_lightcurve().to_pandas().describe()


### PR DESCRIPTION
Pandas only supports data stored in the native byteorder format.  The most common platform (x86) uses little endian, however the FITS file format stores data in big endian, and so it is common for `lightkurve` to pass data in the wrong byteorder to pandas (e.g. see #188).

This PR adds a fix in `to_pandas()` to ensure we always pass little endian to pandas.  I also added unit tests to verify the correct byteorder behavior.

@gully Please review and merge!