### PR TITLE
Changed lc.fold() phase argument to transit midpoint.

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -357,7 +357,7 @@ class LightCurve(object):
             phase.
         """
 
-        if (transit_midpoint > 2450000) & ((self.time[0] < 2450000) | (self.time_format == 'bkjd')):
+        if (transit_midpoint > 2450000) & ((self.time[0] < 2450000) | (self.time_format == 'bkjd') | (self.time_format == 'bkjd')):
             warnings.warn('Transit mid point appears to be in JD, however light curve time appears'
                         ' to be in BKJD (i.e. JD - 2454833).', LightkurveWarning)
         phase = (transit_midpoint % period) / period

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1120,6 +1120,25 @@ class FoldedLightCurve(LightCurve):
             ax.set_xlabel("Phase")
         return ax
 
+    def errorbar(self, **kwargs):
+        """Plot the folded light curve usng matplotlib's `errorbar` method.
+
+        See `LightCurve.scatter` for details on the accepted arguments.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Dictionary of arguments to be passed to `LightCurve.scatter`.
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
+        """
+        ax = super(FoldedLightCurve, self).errorbar(**kwargs)
+        if 'xlabel' not in kwargs:
+            ax.set_xlabel("Phase")
+        return ax
 
 class KeplerLightCurve(LightCurve):
     """Defines a light curve class for NASA's Kepler and K2 missions.

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -335,7 +335,7 @@ class LightCurve(object):
             return flatten_lc, trend_lc
         return flatten_lc
 
-    def fold(self, period, phase=0.):
+    def fold(self, period, transit_midpoint=0.):
         """Folds the lightcurve at a specified ``period`` and ``phase``.
 
         This method returns a new ``LightCurve`` object in which the time
@@ -347,8 +347,8 @@ class LightCurve(object):
         ----------
         period : float
             The period upon which to fold.
-        phase : float, optional
-            Time reference point.
+        transit_midpoint : float, optional
+            Time reference point/epoch.
 
         Returns
         -------
@@ -356,6 +356,11 @@ class LightCurve(object):
             A new ``LightCurve`` in which the data are folded and sorted by
             phase.
         """
+
+        if (transit_midpoint > 2450000) & ((self.time[0] < 2450000) | (self.time_format == 'bkjd')):
+            warnings.warn('Transit mid point appears to be in JD, however light curve time appears'
+                        ' to be in BKJD (i.e. JD - 2454833).', LightkurveWarning)
+        phase = (transit_midpoint % period) / period
         fold_time = (((self.time - phase * period) / period) % 1)
         # fold time domain from -.5 to .5
         fold_time[fold_time > 0.5] -= 1
@@ -363,7 +368,7 @@ class LightCurve(object):
         return FoldedLightCurve(time=fold_time[sorted_args],
                                 flux=self.flux[sorted_args],
                                 flux_err=self.flux_err[sorted_args],
-                                time_original=self.time,
+                                time_original=self.time[sorted_args],
                                 targetid=self.targetid,
                                 label=self.label,
                                 meta=self.meta)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -339,16 +339,17 @@ class LightCurve(object):
         """Folds the lightcurve at a specified ``period`` and ``transit_midpoint``.
 
         This method returns a new ``LightCurve`` object in which the time
-        values range between -0.5 to +0.5.  Data points which occur exactly
-        at ``phase`` or an integer multiple of `phase + n*period` have time
-        value 0.0.
+        values range between -0.5 to +0.5 (i.e. the phase).
+        Data points which occur exactly at ``transit_midpoint`` or an integer
+        multiple of `transit_midpoint + n*period` will have time value 0.0.
 
         Parameters
         ----------
         period : float
             The period upon which to fold.
         transit_midpoint : float, optional
-            Time reference point/epoch.
+            Time reference point in the same units as the LightCurve's `time`
+            attribute.
 
         Returns
         -------
@@ -357,9 +358,15 @@ class LightCurve(object):
             phase.
         """
 
