### PR TITLE
Added Odd and Even mask arrays to FoldedLightCurve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.8.0 (unreleased)
 ==================
 
+- Added ``odd_mask`` and ``even_mask`` properties to ``FoldedLightCurve`` to
+  make it easy to plot odd- and even-numbered transits. [#425]
+
 - Fixed a bug which caused ``TargetPixelFile.interact()`` to raise a
   ``ValueError`` if the pixel file contained NaN flux values. [#679]
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -603,7 +603,9 @@ class LightCurve(object):
                                 time_original=self.time[sorted_args],
                                 targetid=self.targetid,
                                 label=self.label,
-                                meta=self.meta)
+                                meta=self.meta,
+                                period=period,
+                                t0=t0)
 
     def normalize(self, unit='unscaled'):
         """Returns a normalized version of the light curve.
@@ -1635,11 +1637,25 @@ class FoldedLightCurve(LightCurve):
     """
     def __init__(self, *args, **kwargs):
         self.time_original = kwargs.pop("time_original", None)
+        self.period = kwargs.pop("period", None)
+        self.t0 = kwargs.pop("t0", None)
         super(FoldedLightCurve, self).__init__(*args, **kwargs)
 
     @property
     def phase(self):
         return self.time
+
+    @property
+    def odd(self):
+        ''' Mask to show only odd numbered transits/oscillations. '''
+        phase = (self.t0 % self.period) / self.period
+        odd = (((self.time_original - phase * (self.period) - self.period * 0.5) / (self.period * 2)) % 1) < 0.5
+        return odd
+
+    @property
+    def even(self):
+        ''' Mask to show only even numbered transits/oscillations. '''
+        return ~self.odd
 
     def plot(self, **kwargs):
         """Plot the folded light curve using matplotlib's

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -602,10 +602,10 @@ class LightCurve(object):
                                 flux_err=self.flux_err[sorted_args],
                                 time_original=self.time[sorted_args],
                                 targetid=self.targetid,
-                                label=self.label,
-                                meta=self.meta,
                                 period=period,
-                                t0=t0)
+                                t0=t0,
+                                label=self.label,
+                                meta=self.meta)
 
     def normalize(self, unit='unscaled'):
         """Returns a normalized version of the light curve.
@@ -1646,16 +1646,15 @@ class FoldedLightCurve(LightCurve):
         return self.time
 
     @property
-    def odd(self):
+    def odd_mask(self):
         ''' Mask to show only odd numbered transits/oscillations. '''
-        phase = (self.t0 % self.period) / self.period
-        odd = (((self.time_original - phase * (self.period) - self.period * 0.5) / (self.period * 2)) % 1) < 0.5
-        return odd
+        odd_mask = (((self.time_original - self.time * (self.period) - self.period * 0.5) / (self.period * 2)) % 1) < 0.5
+        return odd_mask
 
     @property
-    def even(self):
+    def even_mask(self):
         ''' Mask to show only even numbered transits/oscillations. '''
-        return ~self.odd
+        return ~self.odd_mask
 
     def plot(self, **kwargs):
         """Plot the folded light curve using matplotlib's

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -210,6 +210,12 @@ def test_lightcurve_fold():
     assert (ax.get_xlabel() == 'Phase')
     plt.close('all')
 
+
+    odd = fold.odd
+    even = fold.even
+    assert len(odd) == len(fold.time)
+    assert np.all(odd == ~even)
+    assert np.sum(odd) == np.sum(even)
     # bad transit midpoint should give a warning
     # if user tries a t0 in JD but time is in BKJD
     with pytest.warns(LightkurveWarning, match='appears to be given in JD'):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -211,8 +211,8 @@ def test_lightcurve_fold():
     plt.close('all')
 
 
-    odd = fold.odd
-    even = fold.even
+    odd = fold.odd_mask
+    even = fold.even_mask
     assert len(odd) == len(fold.time)
     assert np.all(odd == ~even)
     assert np.sum(odd) == np.sum(even)


### PR DESCRIPTION
With folded light curves, it's often useful to see odd and even transits. This can be used to see if the signal is a planet or an eclipsing binary. It's also useful to compare the shape of odd and even transits.

I've added two attributes to `FoldedLightCurve`: `odd` and `even` which returns a mask of booleans. You use it to index the folded light curve.

```
f = lc.fold(...)
f[f.odd].scatter()
f[f.even].scatter()
```

Here's a demo:

![image](https://user-images.githubusercontent.com/14965634/52313510-a21fb980-2963-11e9-9f03-e8cbbad61b85.png)

