### PR TITLE
Fixed NaN plotting in tpf.plot()

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -412,9 +412,9 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
     norm = None
     if scale is not None:
         if scale == 'linear':
-            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch())
+            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch(), clip=False)
         elif scale == 'sqrt':
-            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch())
+            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch(), clip=False)
         elif scale == 'log':
             # To use log scale we need to guarantee that vmin > 0, so that
             # we avoid division by zero and/or negative values.
@@ -422,7 +422,6 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
                            clip=True)
         else:
             raise ValueError("scale {} is not available.".format(scale))
-
     cax = ax.imshow(image, origin=origin, norm=norm, **kwargs)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)


### PR DESCRIPTION
NaNs in the `tpf.flux` array were being rendered as high intensity pixels in the `tpf.plot` method.
![image](https://user-images.githubusercontent.com/14965634/53133030-9668f100-3526-11e9-9390-c7d188f6e907.png)

I've added a simple fix so they now render as white and are more clearly pixels with no data.
![image](https://user-images.githubusercontent.com/14965634/53133016-8c46f280-3526-11e9-9719-5ed0dada731a.png)
