### PR TITLE
Prevent `search_tesscut` from crashing upon an empty SearchResult

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -584,8 +584,11 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
                                 'distance': 0.0,
                                 'sequence_number': s}
                                )
-        masked_result = Table(cutouts)
-        masked_result.sort(['distance', 'sequence_number'])
+        if len(cutouts) > 0:
+            masked_result = Table(cutouts)
+            masked_result.sort(['distance', 'sequence_number'])
+        else:
+            masked_result = None
         return SearchResult(masked_result)
 
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -303,8 +303,8 @@ def test_open():
 
 def test_issue_472():
     """Regression test for https://github.com/KeplerGO/lightkurve/issues/472"""
-    # The line below previously threw an exception;
-    # we're expecting an empty SearchResult instead:
+    # The line below previously threw an exception because the target was not
+    # observed in Sector 2; we're expecting an empty SearchResult instead.
     search = search_tesscut("TIC41336498", sector=2)
     assert isinstance(search, SearchResult)
     len(search) == 0

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -299,3 +299,12 @@ def test_open():
     assert(isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile))
     # Can open take a quality_bitmask argument?
     assert(open(k2_path, quality_bitmask='hard').quality_bitmask == 'hard')
+
+
+def test_issue_472():
+    """Regression test for https://github.com/KeplerGO/lightkurve/issues/472"""
+    # The line below previously threw an exception;
+    # we're expecting an empty SearchResult instead:
+    search = search_tesscut("TIC41336498", sector=2)
+    assert isinstance(search, SearchResult)
+    len(search) == 0


### PR DESCRIPTION
This PR addresses #472.