### PR TITLE
Discussion: make LightCurve _repr_() more fancy in Jupyter notebooks?

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1362,7 +1362,10 @@ class KeplerLightCurve(LightCurve):
     def _repr_html_(self):
         """HTML representation which will display in notebooks by default."""
         html = "<p>{}</p>".format(self.__repr__())
-        html += self.to_pandas().reset_index(drop=True).to_html(max_rows=6, notebook=True)
+        html += self.to_pandas().reset_index(drop=True).to_html(
+                                    max_rows=6,
+                                    notebook=True,
+                                    float_format=lambda x: '{:.3f}'.format(x))
         return html
 
     def correct(self, method='sff', **kwargs):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1359,6 +1359,12 @@ class KeplerLightCurve(LightCurve):
     def __repr__(self):
         return('KeplerLightCurve(ID: {})'.format(self.targetid))
 
+    def _repr_html_(self):
+        """HTML representation which will display in notebooks by default."""
+        html = "<p>{}</p>".format(self.__repr__())
+        html += self.to_pandas().reset_index(drop=True).to_html(max_rows=6, notebook=True)
+        return html
+
     def correct(self, method='sff', **kwargs):
         """DEPRECATED: use `to_corrector(method).correct()` instead.
 


### PR DESCRIPTION
For discussion: I wonder if there is merit in showing a snippet of the data as part of the `LightCurve` repr in Jupyter notebooks, to help users understand the data columns contained in a `LightCurve`.

Here is what it could look like. Thoughts?

![screenshot from 2019-02-05 08-11-52](https://user-images.githubusercontent.com/817669/52286801-bccf3f80-291d-11e9-87aa-b908b402c426.png)
