### PR TITLE
Bugfix: Allow `SearchResult` objects to be indexed with -1

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -56,6 +56,10 @@ class SearchResult(object):
 
     def __getitem__(self, key):
         """Implements indexing and slicing, e.g. SearchResult[2:5]."""
+        # this check is necessary due to an astropy bug
+        # for more information, see issue #445
+        if key == -1:
+            key = len(self.table) - 1
         selection = self.table[key]
         # Indexing a Table with an integer will return a Row
         if isinstance(selection, Row):

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -51,13 +51,14 @@ def test_search_targetpixelfile():
         cc = search_targetpixelfile(idx, campaign=c[2]).table
         assert(len(cc) == 2)
     search_targetpixelfile(11904151, quarter=11).download()
-
     # with mission='TESS', it should return TESS observations
     tic = 273985862
     assert(len(search_targetpixelfile(tic, mission='TESS').table) == 1)
     assert(len(search_targetpixelfile(tic, mission='TESS', radius=100).table) == 2)
     search_targetpixelfile(tic, mission='TESS').download()
     assert(len(search_targetpixelfile("pi Mensae", sector=1).table) == 1)
+    # Issue #445: indexing with -1 should return the last index of the search result
+    assert(len(search_targetpixelfile("pi Men")[-1] == 1))
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -58,7 +58,7 @@ def test_search_targetpixelfile():
     search_targetpixelfile(tic, mission='TESS').download()
     assert(len(search_targetpixelfile("pi Mensae", sector=1).table) == 1)
     # Issue #445: indexing with -1 should return the last index of the search result
-    assert(len(search_targetpixelfile("pi Men")[-1] == 1))
+    assert(len(search_targetpixelfile("pi Men")[-1]) == 1)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
Due to [astropy/astropy#8422](https://github.com/astropy/astropy/pull/8422), the following example returns an empty `SearchResult` instead of a table with one line:
```python
import lightkurve as lk
t = lk.search_targetpixelfile("Kepler-10")
t[-1]
```
This PR fixes #445 and adds tests to ensure that the returned table is not empty.