### PR TITLE
remove impulsive outlier as a default flag

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -189,7 +189,7 @@ class TessQualityFlags(QualityFlags):
 
     #: DEFAULT bitmask identifies all cadences which are definitely useless.
     DEFAULT_BITMASK = (AttitudeTweak | SafeMode | CoarsePoint | EarthPoint |
-                       Desat | ManualExclude | ImpulsiveOutlier)
+                       Desat | ManualExclude)
     #: HARD bitmask is conservative and may identify cadences which are useful.
     HARD_BITMASK = (DEFAULT_BITMASK | ApertureCosmic |
                     CollateralCosmic | Straylight)


### PR DESCRIPTION
I don't think that this should be a default flag as it flags flares intrinsic to the star.