### PR TITLE
Solves issue in astropy.convolution.convolve affecting lightkurve's periodogram box method

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function
 
 import copy
 import logging
+import math
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -377,8 +378,8 @@ class Periodogram(object):
             if not np.isclose(np.median(np.diff(self.frequency.value)), fs.value):
                 raise ValueError("the 'boxkernel' method requires the periodogram "
                                  "to have a grid of evenly spaced frequencies.")
-                
-            box_kernel = Box1DKernel(np.ceil(filter_width.value/fs.value))
+
+            box_kernel = Box1DKernel(math.ceil((filter_width/fs).value))
             smooth_power = convolve(self.power.value, box_kernel)
             smooth_pg = self.copy()
             smooth_pg.power = u.Quantity(smooth_power, self.power.unit)


### PR DESCRIPTION
As explained by @barentsen, `astropy 3.1` introduced some behavior that resulted in an error when computing periodograms using `lightkurve`. I didn't completely understand what's going on on the astropy side, but this PR should bring back the expected behavior. I also noted that with `astropy 3.2dev` we didn't need this fix, but it works with it regardless.