### PR TITLE
Fixed errorbar xlabel bug (Fixes #328)

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1115,6 +1115,25 @@ class FoldedLightCurve(LightCurve):
             ax.set_xlabel("Phase")
         return ax
 
+    def errorbar(self, **kwargs):
+        """Plot the folded light curve usng matplotlib's `errorbar` method.
+
+        See `LightCurve.scatter` for details on the accepted arguments.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Dictionary of arguments to be passed to `LightCurve.scatter`.
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
+        """
+        ax = super(FoldedLightCurve, self).errorbar(**kwargs)
+        if 'xlabel' not in kwargs:
+            ax.set_xlabel("Phase")
+        return ax
 
 class KeplerLightCurve(LightCurve):
     """Defines a light curve class for NASA's Kepler and K2 missions.

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -158,7 +158,12 @@ def test_lightcurve_fold():
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
-    fold.plot()
+    ax = fold.plot()
+    assert (ax.get_xlabel() == 'Phase')
+    ax = fold.scatter()
+    assert (ax.get_xlabel() == 'Phase')
+    ax = fold.errorbar()
+    assert (ax.get_xlabel() == 'Phase')
     plt.close('all')
 
 


### PR DESCRIPTION
@nksaunders pointed out that `lc.fold().errorbar()` has the wrong xlabel. This fixes that, and adds a test it will never happen again.

Fixes #328 