### PR TITLE
Add Python 3.7 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.6
   - 3.7
+dist: xenial
 before_install:  # optional dependencies
   - pip install codecov
   - pip install pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.7
   - 3.6
+  - 3.7
 before_install:  # optional dependencies
   - pip install codecov
   - pip install pytest-cov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
       MINICONDA: C:\Miniconda
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda3
+    - PYTHON_VERSION: 3.7
+      MINICONDA: C:\Miniconda3
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"


### PR DESCRIPTION
Let's add Python 3.7 for the CI matrix. It's been around for almost 6 months and other astro software (like [astropy](https://travis-ci.org/astropy/astropy)) are already supporting it! :)