### PR TITLE
Added errorbar and scatter methods to LCF

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -153,7 +153,8 @@ class LightCurveFile(object):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
-        return self._create_plot(method='plot', **kwargs)
+        return self._create_plot(method='plot', flux_types=flux_types,
+                                 style=style, **kwargs)
 
 
     def scatter(self, flux_types=None, style='lightkurve', **kwargs):
@@ -188,7 +189,8 @@ class LightCurveFile(object):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
-        return self._create_plot(method='scatter', **kwargs)
+        return self._create_plot(method='scatter', flux_types=flux_types,
+                                 style=style, **kwargs)
 
     def errorbar(self, flux_types=None, style='lightkurve', **kwargs):
         """Plot the light curve file using matplotlib's `errorbar` method.
@@ -222,7 +224,8 @@ class LightCurveFile(object):
         ax : matplotlib.axes._subplots.AxesSubplot
             The matplotlib axes object.
         """
-        return self._create_plot(method='errorbar', **kwargs)
+        return self._create_plot(method='errorbar', flux_types=flux_types,
+                                 style=style, **kwargs)
 
 
 class KeplerLightCurveFile(LightCurveFile):

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -91,20 +91,14 @@ class LightCurveFile(object):
             quality_vector = np.zeros(len(self.hdu[1].data['TIME']))
         return quality_vector
 
+    def _create_plot(self, method='plot', flux_types=None, style='lightkurve',
+                     **kwargs):
+        """Implements `plot()`, `scatter()`, and `errorbar()` to avoid code duplication.
 
-    def plot(self, flux_types=None, style='lightkurve', **kwargs):
-        """Plot all the light curves contained in this light curve file.
-
-        Parameters
-        ----------
-        flux_types : str or list of str
-            List of flux types to plot. Default is to plot all available.
-            (For Kepler the default fluxes are 'SAP_FLUX' and 'PDCSAP_FLUX'.
-        style : str
-            matplotlib.pyplot.style.context, default is 'fast'
-        kwargs : dict
-            Dictionary of keyword arguments to be passed to
-            `KeplerLightCurve.plot()`.
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
         """
         if style is None or style == 'lightkurve':
             style = MPLSTYLE
@@ -119,7 +113,116 @@ class LightCurveFile(object):
             for idx, ft in enumerate(flux_types):
                 lc = self.get_lightcurve(ft)
                 kwargs['color'] = np.asarray(mpl.rcParams['axes.prop_cycle'])[idx]['color']
-                lc.plot(label=ft, **kwargs)
+                if method == 'plot':
+                    lc.plot(label=ft, **kwargs)
+                elif method == 'scatter':
+                    lc.scatter(label=ft, **kwargs)
+                elif method == 'errorbar':
+                    lc.errorbar(label=ft, **kwargs)
+
+
+    def plot(self, flux_types=None, style='lightkurve', **kwargs):
+        """Plot the light curve file using matplotlib's `plot` method.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            A matplotlib axes object to plot into. If no axes is provided,
+            a new one will be generated.
+        flux_types : list or None
+            Which fluxes in the LCF to plot. Default is lcf._flux_types().
+            For Kepler this is PDCSAP and SAP flux. Pass a list to change flux
+            types.
+        normalize : bool
+            Normalize the lightcurve before plotting?
+        xlabel : str
+            Plot x axis label
+        ylabel : str
+            Plot y axis label
+        title : str
+            Plot set_title
+        style : str
+            Path or URL to a matplotlib style file, or name of one of
+            matplotlib's built-in stylesheets (e.g. 'ggplot').
+            Lightkurve's custom stylesheet is used by default.
+        kwargs : dict
+            Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
+        """
+        return self._create_plot(method='plot', **kwargs)
+
+
+    def scatter(self, flux_types=None, style='lightkurve', **kwargs):
+        """Plot the light curve file using matplotlib's `scatter` method.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            A matplotlib axes object to plot into. If no axes is provided,
+            a new one will be generated.
+        flux_types : list or None
+            Which fluxes in the LCF to plot. Default is lcf._flux_types().
+            For Kepler this is PDCSAP and SAP flux. Pass a list to change flux
+            types.
+        normalize : bool
+            Normalize the lightcurve before plotting?
+        xlabel : str
+            Plot x axis label
+        ylabel : str
+            Plot y axis label
+        title : str
+            Plot set_title
+        style : str
+            Path or URL to a matplotlib style file, or name of one of
+            matplotlib's built-in stylesheets (e.g. 'ggplot').
+            Lightkurve's custom stylesheet is used by default.
+        kwargs : dict
+            Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
+        """
+        return self._create_plot(method='scatter', **kwargs)
+
+    def errorbar(self, flux_types=None, style='lightkurve', **kwargs):
+        """Plot the light curve file using matplotlib's `errorbar` method.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            A matplotlib axes object to plot into. If no axes is provided,
+            a new one will be generated.
+        flux_types : list or None
+            Which fluxes in the LCF to plot. Default is lcf._flux_types().
+            For Kepler this is PDCSAP and SAP flux. Pass a list to change flux
+            types.
+        normalize : bool
+            Normalize the lightcurve before plotting?
+        xlabel : str
+            Plot x axis label
+        ylabel : str
+            Plot y axis label
+        title : str
+            Plot set_title
+        style : str
+            Path or URL to a matplotlib style file, or name of one of
+            matplotlib's built-in stylesheets (e.g. 'ggplot').
+            Lightkurve's custom stylesheet is used by default.
+        kwargs : dict
+            Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
+
+        Returns
+        -------
+        ax : matplotlib.axes._subplots.AxesSubplot
+            The matplotlib axes object.
+        """
+        return self._create_plot(method='errorbar', **kwargs)
 
 
 class KeplerLightCurveFile(LightCurveFile):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -328,6 +328,8 @@ def test_lightcurve_plots():
     for lcf in [KeplerLightCurveFile(TABBY_Q8), TessLightCurveFile(TESS_SIM)]:
         lcf.plot()
         lcf.plot(flux_types=['SAP_FLUX', 'PDCSAP_FLUX'])
+        lcf.scatter()
+        lcf.errorbar()
         lcf.SAP_FLUX.plot()
         lcf.SAP_FLUX.plot(normalize=False, title="Not the default")
         lcf.SAP_FLUX.scatter()


### PR DESCRIPTION
I added errorbar and scatter methods to `lightcurvefile` in the same way as we have them for `lightcurve`. I haven't added tests because it actually looks like we were testing these methods without them ever breaking in `test_lightcurve.py`. Gonna see what code cov says.

Fixes #376 for @amcody 

```python
@pytest.mark.remote_data
def test_lightcurve_plots():
    """Sanity check to verify that lightcurve plotting works"""
    for lcf in [KeplerLightCurveFile(TABBY_Q8), TessLightCurveFile(TESS_SIM)]:
        lcf.plot()
        lcf.plot(flux_types=['SAP_FLUX', 'PDCSAP_FLUX'])
        lcf.SAP_FLUX.plot()
        lcf.SAP_FLUX.plot(normalize=False, title="Not the default")
        lcf.SAP_FLUX.scatter()
        lcf.SAP_FLUX.scatter(c='C3')
        lcf.SAP_FLUX.scatter(c=lcf.SAP_FLUX.time, show_colorbar=True, colorbar_label='Time')
        lcf.SAP_FLUX.errorbar()
        plt.close('all')
```