### PR TITLE
Make `BoxLeastSquaresPeriodogram` robust against NaNs

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -752,7 +752,14 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         except ImportError:
             raise Exception("BLS requires AstroPy v3.1 or later")
 
-        bls = BoxLeastSquares(lc.time, lc.flux, lc.flux_err)
+        # BoxLeastSquares will not work if flux or flux_err contain NaNs
+        lc = lc.remove_nans()
+        if np.isfinite(lc.flux_err).all():
+            dy = lc.flux_err
+        else:
+            dy = None
+
+        bls = BoxLeastSquares(lc.time, lc.flux, dy)
         duration = kwargs.pop("duration", 0.25)
         if hasattr(duration, '__iter__'):
             raise ValueError('`duration` must be a single value.')

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -224,6 +224,7 @@ def test_bls(caplog):
     assert isinstance(p.depth_at_max_power, float)
 
 
+@pytest.mark.skipif(bad_optional_imports, reason="requires astropy.stats.bls")
 def test_bls_period_recovery():
     """Can BLS Periodogram recover the period of a synthetic light curve?"""
     # Planet parameters

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -225,31 +225,33 @@ def test_bls(caplog):
 
 
 def test_bls_period_recovery():
-    """Create a synthetic light curve and try to recover the simulated period."""
+    """Can BLS Periodogram recover the period of a synthetic light curve?"""
     # Planet parameters
     period = 2.0
     transit_time = 0.5
     duration = 0.1
     depth = 0.2
     flux_err = 0.01
-    # Synthetic light curve
+
+    # Create the synthetic light curve
     time = np.arange(0, 100, 0.1)
     flux = np.ones_like(time)
     transit_mask = np.abs((time-transit_time+0.5*period) % period-0.5*period) < 0.5*duration
     flux[transit_mask] = 1.0 - depth
     flux += flux_err * np.random.randn(len(time))
     synthetic_lc = LightCurve(time, flux)
-    # Can we recover the period?
+
+    # Can BLS recover the period?
     bls_period = synthetic_lc.to_periodogram("bls").period_at_max_power
-    assert_almost_equal(bls_period, period)
+    assert_almost_equal(bls_period.value, period, decimal=2)
     # Does it work if we inject a sneaky NaN?
     synthetic_lc.flux[10] = np.nan
     bls_period = synthetic_lc.to_periodogram("bls").period_at_max_power
-    assert_almost_equal(bls_period, period)
+    assert_almost_equal(bls_period.value, period, decimal=2)
     # Does it work if all errors are NaNs?
     # This is a regression test for issue #428
     synthetic_lc.flux_err = np.array([np.nan] * len(time))
-    assert_almost_equal(bls_period, period)
+    assert_almost_equal(bls_period.value, period, decimal=2)
 
 
 def test_error_messages():


### PR DESCRIPTION
This PR ensures we avoid passing NaN `flux` or `flux_err` values to AstroPy's `BoxLeastSquare`.  It explains the funny behavior reported in #428.