### PR TITLE
Bugfix: `tpf.wcs` is invalid for TPF's produced using TessCut

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -213,27 +213,32 @@ class TargetPixelFile(object):
         w : astropy.wcs.WCS object
             WCS solution
         """
-        # Use WCS keywords of the 5th column (FLUX)
-        wcs_keywords = {'1CTYP5': 'CTYPE1',
-                        '2CTYP5': 'CTYPE2',
-                        '1CRPX5': 'CRPIX1',
-                        '2CRPX5': 'CRPIX2',
-                        '1CRVL5': 'CRVAL1',
-                        '2CRVL5': 'CRVAL2',
-                        '1CUNI5': 'CUNIT1',
-                        '2CUNI5': 'CUNIT2',
-                        '1CDLT5': 'CDELT1',
-                        '2CDLT5': 'CDELT2',
-                        '11PC5': 'PC1_1',
-                        '12PC5': 'PC1_2',
-                        '21PC5': 'PC2_1',
-                        '22PC5': 'PC2_2',
-                        'NAXIS1': 'NAXIS1',
-                        'NAXIS2': 'NAXIS2'}
-        mywcs = {}
-        for oldkey, newkey in wcs_keywords.items():
-            mywcs[newkey] = self.hdu[1].header[oldkey]
-        return WCS(mywcs)
+        # TPF's generated using the TESSCut service only seem to have
+        # a valid WCS in the header of the second extension
+        if 'MAST' in self.hdu[0].header['ORIGIN']:
+            return WCS(self.hdu[2])
+        else:
+            # For standard TPF files, we use the WCS keywords for the 5th data column (FLUX)
+            wcs_keywords = {'1CTYP5': 'CTYPE1',
+                            '2CTYP5': 'CTYPE2',
+                            '1CRPX5': 'CRPIX1',
+                            '2CRPX5': 'CRPIX2',
+                            '1CRVL5': 'CRVAL1',
+                            '2CRVL5': 'CRVAL2',
+                            '1CUNI5': 'CUNIT1',
+                            '2CUNI5': 'CUNIT2',
+                            '1CDLT5': 'CDELT1',
+                            '2CDLT5': 'CDELT2',
+                            '11PC5': 'PC1_1',
+                            '12PC5': 'PC1_2',
+                            '21PC5': 'PC2_1',
+                            '22PC5': 'PC2_2',
+                            'NAXIS1': 'NAXIS1',
+                            'NAXIS2': 'NAXIS2'}
+            mywcs = {}
+            for oldkey, newkey in wcs_keywords.items():
+                mywcs[newkey] = self.hdu[1].header[oldkey]
+            return WCS(mywcs)
 
     @classmethod
     def from_fits(cls, path_or_url, **kwargs):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -213,12 +213,15 @@ class TargetPixelFile(object):
         w : astropy.wcs.WCS object
             WCS solution
         """
-        # TPF's generated using the TESSCut service only seem to have
-        # a valid WCS in the header of the second extension
-        if 'MAST' in self.hdu[0].header['ORIGIN']:
+        if 'MAST' in self.hdu[0].header['ORIGIN']:  # Is it a TessCut TPF?
+            # TPF's generated using the TESSCut service in early 2019 only appear
+            # to contain a valid WCS in the second extension (the aperture
+            # extension), so we treat such files as a special case.
             return WCS(self.hdu[2])
         else:
-            # For standard TPF files, we use the WCS keywords for the 5th data column (FLUX)
+            # For standard (Ames-pipeline-produced) TPF files, we use the WCS
+            # keywords provided in the first extension (the data table extension).
+            # Specifically, we use the WCS keywords for the 5th data column (FLUX).
             wcs_keywords = {'1CTYP5': 'CTYPE1',
                             '2CTYP5': 'CTYPE2',
                             '1CRPX5': 'CRPIX1',

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -124,10 +124,10 @@ def test_search_tesscut_download():
     assert(isinstance(tpf, TessTargetPixelFile))
     # Ensure default size is 5x5
     assert(tpf.flux[0].shape == (5, 5))
-    # Ensure the WCS is valid
-    wcs_ra, wcs_dec = tpf.wcs.pixel_to_world_values([[2, 2]])[0]
-    assert_almost_equal(ra, wcs_ra, decimal=1)
-    assert_almost_equal(dec, wcs_dec, decimal=1)
+    # Ensure the WCS is valid (#434 regression test)
+    center_ra, center_dec = tpf.wcs.all_pix2world([[2.5, 2.5]], 1)[0]
+    assert_almost_equal(ra, center_ra, decimal=1)
+    assert_almost_equal(dec, center_dec, decimal=1)
     # Download with different dimensions
     tpfc = search_string.download_all(cutout_size=4)
     assert(isinstance(tpfc, TargetPixelFileCollection))

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -116,13 +116,18 @@ def test_search_tesscut():
 @pytest.mark.skipif(sys.version[2] == '7', reason="GitHub issue #433")
 def test_search_tesscut_download():
     """Can we download TESS cutouts via `search_cutout().download()?"""
-    search_string = search_tesscut('30.578761, -83.210593')
+    ra, dec = 30.578761, -83.210593
+    search_string = search_tesscut('{}, {}'.format(ra, dec))
     # Make sure they can be downloaded with default size
     tpf = search_string.download()
     # Ensure the correct object has been read in
     assert(isinstance(tpf, TessTargetPixelFile))
     # Ensure default size is 5x5
     assert(tpf.flux[0].shape == (5, 5))
+    # Ensure the WCS is valid
+    wcs_ra, wcs_dec = tpf.wcs.pixel_to_world_values([[2, 2]])[0]
+    assert_almost_equal(ra, wcs_ra, decimal=1)
+    assert_almost_equal(dec, wcs_dec, decimal=1)
     # Download with different dimensions
     tpfc = search_string.download_all(cutout_size=4)
     assert(isinstance(tpfc, TargetPixelFileCollection))

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -113,7 +113,7 @@ def test_search_tesscut():
 
 # See issue #433 to understand why this test is skipped on Python 3.7 for now
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.version_info.minor == '7', reason="GitHub issue #433")
+@pytest.mark.skipif(sys.version_info.minor == 7, reason="GitHub issue #433")
 def test_search_tesscut_download():
     """Can we download TESS cutouts via `search_cutout().download()?"""
     ra, dec = 30.578761, -83.210593


### PR DESCRIPTION
In #124 we discovered that the `TargetPixelFile.wcs` property is invalid for TPFs produced using the TessCut service, which presently only populates a valid WCS in the second (aperture) extension but not the first (data table) extension.

This PR makes `TargetPixelFile` resilient against this issue and adds a regression test.