### PR TITLE
Improving PLD

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
   - "ECHO %PATH%"
   - where conda
   - conda config --set always_yes yes --set changeps1 no
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy astropy scipy matplotlib requests tqdm pandas bokeh ipython scikit-learn pybind11 pytest pytest-cov pytest-remotedata"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy astropy scipy matplotlib requests tqdm pandas bokeh ipython pybind11 pytest pytest-cov pytest-remotedata"
   - activate test-environment
   - python setup.py develop
 

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -669,9 +669,9 @@ class PLDCorrector(object):
         X1 = f1 / np.sum(pld_flux, axis=-1)[:, None]
 
         # second order PLD design matrix
-        # f2 = np.reshape(X1[:, None, :] * X1[:, :, None], (len(flux_crop), -1))
-        # pca, _, _ = np.linalg.svd(f2, full_matrices=False)
-        # X2 = pca[:, :X1.shape[1]]
+        f2 = np.reshape(X1[:, None, :] * X1[:, :, None], (len(flux_crop), -1))
+        pca, _, _ = np.linalg.svd(f2, full_matrices=False)
+        X2 = pca[:, :X1.shape[1]]
 
         # Create the design matrix X by stacking X1 and X2 and adding a column
         # vector of 1s for numerical stability (see Luger et al.).

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -628,7 +628,7 @@ class PLDCorrector(object):
             Higher order populates the design matrix with columns constructed
             from the products of pixel fluxes.
         n_pca_terms : int
-            Number of terms to add to the design matrix from each order of PLD
+            Number of terms added to the design matrix from each order of PLD
             when performing Principle Component Analysis for models higher than
             first order. Increasing this value may provide higher precision at
             the expense of computational time.
@@ -684,6 +684,7 @@ class PLDCorrector(object):
         for i in range(2, pld_order+1):
             f2 = np.product(list(multichoose(X1.T, pld_order)), axis=1).T
             try:
+                # optionally dependency for PCA
                 from fbpca import pca
                 components, _, _ = pca(f2, n_pca_terms)
             except ImportError:
@@ -696,7 +697,7 @@ class PLDCorrector(object):
 
         # Create the design matrix X by stacking X1 and higher order components, and
         # adding a column vector of 1s for numerical stability (see Luger et al.).
-        # X has shape (n_components_first + n_components_second + 1, n_cadences)
+        # X has shape (n_components_first + n_components_higher_order + 1, n_cadences)
         X = np.concatenate(X_sections, axis=1)
 
         # set default transit mask
@@ -747,7 +748,7 @@ class PLDCorrector(object):
         else:
             # compute the coefficients C on the basis vectors;
             # the PLD design matrix will be dotted with C to solve for the noise model.
