### PR TITLE
Add `to_timeseries` and `from_timeseries` to support AstroPy TimeSeries objects

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -962,9 +962,33 @@ class LightCurve(object):
         table : `astropy.table.Table`
             An AstroPy Table with columns 'time', 'flux', and 'flux_err'.
         """
-        return Table(data=(self.time, self.flux, self.flux_err),
-                     names=('time', 'flux', 'flux_err'),
-                     meta=self.meta)
+        tbl = Table.from_pandas(self.to_pandas())
+        tbl['time'] = self.astropy_time  # Ensure 'time' is an AstroPy `Time` object
+        tbl.meta = self.meta
+        return tbl
+
+    def to_timeseries(self):
+        """Converts the light curve to an `~astropy_timeseries.TimeSeries` object.
+
+        This is an experimental feature which depends on the placeholder
+        `astropy_timeseries` package (https://astropy-timeseries.readthedocs.io).
+        This package will likely be merged into AstroPy in the near future.
+
+        Returns
+        -------
+        timeseries : `~astropy_timeseries.TimeSeries`
+            An AstroPy TimeSeries object.
+        """
+        from astropy_timeseries import TimeSeries
+        return TimeSeries(self.to_table())
+
+    @staticmethod
+    def from_timeseries(ts):
+        """Create a new `LightCurve` from an `~astropy_timeseries.TimeSeries` object.
+
+        Note: `ts` must have 'time', 'flux', and 'flux_err' columns
+        """
+        return LightCurve(time=ts['time'].value, flux=ts['flux'], flux_err=ts['flux_err'])
 
     def to_pandas(self, columns=['time', 'flux', 'flux_err']):
         """Converts the light curve to a Pandas `~pandas.DataFrame` object.

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -969,25 +969,32 @@ class LightCurve(object):
         return tbl
 
     def to_timeseries(self):
-        """Converts the light curve to an `~astropy_timeseries.TimeSeries` object.
+        """Converts the light curve to an `~astropy.timeseries.TimeSeries` object.
 
-        This is an experimental feature which depends on the placeholder
-        `astropy_timeseries` package (https://astropy-timeseries.readthedocs.io).
-        This package will likely be merged into AstroPy in the near future.
+        This feature requires AstroPy v3.2 or later (released in 2019).
+        An `ImportError` will be raised if this version is not available.
 
         Returns
         -------
-        timeseries : `~astropy_timeseries.TimeSeries`
+        timeseries : `~astropy.timeseries.TimeSeries`
             An AstroPy TimeSeries object.
         """
-        from astropy_timeseries import TimeSeries
+        try:
+            from astropy.timeseries import TimeSeries
+        except ImportError:
+            raise ImportError("You need to install AstroPy v3.2 or later to "
+                              "use the LightCurve.to_timeseries() method.")
         return TimeSeries(self.to_table())
 
     @staticmethod
     def from_timeseries(ts):
-        """Create a new `LightCurve` from an `~astropy_timeseries.TimeSeries` object.
+        """Create a new `LightCurve` from an `~astropy.timeseries.TimeSeries`.
 
-        Note: `ts` must have 'time', 'flux', and 'flux_err' columns
+        Parameters
+        ----------
+        ts : `~astropy.timeseries.TimeSeries`
+            An AstroPy TimeSeries object.  The object must contain columns
+            named 'time', 'flux', and 'flux_err'.
         """
         return LightCurve(time=ts['time'].value, flux=ts['flux'], flux_err=ts['flux_err'])
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -963,7 +963,8 @@ class LightCurve(object):
             An AstroPy Table with columns 'time', 'flux', and 'flux_err'.
         """
         tbl = Table.from_pandas(self.to_pandas())
-        tbl['time'] = self.astropy_time  # Ensure 'time' is an AstroPy `Time` object
+        if self.time_format is not None:
+            tbl['time'] = self.astropy_time  # Ensure 'time' is an AstroPy `Time` object
         tbl.meta = self.meta
         return tbl
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -752,3 +752,17 @@ def test_new_corrector_api():
         lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
     lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
     assert_allclose(lc1.flux, lc2.flux)
+
+
+def test_to_timeseries():
+    """Test the `LightCurve.to_timeseries()` method."""
+    time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
+    lc = LightCurve(time, flux, flux_err)
+    try:
+        ts = lc.to_timeseries()
+        assert_allclose(ts.time, time)
+        assert_allclose(ts.flux, flux)
+        assert_allclose(ts.flux_err, flux_err)
+    except ImportError:
+        # Requires AstroPy v3.2 or later
+        pass


### PR DESCRIPTION
This PR adds the `LightCurve.to_timseries()` and `LightCurve.from_timeseries()` methods to work with the prototype `TimeSeries` objects which are being developed as part of AstroPy ([link](https://astropy-timeseries.readthedocs.io)).

Example:
```Python
import lightkurve as lk
lc = lk.LightCurve(time=[50001, 50002, 50003], flux=[1, 2, 3], time_format='mjd')
lc.to_timeseries()
```

For a demo, see this Notebook gist: https://gist.github.com/barentsen/1a938ede20bd26ce3dca74637d8b1aee

/cc @astrofrog @gully 