### PR TITLE
Update citation page and fix broken links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,21 +43,21 @@ If you have a working version of Python 2 or 3 on your system, you can simply in
 
   pip install lightkurve
 
-Once installed, visit our quickstart guide at `http://docs.lightkurve.org/tutorials/quickstart.html <http://docs.lightkurve.org/tutorials/quickstart.html>`_.
+Once installed, visit our quickstart guide at `http://docs.lightkurve.org/quickstart.html <http://docs.lightkurve.org/quickstart.html>`_.
 
 
 Contributing
 ------------
 
 We welcome community contributions from everyone!
-Please read the contribution guidelines at `http://docs.lightkurve.org/contributing.html <http://docs.lightkurve.org/contributing.html>`_.
+Please read the contribution guidelines at `http://docs.lightkurve.org/about/contributing.html <http://docs.lightkurve.org/about/contributing.html>`_.
 
 
 Citing
 ------
 
-If you find this package useful in your research, please cite it and give us a GitHub star!
-Please read the citation instructions at `http://docs.lightkurve.org/citing.html <http://docs.lightkurve.org/citing.html>`_.
+If you find Lightkurve useful in your research, please cite it and give us a GitHub star!
+Please read the citation instructions at `http://docs.lightkurve.org/about/citing.html <http://docs.lightkurve.org/about/citing.html>`_.
 
 
 Contact

--- a/docs/source/about/citing.rst
+++ b/docs/source/about/citing.rst
@@ -1,26 +1,8 @@
 .. _citing:
 
 ===================================
-Citing and acknowledging lightkurve
+Citing and acknowledging Lightkurve
 ===================================
 
-
-If you find this package useful in your research, please cite it using the DOI
-and BibTeX provided below.
-
-::
-
-    @misc{lightkurve,
-      author       = {Zé Vinícius and
-                      Geert Barentsen and
-                      Christina Hedges and
-                      Michael Gully-Santiago and
-                      Ann Marie Cody},
-      title        = {KeplerGO/lightkurve},
-      month        = feb,
-      year         = 2018,
-      doi          = {10.5281/zenodo.1181928},
-      url          = {http://doi.org/10.5281/zenodo.1181928}
-    }
-
-Also, please give a star to `our GitHub repository <https://github.com/KeplerGO/lightkurve>`_!
+If you find Lightkurve useful in your research and would like to acknowledge it,
+please check our entry on `zenodo https://doi.org/10.5281/zenodo.1181928`.


### PR DESCRIPTION
The current citation page for Lightkurve http://docs.lightkurve.org/about/citing.html does not reflect the sheer amount of work done by many contributors. Thus, I propose we redirect users that would like to cite `lightkurve` to our zenodo URL, which contains a nice updated bibliographical entry. This PR also fixes minor broken links in the `README.rst` file.