### PR TITLE
Prevent `tpf.cadenceno` from returning zeros for TESScut TPFs

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -168,7 +168,12 @@ class TargetPixelFile(object):
     @property
     def cadenceno(self):
         """Return the cadence number for all good-quality cadences."""
-        return self.hdu[1].data['CADENCENO'][self.quality_mask]
+        cadenceno = self.hdu[1].data['CADENCENO'][self.quality_mask]
+        # The TESScut service returns an array of zeros as CADENCENO.
+        # If this is the case, return frame numbers from 0 instead.
+        if cadenceno[0] == 0:
+            return np.arange(0, len(cadenceno), 1, dtype=int)
+        return cadenceno
 
     @property
     def nan_time_mask(self):


### PR DESCRIPTION
`interact()` does not work on TESScut TPFs because the `CADENCENO` column is all zeros (cf. #373).  This will likely be resolved in a few months (cf. https://twitter.com/GeertHub/status/1071172334982094848 ), but for now I propose we merge this workaround.

@gully Can you review, test, and merge?