### PR TITLE
Have `tpf.create_threshold_mask()` return only one contiguous mask

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -421,7 +421,7 @@ class TargetPixelFile(object):
             (col, row) pixel coordinate closest to the desired region.
             For example, use `reference_pixel=(0,0)` to select the region
             closest to the bottom left corner of the target pixel file.
-            If `None` (default) then the region closest ot the center pixel
+            If `None` (default) then the region closest to the center pixel
             will be selected. If `'all'` then all regions will be selected.
 
         Returns

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -396,7 +396,7 @@ class TargetPixelFile(object):
         self._last_aperture_mask = aperture_mask
         return aperture_mask
 
-    def create_threshold_mask(self, threshold=3, reference_pixel=None):
+    def create_threshold_mask(self, threshold=3, reference_pixel='center'):
         """Returns an aperture mask creating using the thresholding method.
 
         This method will identify the pixels in the TargetPixelFile which show
@@ -407,22 +407,22 @@ class TargetPixelFile(object):
 
         If the thresholding method yields multiple contiguous regions, then
         only the region closest to the (col, row) coordinate specified by
-        `reference_pixel` is returned, e.g. `reference_pixel=(0, 0)` will pick
-        the region closest to the bottom left corner.
+        `reference_pixel` is returned.  For exmaple, `reference_pixel=(0, 0)`
+        will pick the region closest to the bottom left corner.
         By default, the region closest to the center of the mask will be
-        returned. If `reference_pixel='all'` then all regions will be returned.
+        returned. If `reference_pixel=None` then all regions will be returned.
 
         Parameters
         ----------
         threshold : float
             A value for the number of sigma by which a pixel needs to be
             brighter than the median flux to be included in the aperture mask.
-        reference_pixel: (int, int) tuple, None, or 'all'
+        reference_pixel: (int, int) tuple, 'center', or None
             (col, row) pixel coordinate closest to the desired region.
             For example, use `reference_pixel=(0,0)` to select the region
             closest to the bottom left corner of the target pixel file.
-            If `None` (default) then the region closest to the center pixel
-            will be selected. If `'all'` then all regions will be selected.
+            If 'center' (default) then the region closest to the center pixel
+            will be selected. If `None` then all regions will be selected.
 
         Returns
         -------
@@ -430,7 +430,7 @@ class TargetPixelFile(object):
             2D boolean numpy array containing `True` for pixels above the
             threshold.
         """
-        if reference_pixel is None:
+        if reference_pixel == 'center':
             reference_pixel = (self.shape[1] / 2, self.shape[2] / 2)
         # Calculate the median image
         with warnings.catch_warnings():
@@ -441,7 +441,7 @@ class TargetPixelFile(object):
         mad_cut = (1.4826 * MAD(vals) * threshold) + np.nanmedian(median_image)
         # Create a mask containing the pixels above the threshold flux
         threshold_mask = np.nan_to_num(median_image) > mad_cut
-        if reference_pixel == 'all':
+        if reference_pixel is None:
             # return all regions above threshold
             return threshold_mask
         else:

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -398,11 +398,12 @@ def test_threshold_aperture_mask():
     tpf.plot(aperture_mask='threshold')
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux == 1).all()
-    # The TESS file shows multiple pixel regions above a 2-sigma threshold;
+    # The TESS file shows three pixel regions above a 2-sigma threshold;
     # let's make sure the `reference_pixel` argument allows them to be selected.
     tpf = TessTargetPixelFile(filename_tess)
     assert tpf.create_threshold_mask(threshold=2.).sum() == 25
-    assert tpf.create_threshold_mask(threshold=2., reference_pixel='all').sum() == 28
+    assert tpf.create_threshold_mask(threshold=2., reference_pixel='center').sum() == 25
+    assert tpf.create_threshold_mask(threshold=2., reference_pixel=None).sum() == 28
     assert tpf.create_threshold_mask(threshold=2., reference_pixel=(5, 0)).sum() == 2
 
 

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -398,6 +398,12 @@ def test_threshold_aperture_mask():
     tpf.plot(aperture_mask='threshold')
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux == 1).all()
+    # The TESS file shows multiple pixel regions above a 2-sigma threshold;
+    # let's make sure the `reference_pixel` argument allows them to be selected.
+    tpf = TessTargetPixelFile(filename_tess)
+    assert tpf.create_threshold_mask(threshold=2.).sum() == 25
+    assert tpf.create_threshold_mask(threshold=2., reference_pixel='all').sum() == 28
+    assert tpf.create_threshold_mask(threshold=2., reference_pixel=(5, 0)).sum() == 2
 
 
 def test_tpf_tess():


### PR DESCRIPTION
This PR attempts to resolve #337, i.e. `aperture_mask='threshold'` should return a mask that marks only one contiguous region of the TPF.