### PR TITLE
Allow quality_bitmask to be passed into open()

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -648,7 +648,7 @@ def _filter_products(products, campaign=None, quarter=None, month=None,
     return products
 
 
-def open(path_or_url):
+def open(path_or_url, quality_bitmask='default'):
     """Opens a Kepler or TESS data product.
 
     This function will use the `detect_filetype()` function to
@@ -686,7 +686,8 @@ def open(path_or_url):
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:
-        return getattr(__import__('lightkurve'), filetype)(path_or_url)
+        return getattr(__import__('lightkurve'),
+                       filetype)(path_or_url, quality_bitmask=quality_bitmask)
     else:
         # if these keywords don't exist, raise `ValueError`
         raise ValueError("Not recognized as a Kepler or TESS data product: "

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -648,7 +648,7 @@ def _filter_products(products, campaign=None, quarter=None, month=None,
     return products
 
 
-def open(path_or_url, quality_bitmask='default'):
+def open(path_or_url, **kwargs):
     """Opens a Kepler or TESS data product.
 
     This function will use the `detect_filetype()` function to
@@ -686,8 +686,7 @@ def open(path_or_url, quality_bitmask='default'):
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:
-        return getattr(__import__('lightkurve'),
-                       filetype)(path_or_url, quality_bitmask=quality_bitmask)
+        return getattr(__import__('lightkurve'), filetype)(path_or_url, **kwargs)
     else:
         # if these keywords don't exist, raise `ValueError`
         raise ValueError("Not recognized as a Kepler or TESS data product: "

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -217,12 +217,13 @@ def test_open():
     k2_path = os.path.join(PACKAGEDIR, "tests", "data", "test-tpf-star.fits")
     tess_path = os.path.join(PACKAGEDIR, "tests", "data", "tess25155310-s01-first-cadences.fits.gz")
     k2tpf = open(k2_path)
-    assert isinstance(k2tpf, KeplerTargetPixelFile)
+    assert(isinstance(k2tpf, KeplerTargetPixelFile))
     tesstpf = open(tess_path)
-    assert isinstance(tesstpf, TessTargetPixelFile)
+    assert(isinstance(tesstpf, TessTargetPixelFile))
     try:
         open(os.path.join(PACKAGEDIR, "tests", "data", "test_factory0.fits"))
     except ValueError:
         pass
-    assert isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile)
-    assert isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile)
+    assert(isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile))
+    assert(isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile))
+    assert(open(k2_path, quality_bitmask='hard').quality_bitmask == 'hard')


### PR DESCRIPTION
`lightkurve.open()` now supports the `quality_bitmask` keyword argument.

Fixes #354.