### PR TITLE
Fix bug reported in #346

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1209,7 +1209,7 @@ class KeplerLightCurve(LightCurve):
                                                   **kwargs)
         else:
             raise ValueError("method {} is not available.".format(method))
-        new_lc = self.copy()
+        new_lc = self[not_nan].copy()
         new_lc.time = corrected_lc.time
         new_lc.flux = corrected_lc.flux
         new_lc.flux_err = self.normalize().flux_err[not_nan]

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -606,3 +606,9 @@ def test_targetid():
     # Does it work for TESS?
     lc = TessLightCurve(time=[], targetid=20)
     assert lc.targetid == 20
+
+
+def test_regression_346():
+    """Regression test for https://github.com/KeplerGO/lightkurve/issues/346"""
+    # This previously triggered an IndexError:
+    KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct().estimate_cdpp()


### PR DESCRIPTION
The LightCurve returned by `lc.correct()` did not have the correct number of cadences in the presence of NaNs.  This should fix it!

@nksaunders would you be willing to review and merge?