### PR TITLE
Added an iterative feature to flatten to iteratively clip outliers when flattening. 

### DIFF
--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -590,6 +590,23 @@ def test_flatten_robustness():
     assert_allclose(flat_lc.time, trend_lc.time)
     assert_allclose(lc.flux, flat_lc.flux * trend_lc.flux)
 
+def test_iterative_flatten():
+    '''Test the iterative sigma clipping in flatten '''
+    # Test a light curve with a single, buried outlier.
+    x = np.arange(2000)
+    y = np.sin(x/200)/100 + 1
+    y[250] -= 0.01
+    lc = LightCurve(x, y)
+
+    # Flatten it
+    c, f = lc.flatten(window_length=25, niters=2, sigma=3, return_trend=True)
+
+    # Only one outlier should remain.
+    assert np.isclose(c.flux, 1, rtol=0.00001).sum() == 1999
+
+
+
+
 
 def test_fill_gaps():
     lc = LightCurve([1,2,3,4,6,7,8], [1,1,1,1,1,1,1])


### PR DESCRIPTION
When flattening light curves with flares or transits, the flatten always makes the transits look funny, because it doesn't remove those outliers before flattening.

I've added in an iterative sigma-clipping which flattens, removes outliers, and then re-flattens the data ignoring those outliers. 

### Problem (before)
![image](https://user-images.githubusercontent.com/14965634/49479816-3beaaf00-f7d9-11e8-8cf6-e463d59b7fc8.png)
![image](https://user-images.githubusercontent.com/14965634/49479842-57ee5080-f7d9-11e8-89a9-a5a1b39c27c0.png)


### Solution (after)

![image](https://user-images.githubusercontent.com/14965634/49479878-7ce2c380-f7d9-11e8-949e-04d4b7212937.png)

![image](https://user-images.githubusercontent.com/14965634/49479900-8ff59380-f7d9-11e8-8079-914962126fc1.png)