-            ivar = 1.0 / M(rawflux_err)**2
+            ivar = 1.0 / M(rawflux_err)**2 # inverse variance
             A = np.dot(MX.T, MX * ivar[:, None])
             B = np.dot(MX.T, M(rawflux) * ivar)
 

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -641,14 +641,15 @@ class PLDCorrector(object):
             returned object will be a `KeplerLightCurve`, `TessLightCurve`, or
             general `LightCurve` object.
         """
-        # Verify optional dependencies
-        try:
-            import celerite
-        except ImportError:
-            log.error("PLD requires the `celerite` Python package. "
-                      "See the installation instructions at "
-                      "https://docs.lightkurve.org/about/install.html")
-            return None
+        if use_gp:
+            # Verify optional dependency
+            try:
+                import celerite
+            except ImportError:
+                log.error("PLD requires the `celerite` Python package. "
+                          "See the installation instructions at "
+                          "https://docs.lightkurve.org/about/install.html")
+                use_gp = False
 
         # Parse the aperture mask to accept strings etc.
         aperture = self.tpf._parse_aperture_mask(aperture_mask)

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -629,7 +629,7 @@ class PLDCorrector(object):
             from the products of pixel fluxes.
         n_pca_terms : int
             Number of terms added to the design matrix from each order of PLD
-            when performing Principle Component Analysis for models higher than
+            when performing Principal Component Analysis for models higher than
             first order. Increasing this value may provide higher precision at
             the expense of computational time.
 

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -16,6 +16,7 @@ import oktopus
 import numpy as np
 from scipy import linalg, interpolate
 from matplotlib import pyplot as plt
+from fbpca import pca
 
 from astropy.io import fits as pyfits
 from astropy.stats import sigma_clip
@@ -675,8 +676,8 @@ class PLDCorrector(object):
         nterms = 10
         for i in range(2, pld_order+1):
             f2 = np.product(list(multichoose(X1.T, pld_order)), axis=1).T
-            pca, _, _ = np.linalg.svd(f2)
-            X_n = pca[:, :nterms]
+            components, _, _ = pca(f2, 10)
+            X_n = components[:, :nterms]
             X_sections.append(X_n)
 
         # Create the design matrix X by stacking X1 and higher order components, and

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -16,7 +16,6 @@ import oktopus
 import numpy as np
 from scipy import linalg, interpolate
 from matplotlib import pyplot as plt
-from fbpca import pca
 
 from astropy.io import fits as pyfits
 from astropy.stats import sigma_clip
@@ -646,9 +645,10 @@ class PLDCorrector(object):
             try:
                 import celerite
             except ImportError:
-                log.error("PLD requires the `celerite` Python package. "
+                log.error("PLD uses the `celerite` Python package. "
                           "See the installation instructions at "
-                          "https://docs.lightkurve.org/about/install.html")
+                          "https://docs.lightkurve.org/about/install.html. "
+                          "`use_gp` has been set to `False`.")
                 use_gp = False
 
         # Parse the aperture mask to accept strings etc.
@@ -683,7 +683,14 @@ class PLDCorrector(object):
         X_sections = [np.ones((len(flux_crop), 1)), X1]
         for i in range(2, pld_order+1):
             f2 = np.product(list(multichoose(X1.T, pld_order)), axis=1).T
-            components, _, _ = pca(f2, n_pca_terms)
+            try:
+                from fbpca import pca
+                components, _, _ = pca(f2, n_pca_terms)
+            except ImportError:
+                log.error("PLD uses the `fbpca` package. You can pip install "
+                          "with `pip install fbpca`. Using `np.linalg.svd` "
+                          "instead.")
+                components, _, _ = np.linalg.svd(f2)
             X_n = components[:, :n_pca_terms]
             X_sections.append(X_n)
 

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -684,7 +684,8 @@ class PLDCorrector(object):
         for i in range(2, pld_order+1):
             f2 = np.product(list(multichoose(X1.T, pld_order)), axis=1).T
             try:
-                # optionally dependency for PCA
+                # We use an optional dependency for very fast PCA (fbpca).
+                # If the import fails we will fall back on using the slower `np.linalg.svd`
                 from fbpca import pca
                 components, _, _ = pca(f2, n_pca_terms)
             except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bs4
 requests
 tqdm
 pandas
+fbpca

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ bs4
 requests
 tqdm
 pandas
-fbpca

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata']
 # `PLDCorrector` requires pybind11, celerite.
 extras_require = {"all":  ["astropy>=3.1",
                            "bokeh>=1.0", "ipython",
-                           "pybind11", "celerite"],
+                           "pybind11", "celerite", "fbpca"],
                   "test": tests_require}
 
 setup(name='lightkurve',

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata']
 # 3. What dependencies are required for optional features?
 # `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.
-# `PLDCorrector` requires scikit-learn, pybind11, celerite.
+# `PLDCorrector` requires pybind11, celerite.
 extras_require = {"all":  ["astropy>=3.1",
                            "bokeh>=1.0", "ipython",
-                           "scikit-learn", "pybind11", "celerite"],
+                           "pybind11", "celerite"],
                   "test": tests_require}
 
 setup(name='lightkurve',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata']
 # 3. What dependencies are required for optional features?
 # `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.
-# `PLDCorrector` requires pybind11, celerite.
+# `PLDCorrector` requires pybind11, celerite, fbpca.
 extras_require = {"all":  ["astropy>=3.1",
                            "bokeh>=1.0", "ipython",
                            "pybind11", "celerite", "fbpca"],


### PR DESCRIPTION
With the help of @dfm, this PR makes a few changes to speed up the `PLDCorrector` class.

 - Remove deprecated dependencies
 - Remove `np.diag` assignment
 - Consolidate redundant calculation of `sigma`
 - replace `np.linalg.solve` with `scipy.linalg.cho_solve`