### PR TITLE
Add support for TESScut TPFs

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -146,8 +146,14 @@ class TargetPixelFile(object):
 
     @property
     def pipeline_mask(self):
-        """Returns the aperture mask used by the pipeline"""
-        return self.hdu[2].data > 2
+        """Returns the optimal aperture mask used by the pipeline."""
+        # Both Kepler and TESS flag the pixels in the optimal aperture using
+        # bit number 2 in the aperture mask extension, e.g. see Section 6 of
+        # the TESS Data Products documentation (EXP-TESS-ARC-ICD-TM-0014.pdf).
+        try:
+            return self.hdu[2].data & 2 > 0
+        except TypeError:  # Early versions of TESScut returned floats in HDU 2
+            return np.ones(self.hdu[2].data.shape, dtype=bool)
 
     @property
     def shape(self):
@@ -1330,15 +1336,6 @@ class TessTargetPixelFile(TargetPixelFile):
 
     def __repr__(self):
         return('TessTargetPixelFile(TICID: {})'.format(self.targetid))
-
-    @property
-    def pipeline_mask(self):
-        """Returns the optimal aperture mask used by the TESS pipeline.
-
-        For details on how the mask is stored in a TPF, see Section 6 of the
-        Data Products documentation (EXP-TESS-ARC-ICD-TM-0014.pdf).
-        """
-        return self.hdu[2].data & 2 > 0
 
     @property
     def background_mask(self):

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -489,6 +489,7 @@ def detect_filetype(header):
         # and `creator` to determine tpf or lc
         telescop = header['telescop'].lower()
         creator = header['creator'].lower()
+        origin = header['origin'].lower()
         if telescop == 'kepler':
             # Kepler TPFs will contain "TargetPixelExporterPipelineModule"
             if 'targetpixel' in creator:
@@ -503,6 +504,9 @@ def detect_filetype(header):
             # TESS LCFs will contain "LightCurveExporterPipelineModule"
             elif 'lightcurve' in creator:
                 return 'TessLightCurveFile'
+            # Early versions of TESScut did not set a good CREATOR keyword
+            elif 'stsci' in origin:
+                return 'TessTargetPixelFile'
     # If the TELESCOP or CREATOR keywords don't exist we expect a KeyError;
     # if one of them is Undefined we expect `.lower()` to yield an AttributeError.
     except (KeyError, AttributeError):


### PR DESCRIPTION
I encountered two issues while trying to read in Target Pixel Files created using MAST's TESScut service:
* the aperture mask extension contained floats instead of ints;
* `lightkurve.open()` did not detect the file as a TPF.

This PR addresses both issues (and slightly refactors `tpf.pipeline_mask`).  I also opened two PR's over at https://github.com/spacetelescope/astrocut related to these issues.