### PR TITLE
Fixed scaling issue in periodogram logmedian smoothing

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -159,7 +159,7 @@ class Periodogram(object):
 
         Periodograms that are unsmoothed have multiplicative noise that is
         distributed as chi squared 2 degrees of freedom.  This noise
-        distirbution has a well defined mean and median but the two are not
+        distribution has a well defined mean and median but the two are not
         equivalent.  The mean of a chi squared 2 dof distribution is 2, but the
         median is 2(8/9)**3.
         (see https://en.wikipedia.org/wiki/Chi-squared_distribution)

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -157,6 +157,25 @@ class Periodogram(object):
         where `filter width` is in log10(frequency) space. This is best for
         estimating the noise background, as it filters over the seismic peaks.
 
+        Periodograms that are unsmoothed have multiplicative noise that is
+        distributed as chi squared 2 degrees of freedom.  This noise
+        distirbution has a well defined mean and median but the two are not
+        equivalent.  The mean of a chi squared 2 dof distribution is 2, but the
+        median is 2(8/9)**3.
+        (see https://en.wikipedia.org/wiki/Chi-squared_distribution)
+        In order to maintain consistency between 'boxkernel' and 'logmedian' a
+        correction factor of (8/9)**3 is applied to (i.e., the median is divided
+        by the factor) to the median values.
+
+        In addition to consistency with the 'boxkernel' method, the correction
+        of the median values is useful when applying the periodogram flatten
+        method.  The flatten method divides the periodgram by the smoothed
+        periodogram using the 'logmedian' method.  By appyling the correction
+        factor we follow asteroseismic convention that the signal-to-noise
+        power has a mean value of unity.  (note the signal-to-noise power is
+        really the signal plus noise divided by the noise and hence should be
+        unity in the absence of any signal)
+
         Parameters
         ----------
         method : str, one of 'boxkernel' or 'logmedian'
@@ -207,8 +226,6 @@ class Periodogram(object):
             count = np.zeros(len(self.frequency.value), dtype=int)
             bkg = np.zeros_like(self.frequency.value)
             x0 = np.log10(self.frequency[0].value)
-            # The median of chi squared 2 dof noise is 2(8/9)**3 where as the
-            # mean is 2.  To correct for this we divide the median by (8/9)**3
             corr_factor = (8.0/9.0)**3
             while x0 < np.log10(self.frequency[-1].value):
                 m = np.abs(np.log10(self.frequency.value) - x0) < filter_width

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -207,10 +207,13 @@ class Periodogram(object):
             count = np.zeros(len(self.frequency.value), dtype=int)
             bkg = np.zeros_like(self.frequency.value)
             x0 = np.log10(self.frequency[0].value)
+            # The median of chi squared 2 dof noise is 2(8/9)**3 where as the
+            # mean is 2.  To correct for this we divide the median by (8/9)**3
+            corr_factor = (8.0/9.0)**3
             while x0 < np.log10(self.frequency[-1].value):
                 m = np.abs(np.log10(self.frequency.value) - x0) < filter_width
                 if len(bkg[m] > 0):
-                    bkg[m] += np.nanmedian(self.power[m].value)
+                    bkg[m] += np.nanmedian(self.power[m].value) / corr_factor
                     count[m] += 1
                 x0 += 0.5 * filter_width
             bkg /= count

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -226,7 +226,7 @@ class Periodogram(object):
             count = np.zeros(len(self.frequency.value), dtype=int)
             bkg = np.zeros_like(self.frequency.value)
             x0 = np.log10(self.frequency[0].value)
-            corr_factor = (8.0/9.0)**3
+            corr_factor = (8.0 / 9.0)**3
             while x0 < np.log10(self.frequency[-1].value):
                 m = np.abs(np.log10(self.frequency.value) - x0) < filter_width
                 if len(bkg[m] > 0):

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -134,8 +134,8 @@ def test_smooth():
     with pytest.raises(ValueError) as err:
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
-    # Check logmedian smooth returns mean of unity
-    assert np.abs(p.smooth().power - 1.0) < 0.05
+    # Check logmedian smooth that the mean of the smoothed power should be consistent with the mean of the power
+    assert np.isclose(np.mean(p.smooth(method='logmedian').power), np.mean(p.power), atol=0.05)
 
 
 def test_flatten():
@@ -148,8 +148,9 @@ def test_flatten():
     assert all(p.flatten(method='logmedian').frequency == p.frequency)
     assert all(p.flatten(method='boxkernel').frequency == p.frequency)
 
-    # Check logmedian flatten returns mean of unity
-    assert np.abs(p.flatten(method='logmedian').power - 1.0) < 0.05
+    # Check logmedian flatten of white noise returns mean of ~unity
+    assert np.isclose(np.mean(p.flatten(method='logmedian').power), 1.0,
+                      atol=0.05)
 
     # Check return trend works
     s, b = p.flatten(return_trend=True)

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -134,8 +134,10 @@ def test_smooth():
     with pytest.raises(ValueError) as err:
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
-    # Check logmedian smooth that the mean of the smoothed power should be consistent with the mean of the power
-    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value), np.mean(p.power.value), atol=0.05)
+    # Check logmedian smooth that the mean of the smoothed power should
+    # be consistent with the mean of the power
+    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value),
+                     np.mean(p.power.value), atol=0.05*np.mean(p.power.value))
 
 
 def test_flatten():

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -135,7 +135,7 @@ def test_smooth():
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
     # Check logmedian smooth that the mean of the smoothed power should be consistent with the mean of the power
