### PR TITLE
Support rectangular TESS FFI cutouts

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -282,10 +282,6 @@ class SearchResult(object):
         # Enforce bounds on cutout_size
         if cutout_size is None:
             cutout_size = 5
-        elif cutout_size <= 0:
-            raise ValueError('`cutout_size` must be positive.')
-        elif cutout_size > 100:
-            warnings.warn('Cutout size is large and may take a few minutes to download.')
 
         # Resolve SkyCoord of given target
         coords = MastClass()._resolve_object(target)

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -118,8 +118,9 @@ class SearchResult(object):
         download_dir : str
             Location where the data files will be stored.
             Defaults to "~/.lightkurve-cache" if `None` is passed.
-        cutout_size : int or float
-            Side length of cutout in pixels. Default value is 5.
+        cutout_size : int, float or tuple
+            Side length of cutout in pixels. Tuples should have dimensions (y, x).
+            Default size is (5, 5)
 
         Returns
         -------
@@ -189,8 +190,9 @@ class SearchResult(object):
         download_dir : str
             Location where the data files will be stored.
             Defaults to "~/.lightkurve-cache" if `None` is passed.
-        cutout_size : int or float
-            Side length of cutout in pixels. Default value is 5.
+        cutout_size : int, float or tuple
+            Side length of cutout in pixels. Tuples should have dimensions (y, x).
+            Default size is (5, 5)
 
         Returns
         -------
@@ -267,8 +269,9 @@ class SearchResult(object):
         download_dir : str
             Path to location of `.lightkurve-cache` directory where downloaded
             cutouts are stored
-        cutout_size : int or float
-            Side length of cutout in pixels
+        cutout_size : int, float or tuple
+            Side length of cutout in pixels. Tuples should have dimensions (y, x).
+            Default size is (5, 5)
 
         Returns
         -------
@@ -279,7 +282,7 @@ class SearchResult(object):
         from astroquery.mast.core import MastClass
         coords = MastClass()._resolve_object(target)
 
-        # Enforce bounds on cutout_size
+        # Set cutout_size defaults
         if cutout_size is None:
             cutout_size = 5
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -133,6 +133,9 @@ def test_search_tesscut_download():
     assert(isinstance(tpfc, TargetPixelFileCollection))
     # Ensure correct dimensions
     assert(tpfc[0].flux[0].shape == (4, 4))
+    # Download with rectangular dimennsions?
+    rect_tpf = search_string.download(cutout_size=(3,5))
+    assert(rect_tpf.flux[0].shape == (3,5))
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
**By popular demand!** `search_tesscut()` now support rectangular cutouts with the following syntax:

```python
import lightkurve as lk
search_tesscut('pi Men').download(cutout_size=(4,10))
```