-        if (transit_midpoint > 2450000) & ((self.time[0] < 2450000) | (self.time_format == 'bkjd') | (self.time_format == 'bkjd')):
-            warnings.warn('Transit mid point appears to be in JD, however light curve time appears'
-                        ' to be in BKJD (i.e. JD - 2454833).', LightkurveWarning)
+        if (transit_midpoint > 2450000):
+            if self.time_format == 'bkjd':
+                warnings.warn('`transit_midpoint` appears to be given in JD, '
+                              'however the light curve time uses BKJD '
+                              '(i.e. JD - 2454833).', LightkurveWarning)
+            elif self.time_format == 'btjd':
+                warnings.warn('`transit_midpoint` appears to be given in JD, '
+                              'however the light curve time uses BTJD '
+                              '(i.e. JD - 2457000).', LightkurveWarning)
         phase = (transit_midpoint % period) / period
         fold_time = (((self.time - phase * period) / period) % 1)
         # fold time domain from -.5 to .5

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -160,7 +160,7 @@ def test_lightcurve_fold():
     assert fold.meta == lc.meta
     assert_array_equal(np.sort(fold.time_original), lc.time)
     assert len(fold.time_original) == len(lc.time)
-    fold = lc.fold(period=1, phase=-0.1)
+    fold = lc.fold(period=1, transit_midpoint=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -163,7 +163,12 @@ def test_lightcurve_fold():
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
-    fold.plot()
+    ax = fold.plot()
+    assert (ax.get_xlabel() == 'Phase')
+    ax = fold.scatter()
+    assert (ax.get_xlabel() == 'Phase')
+    ax = fold.errorbar()
+    assert (ax.get_xlabel() == 'Phase')
     plt.close('all')
 
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -150,7 +150,7 @@ def test_bitmasking(quality_bitmask, answer):
 def test_lightcurve_fold():
     """Test the ``LightCurve.fold()`` method."""
     lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1,
-                    targetid=999, label='mystar', meta={'ccd': 2})
+                    targetid=999, label='mystar', meta={'ccd': 2}, time_format='bkjd')
     fold = lc.fold(period=1)
     assert_almost_equal(fold.phase[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -174,8 +174,9 @@ def test_lightcurve_fold():
 
     # bad transit midpoint should give a warning
     # if user tries a t0 in JD but time is in BKJD
-    with pytest.warns(LightkurveWarning, match='appears to be in JD, however '):
-        f = lc.fold(10, 2456600)
+    with pytest.warns(LightkurveWarning, match='appears to be given in JD'):
+        lc.fold(10, 2456600)
+
 
 def test_lightcurve_append():
     """Test ``LightCurve.append()``."""

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -158,8 +158,8 @@ def test_lightcurve_fold():
     assert fold.targetid == lc.targetid
     assert fold.label == lc.label
     assert fold.meta == lc.meta
-    assert_array_equal(fold.time_original, lc.time)
-    fold = lc.fold(period=1, phase=-0.1)
+    assert_array_equal(np.sort(fold.time_original), lc.time)
+    fold = lc.fold(period=1, transit_midpoint=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
@@ -171,6 +171,10 @@ def test_lightcurve_fold():
     assert (ax.get_xlabel() == 'Phase')
     plt.close('all')
 
+    # bad transit midpoint should give a warning
+    # if user tries a t0 in JD but time is in BKJD
+    with pytest.warns(LightkurveWarning, match='appears to be in JD, however '):
+        f = lc.fold(10, 2456600)
 
 def test_lightcurve_append():
     """Test ``LightCurve.append()``."""


### PR DESCRIPTION
I've changed lc.fold() phase argument to transit midpoint to fix issue #357. I've also fixed #353 and fixed the unit test. 

### Fold now takes `transit_midpoint` as an argument, not phase.
![image](https://user-images.githubusercontent.com/14965634/49320405-44c84180-f4b6-11e8-8b86-ba938fe5878c.png)

Note that if `transit_midpoint` is in JD it will warn the user that it doesn't look right. It just raises a warning, not an exception, because it's conceivable that the user knows what they're doing. @barentsen do you want to chime in on this?

### Folded light curve attribute `time_original` is now in the correct order.
![image](https://user-images.githubusercontent.com/14965634/49320430-6de8d200-f4b6-11e8-8e1a-01bb806b239b.png)

Fixes #357 
Fixes #353 