### PR TITLE
Rename min_period/max_period into minimum_period/maximum_period in `LombScarglePeriodogram`

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1029,13 +1029,13 @@ class LightCurve(object):
         which in turn wrap `astropy.stats.LombScargle` and `astropy.stats.BoxLeastSquares`.
 
         Optional keywords accepted if ``method='lombscargle'`` are:
-            ``min_frequency``, ``max_frequency``, ``min_period``, ``max_period``,
-            ``frequency``, ``period``, ``nterms``, ``nyquist_factor``,
-            ``oversample_factor``, ``freq_unit``.
+            ``minimum_frequency``, ``maximum_frequency``, ``mininum_period``,
+            ``maximum_period``, ``frequency``, ``period``, ``nterms``,
+            ``nyquist_factor``, ``oversample_factor``, ``freq_unit``.
 
         Optional keywords accepted for ``method='bls'`` are:
-            ``minimum_period``, ``maximum_period``, ``period``, ``frequency_factor``,
-            ``duration``.
+            ``minimum_period``, ``maximum_period``, ``period``,
+            ``frequency_factor``, ``duration``.
 
         Parameters
         ----------

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -547,8 +547,8 @@ class LombScarglePeriodogram(Periodogram):
         return('LombScarglePeriodogram(ID: {})'.format(self.targetid))
 
     @staticmethod
