### PR TITLE
Ensure all sectors are returned by `download_all()` for tesscut

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -877,8 +877,7 @@ def open(path_or_url, **kwargs):
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
     # pass header into `detect_filetype()`
-    with fits.open(path_or_url) as temp:
-        filetype = detect_filetype(temp[0].header)
+    filetype = detect_filetype(fits.open(path_or_url)[0].header)
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -287,10 +287,20 @@ class SearchResult(object):
         elif cutout_size > 100:
             warnings.warn('Cutout size is large and may take a few minutes to download.')
 
+        # Check existence of `~/.lightkurve-cache/tesscut`
+        tesscut_dir = os.path.join(download_dir, 'tesscut')
+        if not os.path.isdir(tesscut_dir):
+            # if it doesn't exist, make a new cache directory
+            try:
+                os.mkdir(tesscut_dir)
+            # downloads into default cache if OSError occurs
+            except OSError:
+                tesscut_dir = download_dir
+
         # Resolve SkyCoord of given target
         coords = MastClass()._resolve_object(target)
         cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
-                                                      sector=sector, path=download_dir)
+                                                      sector=sector, path=tesscut_dir)
 
         path = os.path.join(download_dir, cutout_path[0][0])
         return path

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -289,7 +289,6 @@ class SearchResult(object):
 
         # Resolve SkyCoord of given target
         coords = MastClass()._resolve_object(target)
-        sector = self.table[0]['sequence_number']
         cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
                                                       sector=sector, path=download_dir)
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -878,7 +878,8 @@ def open(path_or_url, **kwargs):
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
     # pass header into `detect_filetype()`
-    filetype = detect_filetype(fits.open(path_or_url)[0].header)
+    with fits.open(path_or_url) as temp:
+        filetype = detect_filetype(temp[0].header)
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:


### PR DESCRIPTION
**Bugfix!** 

`download_all()` failed to download all cutouts returned by `search_tesscut()`, and instead downloaded the first element of the `SearchResult` table _n_ times for a table with _n_ rows. With this PR, all search results will be downloaded.