### PR TITLE
[bugfix] LightCurve.bin() did not bin QUALITY and CADENCENO correctly

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -623,6 +623,7 @@ class LightCurve(object):
         if hasattr(binned_lc, 'cadenceno'):
             binned_lc.cadenceno = np.array([np.nan] * n_bins)
         if hasattr(binned_lc, 'centroid_col'):
+            # Note: nanmean/nanmedian yield a RuntimeWarning if a slice is all NaNs
             binned_lc.centroid_col = np.array(
                 [methodf(a) if np.any(np.isfinite(a)) else np.nan
                  for a in np.array_split(self.centroid_col, n_bins)])

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -616,18 +616,20 @@ class LightCurve(object):
             binned_lc.flux_err = np.zeros(len(binned_lc.flux))
 
         if hasattr(binned_lc, 'quality'):
+            # Note: np.bitwise_or only works if there are no NaNs
             binned_lc.quality = np.array(
-                [np.bitwise_or.reduce(a) if np.all(np.isfinite(a))
-                 else np.nan
+                [np.bitwise_or.reduce(a) if np.all(np.isfinite(a)) else np.nan
                  for a in np.array_split(self.quality, n_bins)])
         if hasattr(binned_lc, 'cadenceno'):
             binned_lc.cadenceno = np.array([np.nan] * n_bins)
         if hasattr(binned_lc, 'centroid_col'):
             binned_lc.centroid_col = np.array(
-                [methodf(a) for a in np.array_split(self.centroid_col, n_bins)])
+                [methodf(a) if np.any(np.isfinite(a)) else np.nan
+                 for a in np.array_split(self.centroid_col, n_bins)])
         if hasattr(binned_lc, 'centroid_row'):
             binned_lc.centroid_row = np.array(
-                [methodf(a) for a in np.array_split(self.centroid_row, n_bins)])
+                [methodf(a) if np.any(np.isfinite(a)) else np.nan
+                 for a in np.array_split(self.centroid_row, n_bins)])
 
         return binned_lc
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -617,7 +617,11 @@ class LightCurve(object):
 
         if hasattr(binned_lc, 'quality'):
             binned_lc.quality = np.array(
-                [np.bitwise_or.reduce(a) for a in np.array_split(self.quality, n_bins)])
+                [np.bitwise_or.reduce(a) if np.all(np.isfinite(a))
+                 else np.nan
+                 for a in np.array_split(self.quality, n_bins)])
+        if hasattr(binned_lc, 'cadenceno'):
+            binned_lc.cadenceno = np.array([np.nan] * n_bins)
         if hasattr(binned_lc, 'centroid_col'):
             binned_lc.centroid_col = np.array(
                 [methodf(a) for a in np.array_split(self.centroid_col, n_bins)])

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -346,6 +346,7 @@ def test_bin():
     lc = KeplerLightCurve(time=np.arange(10),
                           flux=2*np.ones(10))
     lc.bin(5).remove_outliers()
+    # Second regression test for #377
     lc = KeplerLightCurve(time=np.arange(1000) * 0.02,
                           flux=1*np.ones(1000) + np.random.normal(0, 1e-6, 1000),
                           cadenceno=np.arange(1000))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -347,7 +347,9 @@ def test_bin():
                           flux=2*np.ones(10))
     lc.bin(5).remove_outliers()
 
-
+lc = lk.KeplerLightCurve(time=np.arange(1000) * 0.02,
+                          flux=1*np.ones(1000) + np.random.normal(0, 0.00002, 1000), cadenceno=np.arange(1000)+3000)
+np.isclose(lc.estimate_cdpp(), 5, rtol=2)
 def test_bin_quality():
     """Binning must also revise the quality and centroid columns."""
     lc = KeplerLightCurve(time=[1, 2, 3, 4],

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -346,10 +346,12 @@ def test_bin():
     lc = KeplerLightCurve(time=np.arange(10),
                           flux=2*np.ones(10))
     lc.bin(5).remove_outliers()
+    lc = KeplerLightCurve(time=np.arange(1000) * 0.02,
+                          flux=1*np.ones(1000) + np.random.normal(0, 1e-6, 1000),
+                          cadenceno=np.arange(1000))
+    assert np.isclose(lc.bin(2).estimate_cdpp(), 1, rtol=1)
 
-lc = lk.KeplerLightCurve(time=np.arange(1000) * 0.02,
-                          flux=1*np.ones(1000) + np.random.normal(0, 0.00002, 1000), cadenceno=np.arange(1000)+3000)
-np.isclose(lc.estimate_cdpp(), 5, rtol=2)
+
 def test_bin_quality():
     """Binning must also revise the quality and centroid columns."""
     lc = KeplerLightCurve(time=[1, 2, 3, 4],

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -342,6 +342,10 @@ def test_bin():
                     flux=2*np.ones(10))
     binned_lc = lc.bin(binsize=2)
     assert_allclose(binned_lc.flux_err, np.zeros(5))
+    # Regression test for #377
+    lc = KeplerLightCurve(time=np.arange(10),
+                          flux=2*np.ones(10))
+    lc.bin(5).remove_outliers()
 
 
 def test_bin_quality():


### PR DESCRIPTION
Christina reported verbally that `KeplerLightCurve.bin(15).estimate_cdpp()` failed.  I believe this PR addresses the bug, and adds a regression test.

@christinahedges Please review, test, and merge!  Thx++.