### PR TITLE
Make `utils.detect_filetype()` more robust

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -997,7 +997,7 @@ class LightCurve(object):
             from . import __version__
             default = default = {'ORIGIN': "Unofficial data product",
                                  'DATE': datetime.datetime.now().strftime("%Y-%m-%d"),
-                                 'CREATOR': "lightkurve",
+                                 'CREATOR': "lightkurve.LightCurve.to_fits()",
                                  'PROCVER': str(__version__)}
 
             for kw in default:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1130,7 +1130,8 @@ class KeplerTargetPixelFileFactory(object):
         # Override the defaults where necessary
         hdu.header['ORIGIN'] = "Unofficial data product"
         hdu.header['DATE'] = datetime.datetime.now().strftime("%Y-%m-%d")
-        hdu.header['CREATOR'] = "lightkurve"
+        hdu.header['TELESCOP'] = "Kepler"
+        hdu.header['CREATOR'] = "lightkurve.KeplerTargetPixelFileFactory"
         hdu.header['OBJECT'] = self.target_id
         hdu.header['KEPLERID'] = self.target_id
         # Empty a bunch of keywords rather than having incorrect info

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -10,7 +10,7 @@ import pytest
 import warnings
 
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
-from ..lightcurvefile import KeplerLightCurveFile, TessLightCurveFile
+from ..lightcurvefile import LightCurveFile, KeplerLightCurveFile, TessLightCurveFile
 from ..utils import LightkurveWarning
 
 # 8th Quarter of Tabby's star
@@ -393,6 +393,7 @@ def test_to_csv():
         pass
 
 
+@pytest.mark.remote_data
 def test_to_fits():
     """Test the KeplerLightCurve.to_fits() method"""
     lcf = KeplerLightCurveFile(TABBY_Q8)
@@ -407,13 +408,14 @@ def test_to_fits():
     assert hdu[1].header['TTYPE3'] == 'FLUX_ERR'
     assert hdu[1].header['TTYPE4'] == 'CADENCENO'
     hdu = LightCurve([0, 1, 2, 3, 4], [1, 1, 1, 1, 1]).to_fits()
-    lcf_new = KeplerLightCurveFile(hdu)  # Regression test for #233
+    lcf_new = LightCurveFile(hdu)  # Regression test for #233
     assert hdu[0].header['EXTNAME'] == 'PRIMARY'
     assert hdu[1].header['EXTNAME'] == 'LIGHTCURVE'
     assert hdu[1].header['TTYPE1'] == 'TIME'
     assert hdu[1].header['TTYPE2'] == 'FLUX'
 
 
+@pytest.mark.remote_data
 def test_astropy_time():
     '''Test the `astropy_time` property'''
     lcf = KeplerLightCurveFile(TABBY_Q8)
@@ -443,6 +445,7 @@ def test_lightcurve_repr():
     repr(TessLightCurve(time, flux))
 
 
+@pytest.mark.remote_data
 def test_lightcurvefile_repr():
     """Do __str__ and __repr__ work?"""
     lcf = KeplerLightCurveFile(TABBY_Q8)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -278,8 +278,8 @@ def test_tpf_factory():
                             header={'TSTART': 90, 'TSTOP': 100})
 
     # Can we add our own keywords?
-    tpf = factory.get_tpf(hdu0_keywords={'creator': 'Christina'})
-    assert tpf.header['CREATOR'] == 'Christina'
+    tpf = factory.get_tpf(hdu0_keywords={'creator': 'Christina TargetPixelFileWriter'})
+    assert tpf.header['CREATOR'] == 'Christina TargetPixelFileWriter'
 
 
 def test_tpf_from_images():

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -457,9 +457,9 @@ def suppress_stdout(f, *args, **kwargs):
                 sys.stdout = old_out
     return wrapper
 
+
 def detect_filetype(header):
-    """
-    Detects filetype of a given header.
+    """Returns Kepler and TESS file types given their primary header.
 
     This function will detect the file type by looking at both the TELESCOP and
     CREATOR keywords in the first extension of the FITS header. If the file is
