### PR TITLE
Ensure TessCut TPFs have a `targetid`

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -157,6 +157,10 @@ class SearchResult(object):
                 raise SearchError('Unable to download FFI cutout. Desired target '
                                   'coordinates may be too near the edge of the FFI.')
 
+            return open(path,
+                        quality_bitmask=quality_bitmask,
+                        targetid=self.table[0]['targetid'])
+
         else:
             if cutout_size is not None:
                 warnings.warn('`cutout_size` can only be specified for TESS '
@@ -165,8 +169,8 @@ class SearchResult(object):
             path = Observations.download_products(self.table[:1], mrp_only=False,
                                                   download_dir=download_dir)['Local Path'][0]
 
-        # open() will determine filetype and return
-        return open(path, quality_bitmask=quality_bitmask)
+            # open() will determine filetype and return
+            return open(path, quality_bitmask=quality_bitmask)
 
     @suppress_stdout
     def download_all(self, quality_bitmask='default', download_dir=None, cutout_size=None):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1408,10 +1408,11 @@ class TessTargetPixelFile(TargetPixelFile):
                           "observation.", LightkurveWarning)
 
         # Use the TICID keyword as the default targetid
-        try:
-            self.targetid = self.header['TICID']
-        except KeyError:
-            self.targetid = None
+        if self.targetid is None:
+            try:
+                self.targetid = self.header['TICID']
+            except KeyError:
+                pass
 
     def __repr__(self):
         return('TessTargetPixelFile(TICID: {})'.format(self.targetid))

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -114,7 +114,6 @@ def test_search_tesscut():
 
 # See issue #433 to understand why this test is skipped on Python 3.7 for now
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.version_info.minor == 7, reason="GitHub issue #433")
 def test_search_tesscut_download():
     """Can we download TESS cutouts via `search_cutout().download()?"""
     ra, dec = 30.578761, -83.210593
@@ -125,6 +124,8 @@ def test_search_tesscut_download():
     assert(isinstance(tpf, TessTargetPixelFile))
     # Ensure default size is 5x5
     assert(tpf.flux[0].shape == (5, 5))
+    # Ensure the tpf has a targetid (#473 regression test)
+    assert(len(tpf.targetid) > 0)
     # Ensure the WCS is valid (#434 regression test)
     center_ra, center_dec = tpf.wcs.all_pix2world([[2.5, 2.5]], 1)[0]
     assert_almost_equal(ra, center_ra, decimal=1)


### PR DESCRIPTION
This PR fixes #473. 