-    assert np.isclose(np.mean(p.smooth(method='logmedian').power), np.mean(p.power), atol=0.05)
+    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value), np.mean(p.power), atol=0.05)
 
 
 def test_flatten():
@@ -149,7 +149,7 @@ def test_flatten():
     assert all(p.flatten(method='boxkernel').frequency == p.frequency)
 
     # Check logmedian flatten of white noise returns mean of ~unity
-    assert np.isclose(np.mean(p.flatten(method='logmedian').power), 1.0,
+    assert np.isclose(np.mean(p.flatten(method='logmedian').power.value), 1.0,
                       atol=0.05)
 
     # Check return trend works

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -135,7 +135,7 @@ def test_smooth():
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
     # Check logmedian smooth that the mean of the smoothed power should be consistent with the mean of the power
-    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value), np.mean(p.power), atol=0.05)
+    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value), np.mean(p.power.value), atol=0.05)
 
 
 def test_flatten():

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -134,6 +134,9 @@ def test_smooth():
     with pytest.raises(ValueError) as err:
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
+    # Check logmedian smooth returns mean of unity
+    assert np.abs(p.smooth().power - 1.0) < 0.05
+
 
 def test_flatten():
     lc = LightCurve(time=np.arange(1000),
@@ -144,6 +147,9 @@ def test_flatten():
     # Check method returns equal frequency
     assert all(p.flatten(method='logmedian').frequency == p.frequency)
     assert all(p.flatten(method='boxkernel').frequency == p.frequency)
+
+    # Check logmedian flatten returns mean of unity
+    assert np.abs(p.flatten(method='logmedian').power - 1.0) < 0.05
 
     # Check return trend works
     s, b = p.flatten(return_trend=True)

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -106,6 +106,7 @@ def test_bin():
 def test_smooth():
     """Test if you can smooth the periodogram and check any pitfalls
     """
+    np.random.seed(42)
     lc = LightCurve(time=np.arange(1000),
                     flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
@@ -115,6 +116,12 @@ def test_smooth():
     assert all(p.smooth(method='logmedian').frequency == p.frequency)
     # Check output units
     assert p.smooth().power.unit == p.power.unit
+
+    # Check logmedian smooth that the mean of the smoothed power should
+    # be consistent with the mean of the power
+    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value),
+                     np.mean(p.power.value), atol=0.05*np.mean(p.power.value))
+
 
     # Can't pass filter_width below 0.
     with pytest.raises(ValueError) as err:
@@ -134,16 +141,15 @@ def test_smooth():
     with pytest.raises(ValueError) as err:
         p.smooth(method='logmedian',  filter_width=5.*u.day)
 
-    # Check logmedian smooth that the mean of the smoothed power should
-    # be consistent with the mean of the power
-    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value),
-                     np.mean(p.power.value), atol=0.05*np.mean(p.power.value))
+
 
 
 def test_flatten():
-    lc = LightCurve(time=np.arange(1000),
-                    flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    npts = 10000
+    np.random.seed(12069424)
+    lc = LightCurve(time=np.arange(npts),
+                    flux=np.random.normal(1, 0.1, npts),
+                    flux_err=np.zeros(npts)+0.1)
     p = lc.to_periodogram()
 
     # Check method returns equal frequency


### PR DESCRIPTION
The logmedian smoothing of data with noise properties of chi^2 2 dof was producing an offset wrt the boxkernel.  The problem was that the median of the chi^2_2 distribution is 2(8/9)**3 where as the mean is 2.  I added the correction factor in periodogram.smooth and this seemed to fix the scaling issue with the flattened periodogram at the same time,

I added a suggestion for two tests to check the scaling.