### PR TITLE
Refactor `SFFCorrector` to use new `Corrector` API design

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1094,8 +1094,9 @@ class KeplerTargetPixelFile(TargetPixelFile):
         """
         allowed_methods = ["pld"]
         if method == "sff":
-            raise ValueError("The 'sff' method can only be used on "
-                             "`LightCurve` objects, not `TargetPixelFile` objects.")
+            raise ValueError("The 'sff' method requires a `LightCurve` instead "
+                             "of a `TargetPixelFile` object.  Use `to_lightcurve()` "
+                             "to obtain a `LightCurve` first.")
         if method not in allowed_methods:
             raise ValueError(("Unrecognized method '{0}'\n"
                               "allowed methods are: {1}")

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1093,6 +1093,9 @@ class KeplerTargetPixelFile(TargetPixelFile):
             and `diagnose()` methods.
         """
         allowed_methods = ["pld"]
+        if method == "sff":
+            raise ValueError("The 'sff' method can only be used on "
+                             "`LightCurve` objects, not `TargetPixelFile` objects.")
         if method not in allowed_methods:
             raise ValueError(("Unrecognized method '{0}'\n"
                               "allowed methods are: {1}")

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 from astropy.utils.data import get_pkg_data_filename
 
-from ..lightcurve import KeplerLightCurve, TessLightCurve
+from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import KeplerLightCurveFile
 from ..correctors import KeplerCBVCorrector, SFFCorrector, PLDCorrector
 from ..search import search_targetpixelfile
@@ -41,14 +41,14 @@ def test_sff_corrector():
     arclength = data[:, 5]
     correction = data[:, 6]
 
-    sff = SFFCorrector()
-    corrected_lc = sff.correct(time=time, flux=raw_flux,
-                               centroid_col=centroid_col,
+    lc = LightCurve(time=time, flux=raw_flux)
+    sff = SFFCorrector(lc)
+    corrected_lc = sff.correct(centroid_col=centroid_col,
                                centroid_row=centroid_row,
                                niters=1, windows=1)
     # do hidden plots execute smoothly?
-    ax = sff._plot_rotated_centroids()
-    ax = sff._plot_normflux_arclength()
+    sff._plot_rotated_centroids()
+    sff._plot_normflux_arclength()
 
     # the factor self.bspline(time-time[0]) accounts for
     # the long term trend which is divided out in order to get a "flat"

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.testing import (assert_almost_equal, assert_array_equal,
                            assert_allclose)
 import pytest
+import tempfile
 import warnings
 
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
@@ -449,25 +450,25 @@ def test_to_fits():
     assert hdu[1].header['TTYPE2'] == 'FLUX'
 
     # Test aperture mask support in to_fits
-    for tpf in [KeplerTargetPixelFile(TABBY_TPF),TessTargetPixelFile(filename_tess)]:
-        random_mask = np.random.randint(0, 2,size=tpf.flux[0].shape, dtype=bool)
+    for tpf in [KeplerTargetPixelFile(TABBY_TPF), TessTargetPixelFile(filename_tess)]:
+        random_mask = np.random.randint(0, 2, size=tpf.flux[0].shape, dtype=bool)
         thresh_mask = tpf.create_threshold_mask(threshold=3)
 
         lc = tpf.to_lightcurve(aperture_mask=random_mask)
-        lc.to_fits(path='out1.fits', aperture_mask=random_mask, overwrite=True)
+        lc.to_fits(path=tempfile.NamedTemporaryFile().name, aperture_mask=random_mask)
 
         lc = tpf[0:2].to_lightcurve(aperture_mask=thresh_mask)
-        lc.to_fits(aperture_mask=thresh_mask, path='out2.fits', overwrite=True)
+        lc.to_fits(aperture_mask=thresh_mask, path=tempfile.NamedTemporaryFile().name)
 
         # Test the extra data kwargs
         bkg_mask = ~tpf.create_threshold_mask(threshold=0.1)
         bkg_lc = tpf.to_lightcurve(aperture_mask=bkg_mask)
         lc = tpf.to_lightcurve(aperture_mask=tpf.hdu['APERTURE'].data)
-        #lc = tpf.to_lightcurve(aperture_mask=None) ## will error
+        lc = tpf.to_lightcurve(aperture_mask=None)
         lc = tpf.to_lightcurve(aperture_mask=thresh_mask)
         lc_out = lc - bkg_lc.flux * (thresh_mask.sum()/bkg_mask.sum())
-        lc_out.to_fits(aperture_mask=thresh_mask, path='out2.fits',
-                   overwrite=True, extra_data={'BKG':bkg_lc.flux})
+        lc_out.to_fits(aperture_mask=thresh_mask, path=tempfile.NamedTemporaryFile().name,
+                       overwrite=True, extra_data={'BKG': bkg_lc.flux})
 
 
 @pytest.mark.remote_data
@@ -697,6 +698,7 @@ def test_regression_346():
 
 def test_new_corrector_api():
     """This test can be remove after we remove the deprecated `LightCurve.correct()` method"""
-    lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
+    with pytest.warns(LightkurveWarning, match='deprecated'):
+        lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
     lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
     assert_allclose(lc1.flux, lc2.flux)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -698,7 +698,8 @@ def test_regression_346():
 
 def test_new_corrector_api():
     """This test can be remove after we remove the deprecated `LightCurve.correct()` method"""
-    with pytest.warns(LightkurveWarning, match='deprecated'):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LightkurveWarning)  # Deprecation warning
         lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
     lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
     assert_allclose(lc1.flux, lc2.flux)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -693,3 +693,4 @@ def test_regression_346():
     """Regression test for https://github.com/KeplerGO/lightkurve/issues/346"""
     # This previously triggered an IndexError:
     KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct().estimate_cdpp()
+    KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct().estimate_cdpp()

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -692,5 +692,11 @@ def test_targetid():
 def test_regression_346():
     """Regression test for https://github.com/KeplerGO/lightkurve/issues/346"""
     # This previously triggered an IndexError:
-    KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct().estimate_cdpp()
     KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct().estimate_cdpp()
+
+
+def test_new_corrector_api():
+    """This test can be remove after we remove the deprecated `LightCurve.correct()` method"""
+    lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
+    lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
+    assert_array_equal(lc1.flux, lc2.flux)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -699,4 +699,4 @@ def test_new_corrector_api():
     """This test can be remove after we remove the deprecated `LightCurve.correct()` method"""
     lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
     lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
-    assert_array_equal(lc1.flux, lc2.flux)
+    assert_allclose(lc1.flux, lc2.flux)


### PR DESCRIPTION
This PR addresses #408.

This PR also deprecates `LightCurve.correct()` in favor of a new `LightCurve.to_corrector()` method.