### PR TITLE
Pass extra data from LightCurve to FoldedLightCurve

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -362,9 +362,13 @@ class LightCurve(object):
         # fold time domain from -.5 to .5
         fold_time[fold_time > 0.5] -= 1
         sorted_args = np.argsort(fold_time)
-        return FoldedLightCurve(fold_time[sorted_args],
-                                self.flux[sorted_args],
-                                flux_err=self.flux_err[sorted_args])
+        return FoldedLightCurve(time=fold_time[sorted_args],
+                                flux=self.flux[sorted_args],
+                                flux_err=self.flux_err[sorted_args],
+                                time_original=self.time,
+                                targetid=self.targetid,
+                                label=self.label,
+                                meta=self.meta)
 
     def normalize(self):
         """Returns a normalized version of the lightcurve.
@@ -1061,11 +1065,13 @@ class LightCurve(object):
             hdu.writeto(path, overwrite=overwrite, checksum=True)
         return hdu
 
+
 class FoldedLightCurve(LightCurve):
     """Defines a folded lightcurve with different plotting defaults."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, time_original=None, **kwargs):
         super(FoldedLightCurve, self).__init__(*args, **kwargs)
+        self.time_original = time_original
 
     @property
     def phase(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1069,9 +1069,9 @@ class LightCurve(object):
 class FoldedLightCurve(LightCurve):
     """Defines a folded lightcurve with different plotting defaults."""
 
-    def __init__(self, *args, time_original=None, **kwargs):
+    def __init__(self, *args, **kwargs):
+        self.time_original = kwargs.pop("time_original", None)
         super(FoldedLightCurve, self).__init__(*args, **kwargs)
-        self.time_original = time_original
 
     @property
     def phase(self):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -146,11 +146,16 @@ def test_bitmasking(quality_bitmask, answer):
 
 def test_lightcurve_fold():
     """Test the ``LightCurve.fold()`` method."""
-    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1)
+    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1,
+                    targetid=999, label='mystar', meta={'ccd': 2})
     fold = lc.fold(period=1)
     assert_almost_equal(fold.phase[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
+    assert fold.targetid == lc.targetid
+    assert fold.label == lc.label
+    assert fold.meta == lc.meta
+    assert_array_equal(fold.time_original, lc.time)
     fold = lc.fold(period=1, phase=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)


### PR DESCRIPTION
This PR changes `LightCurve.fold()` to pass along `time_original`, `targetid`, `label`, and `meta` to the `FoldedLightCurve` object it returns.

This addresses #237.