@@ -485,22 +485,24 @@ def detect_filetype(header):
         A string describing the detected filetype. If the filetype is not
         recognized, `None` will be returned.
     """
-
     try:
         # use `telescop` keyword to determine mission
         # and `creator` to determine tpf or lc
-        telescop = header['telescop']
-        creator = header['creator']
-        if telescop == 'Kepler':
-            if 'TargetPixel' in creator:
+        telescop = header['telescop'].lower()
+        creator = header['creator'].lower()
+        if telescop == 'kepler':
+            # Kepler TPFs will show "TargetPixelExporterPipelineModule"
+            if 'targetpixel' in creator:
                 return 'KeplerTargetPixelFile'
-            elif 'Flux' in creator:
+            # Kepler LCFs will show "FluxExporter2PipelineModule"
+            elif 'fluxexporter' in creator or 'lightcurve' in creator:
                 return 'KeplerLightCurveFile'
-        elif telescop == 'TESS':
-            if 'TargetPixel' in creator:
+        elif telescop == 'tESS':
+            if 'targetpixel' in creator:
                 return 'TessTargetPixelFile'
-            elif 'Flux' in creator:
+            # TESS LCFs will show "LightCurveExporterPipelineModule"
+            elif 'lightcurve' in creator:
                 return 'TessLightCurveFile'
-    # if these keywords don't exist, raise `ValueError`
+    # if these keywords don't exist, return None
     except KeyError:
         return None

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -5,7 +5,6 @@ import sys
 import os
 import warnings
 
-from astropy.io import fits
 from astropy.visualization import (PercentileInterval, ImageNormalize,
                                    SqrtStretch, LinearStretch)
 from astropy.time import Time
@@ -471,13 +470,13 @@ def detect_filetype(header):
         * `'KeplerLightCurveFile'`
         * `'TessLightCurveFile'`
 
-    If the file is not recognized as a Kepler or TESS data product,
+    If the file is not recognized as a Kepler or TESS data product, then
     `None` will be returned.
 
     Parameters
     ----------
-    header :
-        The `header` for the first index of a fits file's hdulist.
+    header : astropy.io.fits.Header object
+        The primary header of a FITS file.
 
     Returns
     -------
@@ -504,6 +503,7 @@ def detect_filetype(header):
             # TESS LCFs will contain "LightCurveExporterPipelineModule"
             elif 'lightcurve' in creator:
                 return 'TessLightCurveFile'
-    # if these keywords don't exist, return None
-    except KeyError:
+    # If the TELESCOP or CREATOR keywords don't exist we expect a KeyError;
+    # if one of them is Undefined we expect `.lower()` to yield an AttributeError.
+    except (KeyError, AttributeError):
         return None

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -491,16 +491,17 @@ def detect_filetype(header):
         telescop = header['telescop'].lower()
         creator = header['creator'].lower()
         if telescop == 'kepler':
-            # Kepler TPFs will show "TargetPixelExporterPipelineModule"
+            # Kepler TPFs will contain "TargetPixelExporterPipelineModule"
             if 'targetpixel' in creator:
                 return 'KeplerTargetPixelFile'
-            # Kepler LCFs will show "FluxExporter2PipelineModule"
+            # Kepler LCFs will contain "FluxExporter2PipelineModule"
             elif 'fluxexporter' in creator or 'lightcurve' in creator:
                 return 'KeplerLightCurveFile'
-        elif telescop == 'tESS':
+        elif telescop == 'tess':
+            # TESS TPFs will contain "TargetPixelExporterPipelineModule"
             if 'targetpixel' in creator:
                 return 'TessTargetPixelFile'
-            # TESS LCFs will show "LightCurveExporterPipelineModule"
+            # TESS LCFs will contain "LightCurveExporterPipelineModule"
             elif 'lightcurve' in creator:
                 return 'TessLightCurveFile'
     # if these keywords don't exist, return None


### PR DESCRIPTION
The introduction of the new `utils.detect_filetype()` function led to a few new LightKurveWarnings being triggered by the unit tests, mainly because `detect_filetype()` did not detect files written by `LightCurve.to_fits()` or `KeplerTargetPixelFileFactory`.  This PR mitigates those warnings.