### PR TITLE
[WIP] Add a `TransitLeastSquaresPeriodogram` class

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1039,15 +1039,17 @@ class LightCurve(object):
 
         Parameters
         ----------
-        method : {'lombscargle', 'boxleastsquares', 'ls', 'bls'}
-            Use the Lomb Scargle or Box Least Squares (BLS) method to
-            extract the power spectrum. Defaults to ``'lombscargle'``.
-            ``'ls'`` and ``'bls'`` are shorthands for ``'lombscargle'``
-            and ``'boxleastsquares'``.
+        method : {'lombscargle', 'boxleastsquares', 'transitleastsquares',
+                  'ls', 'bls', 'tls'}
+            Use the Lomb Scargle, Box Least Squares (BLS), or Transit Least Squares (TLS)
+            method to extract the power spectrum. Defaults to ``'lombscargle'``.
+            ``'ls'``, ``'bls'``, and ``'tls'`` are shorthands for
+            ``'lombscargle'``, ``'boxleastsquares'``, and ``'transitleastsquares'``.
         kwargs : dict
-            Keyword arguments passed to either
-            `~lightkurve.periodogram.LombScarglePeriodogram` or
-            `~lightkurve.periodogram.BoxLeastSquaresPeriodogram`.
+            Keyword arguments passed to the constructor of either
+            `~lightkurve.periodogram.LombScarglePeriodogram`,
+            `~lightkurve.periodogram.BoxLeastSquaresPeriodogram`,
+            or `~lightkurve.periodogram.TransitLeastSquaresPeriodogram`.
 
         Returns
         -------
@@ -1055,7 +1057,8 @@ class LightCurve(object):
             The power spectrum object extracted from the light curve.
         """
         method_clean = method.replace(' ', '').lower()
-        allowed_methods = ["ls", "bls", "lombscargle", "boxleastsquares"]
+        allowed_methods = ["ls", "bls", "tls",
+                           "lombscargle", "boxleastsquares", "transitleastsquares"]
         if method_clean not in allowed_methods:
             raise ValueError(("Unrecognized method '{0}'\n"
                               "allowed methods are: {1}")
@@ -1063,6 +1066,9 @@ class LightCurve(object):
         if method_clean in ["bls", "boxleastsquares"]:
             from . import BoxLeastSquaresPeriodogram
             return BoxLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
+        elif method_clean in ["tls", "transitleastsquares"]:
+            from . import TransitLeastSquaresPeriodogram
+            return TransitLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
         else:
             from . import LombScarglePeriodogram
             return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)


### PR DESCRIPTION
This PR adds a `TransitLeastSquaresPeriodogram` class to add support for the new `transitleastsquares` package by @hippke (cf. #431 and [https://github.com/hippke/tls](https://github.com/hippke/tls)).

This is a work in progress.  Working demo showing BLS vs TLS:

![Screenshot from 2019-03-27 21-44-57](https://user-images.githubusercontent.com/817669/55125985-9df95800-50d9-11e9-9dd2-ccb994545b79.png)


