### PR TITLE
Rename transit_midpoint into t0

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -376,21 +376,23 @@ class LightCurve(object):
             return flatten_lc, trend_lc
         return flatten_lc
 
-    def fold(self, period, transit_midpoint=0.):
-        """Folds the lightcurve at a specified ``period`` and ``transit_midpoint``.
+    def fold(self, period, t0=None, transit_midpoint=0.):
+        """Folds the lightcurve at a specified ``period`` and reference time ``t0``.
 
         This method returns a `FoldedLightCurve` object in which the time
         values range between -0.5 to +0.5 (i.e. the phase).
-        Data points which occur exactly at ``transit_midpoint`` or an integer
-        multiple of ``transit_midpoint + n*period`` will have time value 0.0.
+        Data points which occur exactly at ``t0`` or an integer multiple of
+        ``t0 + n*period`` will have phase value 0.0.
 
         Parameters
         ----------
         period : float
             The period upon which to fold.
+        t0 : float, optional
+            Time corresponding to zero phase. In the same units as the
+            LightCurve's ``time`` attribute.  Defaults to 0.
         transit_midpoint : float, optional
-            Time reference point in the same units as the LightCurve's ``time``
-            attribute.
+            Synonym for `t0`. This parameter will be ignored if ``t0`` is set.
 
         Returns
         -------
@@ -398,17 +400,18 @@ class LightCurve(object):
             A new light curve object in which the data are folded and sorted by
             phase. The object contains an extra ``phase`` attribute.
         """
-
-        if (transit_midpoint > 2450000):
+        if t0 is None:
+            t0 = transit_midpoint
+        if (t0 > 2450000):
             if self.time_format == 'bkjd':
-                warnings.warn('`transit_midpoint` appears to be given in JD, '
+                warnings.warn('`t0` appears to be given in JD, '
                               'however the light curve time uses BKJD '
                               '(i.e. JD - 2454833).', LightkurveWarning)
             elif self.time_format == 'btjd':
-                warnings.warn('`transit_midpoint` appears to be given in JD, '
+                warnings.warn('`t0` appears to be given in JD, '
                               'however the light curve time uses BTJD '
                               '(i.e. JD - 2457000).', LightkurveWarning)
-        phase = (transit_midpoint % period) / period
+        phase = (t0 % period) / period
         fold_time = (((self.time - phase * period) / period) % 1)
         # fold time domain from -.5 to .5
         fold_time[fold_time > 0.5] -= 1

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -163,10 +163,12 @@ def test_lightcurve_fold():
     assert fold.meta == lc.meta
     assert_array_equal(np.sort(fold.time_original), lc.time)
     assert len(fold.time_original) == len(lc.time)
-    fold = lc.fold(period=1, transit_midpoint=-0.1)
+    fold = lc.fold(period=1, t0=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
+    fold = lc.fold(period=1, transit_midpoint=-0.1)
+    assert_almost_equal(fold.time[0], -0.5, 2)
     ax = fold.plot()
     assert (ax.get_xlabel() == 'Phase')
     ax = fold.scatter()


### PR DESCRIPTION
This PR proposes to change `transit_midpoint` into `t0` as the recommended way to specify the reference time in the `LightCurve.fold()` method, i.e.
```python
lc.fold(period=2.34, transit_midpoint=3456.7)
```
becomes
```python
lc.fold(period=2.34, t0=3456.7)
```

The reason is that `transit_midpoint` is too specific to exoplanets (cf. #384).  However this PR retains `transit_midpoint` as a valid synonym for `t0`, i.e. we won't break people's code (for now).