### PR TITLE
Quick fix for Bokeh v1.0.0

### DIFF
--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -344,8 +344,12 @@ def show_interact_widget(tpf, lc=None, notebook_url='localhost:8888', max_cadenc
         # Callbacks
         def update_upon_pixel_selection(attr, old, new):
             """Callback to take action when pixels are selected."""
-            if tpf_source.selected.indices != []:
-                selected_indices = np.array(tpf_source.selected.indices)
+            if ((sorted(old) == sorted(new)) & (new != [])):
+                # Trigger recursion
+                tpf_source.selected.indices = new[1:]
+
+            if new != []:
+                selected_indices = np.array(new)
                 selected_mask = np.isin(pixel_index_array, selected_indices)
                 lc_new = tpf.to_lightcurve(aperture_mask=selected_mask)
                 lc_source.data['flux'] = lc_new.flux
@@ -379,8 +383,8 @@ def show_interact_widget(tpf, lc=None, notebook_url='localhost:8888', max_cadenc
                 cadence_slider.value = existing_value - 1
 
         def jump_to_lightcurve_position(attr, old, new):
-            if new.indices != []:
-                cadence_slider.value = lc.cadenceno[new.indices[0]]
+            if new != []:
+                cadence_slider.value = lc.cadenceno[new[0]]
 
         # Map changes to callbacks
         r_button.on_click(go_right_by_one)

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -31,6 +31,8 @@ try:
     from bokeh.models.tools import HoverTool
     from bokeh.models.widgets import Button
     from bokeh.models.formatters import PrintfTickFormatter
+    if bokeh.__version__[0] == '0':
+        warnings.warn("interact() requires Bokeh version 1.0 or later", LightkurveWarning)
 except ImportError:
     pass  # We will print a nice error message in the `show_interact_widget` function
 

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -14,9 +14,10 @@ Note that this will only work inside a Jupyter notebook at this time.
 """
 from __future__ import division, print_function
 import logging
+import warnings
 import numpy as np
 from astropy.stats import sigma_clip
-from .utils import KeplerQualityFlags
+from .utils import KeplerQualityFlags, LightkurveWarning
 
 log = logging.getLogger(__name__)
 
@@ -31,8 +32,6 @@ try:
     from bokeh.models.tools import HoverTool
     from bokeh.models.widgets import Button
     from bokeh.models.formatters import PrintfTickFormatter
-    if bokeh.__version__[0] == '0':
-        warnings.warn("interact() requires Bokeh version 1.0 or later", LightkurveWarning)
 except ImportError:
     pass  # We will print a nice error message in the `show_interact_widget` function
 
@@ -296,6 +295,8 @@ def show_interact_widget(tpf, lc=None, notebook_url='localhost:8888', max_cadenc
     """
     try:
         import bokeh
+        if bokeh.__version__[0] == '0':
+            warnings.warn("interact() requires Bokeh version 1.0 or later", LightkurveWarning)
     except ImportError:
         log.error("The interact() tool requires the `bokeh` package; "
                   "you can install bokeh using e.g. `conda install bokeh`.")

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -341,19 +341,9 @@ def show_interact_widget(tpf, lc=None, notebook_url='localhost:8888', max_cadenc
         r_button = Button(label=">", button_type="default", width=30)
         l_button = Button(label="<", button_type="default", width=30)
 
-        existing_selection = tpf_source.selected.to_json(True).copy()
-
         # Callbacks
         def update_upon_pixel_selection(attr, old, new):
             """Callback to take action when pixels are selected."""
-            # check if a selection was "re-clicked".
-            if ((sorted(existing_selection['indices']) == sorted(new.indices)) &
-                    (new.indices != [])):
-                tpf_source.selected = Selection(indices=new.indices[1:])
-                existing_selection['indices'] = new.indices[1:]
-            else:
-                existing_selection['indices'] = new.indices
-
             if tpf_source.selected.indices != []:
                 selected_indices = np.array(tpf_source.selected.indices)
                 selected_mask = np.isin(pixel_index_array, selected_indices)
@@ -395,8 +385,8 @@ def show_interact_widget(tpf, lc=None, notebook_url='localhost:8888', max_cadenc
         # Map changes to callbacks
         r_button.on_click(go_right_by_one)
         l_button.on_click(go_left_by_one)
-        tpf_source.on_change('selected', update_upon_pixel_selection)
-        lc_source.on_change('selected', jump_to_lightcurve_position)
+        tpf_source.selected.on_change('indices', update_upon_pixel_selection)
+        lc_source.selected.on_change('indices', jump_to_lightcurve_position)
         cadence_slider.on_change('value', update_upon_cadence_change)
 
         # Layout all of the plots


### PR DESCRIPTION
@gully I think it would be good to merge a quick workaround fix for Bokeh v1.0.0 (cf. https://bokeh.pydata.org/en/latest/docs/releases.html#handling-of-selections), separately from the ongoing work to add a `Save lightcurve` button (#329).

Does this PR look right?  I am aware that this fix causes the deselection of pixels to no longer work, but it does seem to restore all other functionality, so I'd like to suggest we go ahead and merge this.

(If we can restore the deselection feature, all the better of course, but I didn't find an obvious workaround?)