### PR TITLE
Fix Travis error (`Can't open /etc/init.d/xvfb`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 3.6
   - 3.7
 dist: xenial
+services:
+  - xvfb  # X Virtual FrameBuffer (enables plotting in a headless environment)
 before_install:  # optional dependencies
   - pip install codecov
   - pip install pytest-cov
@@ -15,15 +17,9 @@ before_install:  # optional dependencies
   - pip install bokeh
 install:
   - pip install -r requirements.txt
-# command to run tests
-before_script: # configure a headless display to test plot generation
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-# command to run tests
-script:
+script:  # how to run the tests?
   - python setup.py develop
   - pytest --remote-data
-
 after_success:
   - codecov
+

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -419,7 +419,7 @@ def test_to_csv():
     time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
     try:
         lc = LightCurve(time, flux, flux_err)
-        assert(lc.to_csv(index=False) == 'time,flux,flux_err\n0,1.0,0.0\n1,1.0,0.0\n2,1.0,0.0\n')
+        assert(lc.to_csv(index=False, line_terminator='\n') == 'time,flux,flux_err\n0,1.0,0.0\n1,1.0,0.0\n2,1.0,0.0\n')
     except ImportError:
         # pandas is an optional dependency
         pass

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -258,17 +258,17 @@ def test_lightcurve_copy():
     # with a repeating decimal. However, float precision for python 2.7 is 10
     # decimal digits, while python 3.6's is 13 decimal digits. Therefore,
     # a regular expression is needed for both versions.
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.time, nlc.time)
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.flux, nlc.flux)
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.centroid_col, nlc.centroid_col)
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.centroid_row, nlc.centroid_row)
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.cadenceno, nlc.cadenceno)
-    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+%\)'):
+    with pytest.raises(AssertionError, match=r'\(mismatch 33\.3+'):
         assert_array_equal(lc.quality, nlc.quality)
 
 


### PR DESCRIPTION
Travis has been failing in the past 1-2 weeks with the following error message:
```
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```

This is because [Travis changed the way](https://hk.saowen.com/a/3f9c720bb360f9daa8ad29bdd3fbc48f34ce2aad47215b5802dd4fcc9e781730) in which the `xvfb` service (X Virtual FrameBuffer) ought to be started.  We use `xvfb` to enable our plots to be tested in a headless environment.

This PR should fix the issue!