-    def from_lightcurve(lc, min_frequency=None, max_frequency=None,
-                        min_period=None, max_period=None,
+    def from_lightcurve(lc, minimum_frequency=None, maximum_frequency=None,
+                        minimum_period=None, maximum_period=None,
                         frequency=None, period=None,
                         nterms=1, nyquist_factor=1, oversample_factor=1,
                         freq_unit=1/u.day, **kwargs):
@@ -590,16 +590,16 @@ class LombScarglePeriodogram(Periodogram):
         ----------
         lc : LightCurve object
             The LightCurve from which to compute the Periodogram.
-        min_frequency : float
+        minimum_frequency : float
             If specified, use this minimum frequency rather than one over the
             time baseline.
-        max_frequency : float
+        maximum_frequency : float
             If specified, use this maximum frequency rather than nyquist_factor
             times the nyquist frequency.
-        min_period : float
+        minimum_period : float
             If specified, use 1./minium_period as the maximum frequency rather
             than nyquist_factor times the nyquist frequency.
-        max_period : float
+        maximum_period : float
             If specified, use 1./maximum_period as the minimum frequency rather
             than one over the time baseline.
         frequency :  array-like
@@ -635,14 +635,14 @@ class LombScarglePeriodogram(Periodogram):
         lc = lc.normalize()
 
         # Check if any values of period have been passed and set format accordingly
-        if not all(b is None for b in [period, min_period, max_period]):
+        if not all(b is None for b in [period, minimum_period, maximum_period]):
             view = 'period'
         else:
             view = 'frequency'
 
         # If period and frequency keywords have both been set, throw an error
-        if (not all(b is None for b in [period, min_period, max_period])) & \
-           (not all(b is None for b in [frequency, min_frequency, max_frequency])):
+        if (not all(b is None for b in [period, minimum_period, maximum_period])) & \
+           (not all(b is None for b in [frequency, minimum_frequency, maximum_frequency])):
             raise ValueError('You have input keyword arguments for both frequency and period. '
                              'Please only use one.')
 
@@ -662,46 +662,46 @@ class LombScarglePeriodogram(Periodogram):
         fs = fs.to(freq_unit)
 
         # Warn if there is confusing input
-        if (frequency is not None) & (any([a is not None for a in [min_frequency, max_frequency]])):
+        if (frequency is not None) & (any([a is not None for a in [minimum_frequency, maximum_frequency]])):
             log.warning("You have passed both a grid of frequencies "
-                        "and min_frequency/max_frequency arguments; "
+                        "and min_frequency/maximum_frequency arguments; "
                         "the latter will be ignored.")
-        if (period is not None) & (any([a is not None for a in [min_period, max_period]])):
+        if (period is not None) & (any([a is not None for a in [minimum_period, maximum_period]])):
             log.warning("You have passed a grid of periods "
-                        "and min_period/max_period arguments; "
+                        "and minimum_period/maximum_period arguments; "
                         "the latter will be ignored.")
 
         # Tidy up the period stuff...
-        if max_period is not None:
-            # min_frequency MUST be none by this point.
-            min_frequency = 1. / max_period
-        if min_period is not None:
-            # max_frequency MUST be none by this point.
-            max_frequency = 1. / min_period
+        if maximum_period is not None:
+            # minimum_frequency MUST be none by this point.
+            minimum_frequency = 1. / maximum_period
+        if minimum_period is not None:
+            # maximum_frequency MUST be none by this point.
+            maximum_frequency = 1. / minimum_period
         # If the user specified a period, copy it into the frequency.
         if (period is not None):
             frequency = 1. / period
 
         # Do unit conversions if user input min/max frequency or period
         if frequency is None:
-            if min_frequency is not None:
-                min_frequency = u.Quantity(min_frequency, freq_unit)
-            if max_frequency is not None:
-                max_frequency = u.Quantity(max_frequency, freq_unit)
-            if (min_frequency is not None) & (max_frequency is not None):
-                if (min_frequency > max_frequency):
+            if minimum_frequency is not None:
+                minimum_frequency = u.Quantity(minimum_frequency, freq_unit)
+            if maximum_frequency is not None:
+                maximum_frequency = u.Quantity(maximum_frequency, freq_unit)
+            if (minimum_frequency is not None) & (maximum_frequency is not None):
+                if (minimum_frequency > maximum_frequency):
                     if view == 'frequency':
-                        raise ValueError('min_frequency cannot be larger than max_frequency')
+                        raise ValueError('minimum_frequency cannot be larger than maximum_frequency')
                     if view == 'period':
-                        raise ValueError('min_period cannot be larger than max_period')
+                        raise ValueError('minimum_period cannot be larger than maximum_period')
             # If nothing has been passed in, set them to the defaults
-            if min_frequency is None:
-                min_frequency = fs
-            if max_frequency is None:
-                max_frequency = nyquist * nyquist_factor
+            if minimum_frequency is None:
+                minimum_frequency = fs
+            if maximum_frequency is None:
+                maximum_frequency = nyquist * nyquist_factor
 
             # Create frequency grid evenly spaced in frequency
-            frequency = np.arange(min_frequency.value, max_frequency.value, fs.to(freq_unit).value)
+            frequency = np.arange(minimum_frequency.value, maximum_frequency.value, fs.to(freq_unit).value)
 
         # Convert to desired units
         frequency = u.Quantity(frequency, freq_unit)

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function
 import copy
 import logging
 import math
+import warnings
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -16,6 +17,7 @@ from astropy.units import cds
 from astropy.convolution import convolve, Box1DKernel
 
 from . import MPLSTYLE
+from .utils import LightkurveWarning
 
 log = logging.getLogger(__name__)
 
@@ -631,6 +633,27 @@ class LombScarglePeriodogram(Periodogram):
         Periodogram : `Periodogram` object
             Returns a Periodogram object extracted from the lightcurve.
         """
+        if "min_period" in kwargs:
+            warnings.warn("`min_period` keyword is deprecated, "
+                          "please use `minimum_period` instead.",
+                          LightkurveWarning)
+            minimum_period = kwargs.pop("min_period", None)
+        if "max_period" in kwargs:
+            warnings.warn("`max_period` keyword is deprecated, "
+                          "please use `maximum_period` instead.",
+                          LightkurveWarning)
+            maximum_period = kwargs.pop("max_period", None)
+        if "min_frequency" in kwargs:
+            warnings.warn("`min_frequency` keyword is deprecated, "
+                          "please use `minimum_frequency` instead.",
+                          LightkurveWarning)
+            minimum_frequency = kwargs.pop("min_frequency", None)
+        if "max_frequency" in kwargs:
+            warnings.warn("`max_frequency` keyword is deprecated, "
+                          "please use `maximum_frequency` instead.",
+                          LightkurveWarning)
+            maximum_frequency = kwargs.pop("max_frequency", None)
+
         # Make sure the lightcurve object is normalized
         lc = lc.normalize()
 


### PR DESCRIPTION
This PR addresses #444.

TODO: Restore support for the old arguments with a deprecation warning?