### PR TITLE
Cache TESSCut downloads to speed up file access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.9.0 (unreleased)
+==================
+
+- Added caching to `search_tesscut` to avoid requesting an identical cut out
+  more than once. [#481]
+
+
+
 1.8.0 (2020-02-09)
 ==================
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -384,10 +384,8 @@ class SearchResult(object):
         temp_path = os.path.join(download_dir, (sector_name + '_' + coords_str
                                  + '_' + size_str + '_astrocut.fits'))
 
-        print(temp_path)
         if os.path.isfile(temp_path):
             path = temp_path
-            print('quick download')
         else:
             cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
                                                           sector=sector, path=tesscut_dir)

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -375,16 +375,15 @@ class SearchResult(object):
         # this is necessary to ensure cutouts are not downloaded multiple times
         sec = TesscutClass().get_sectors(coords)
         sector_name = sec[sec['sector'] == 1]['sectorName'][0]
-        coords_str = str(round(coords.ra.value,5)) + '_' + str(round(coords.dec.value,5))
+        coords_str = str(round(coords.ra.value,13)) + '_' + str(round(coords.dec.value,13))
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
             size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
 
         fname = sector_name + '_' + coords_str + '_' + size_str + '_astrocut.fits'
-        temp_path = os.path.join(download_dir, fname)
+        temp_path = os.path.join(download_dir, 'tesscut', fname)
 
-        print(temp_path)
         if os.path.exists(temp_path):
             path = temp_path
         else:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -127,7 +127,6 @@ class SearchResult(object):
         """Returns an array of dec values for targets in search"""
         return self.table['s_dec'].data.data
 
-<<<<<<< HEAD
     def _download_one(self, table, quality_bitmask, download_dir, cutout_size):
         """Private method used by `download()` and `download_all()` to download
         exactly one file from the MAST archive.
@@ -180,9 +179,6 @@ class SearchResult(object):
             return _open_downloaded_file(path, quality_bitmask=quality_bitmask)
 
     @suppress_stdout
-=======
-    # @suppress_stdout
->>>>>>> support caching tesscut downloads
     def download(self, quality_bitmask='default', download_dir=None, cutout_size=None):
         """Returns a single `KeplerTargetPixelFile` or `KeplerLightCurveFile` object.
 
@@ -363,29 +359,27 @@ class SearchResult(object):
                 tesscut_dir = download_dir
 
         # Resolve SkyCoord of given target
-<<<<<<< HEAD
         coords = _resolve_object(target)
         cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
                                                       sector=sector, path=tesscut_dir)
-=======
-        coords = MastClass()._resolve_object(target)
->>>>>>> support caching tesscut downloads
 
         # build path string name and check if it exists
         # this is necessary to ensure cutouts are not downloaded multiple times
         sec = TesscutClass().get_sectors(coords)
         sector_name = sec[sec['sector'] == 1]['sectorName'][0]
-        coords_str = str(round(coords.ra.value,13)) + '_' + str(round(coords.dec.value,13))
+        coords_str = str(round(coords.ra.value,5)) + '_' + str(round(coords.dec.value,5))
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
             size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
 
-        fname = sector_name + '_' + coords_str + '_' + size_str + '_astrocut.fits'
-        temp_path = os.path.join(download_dir, 'tesscut', fname)
+        temp_path = os.path.join(download_dir, (sector_name + '_' + coords_str
+                                 + '_' + size_str + '_astrocut.fits'))
 
-        if os.path.exists(temp_path):
+        print(temp_path)
+        if os.path.isfile(temp_path):
             path = temp_path
+            print('quick download')
         else:
             cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
                                                           sector=sector, path=tesscut_dir)

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -370,12 +370,14 @@ class SearchResult(object):
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
             size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
 
+        # search cache for file with matching ra, dec, and cutout size
+        # ra and dec are searched within 0.001 degrees of input target
+        ra_string = str(coords.ra.value)
+        dec_string = str(coords.dec.value)
         matchstring = r"{}_{}*_{}*_{}_astrocut.fits".format(sector_name,
-                                                            str(coords.ra.value)[:-1],
-                                                            str(coords.dec.value)[:-1],
+                                                            ra_string[:ra_string.find('.')+4],
+                                                            dec_string[:dec_string.find('.')+4],
                                                             size_str)
-
-        # check for matching files
         cached_files = glob.glob(os.path.join(tesscut_dir, matchstring))
 
         # if any files exist, return the path to them instead of downloading

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -368,7 +368,7 @@ class SearchResult(object):
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
-            size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
+            size_str = str(int(cutout_size[1])) + 'x' + str(int(cutout_size[0]))
 
         # search cache for file with matching ra, dec, and cutout size
         # ra and dec are searched within 0.001 degrees of input target

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -127,6 +127,7 @@ class SearchResult(object):
         """Returns an array of dec values for targets in search"""
         return self.table['s_dec'].data.data
 
+<<<<<<< HEAD
     def _download_one(self, table, quality_bitmask, download_dir, cutout_size):
         """Private method used by `download()` and `download_all()` to download
         exactly one file from the MAST archive.
@@ -179,6 +180,9 @@ class SearchResult(object):
             return _open_downloaded_file(path, quality_bitmask=quality_bitmask)
 
     @suppress_stdout
+=======
+    # @suppress_stdout
+>>>>>>> support caching tesscut downloads
     def download(self, quality_bitmask='default', download_dir=None, cutout_size=None):
         """Returns a single `KeplerTargetPixelFile` or `KeplerLightCurveFile` object.
 
@@ -237,7 +241,7 @@ class SearchResult(object):
                                   download_dir=download_dir,
                                   cutout_size=cutout_size)
 
-    @suppress_stdout
+    # @suppress_stdout
     def download_all(self, quality_bitmask='default', download_dir=None, cutout_size=None):
         """Returns a `~lightkurve.collections.TargetPixelFileCollection` or
         `~lightkurve.collections.LightCurveFileCollection`.
@@ -359,11 +363,36 @@ class SearchResult(object):
                 tesscut_dir = download_dir
 
         # Resolve SkyCoord of given target
+<<<<<<< HEAD
         coords = _resolve_object(target)
         cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
                                                       sector=sector, path=tesscut_dir)
+=======
+        coords = MastClass()._resolve_object(target)
+>>>>>>> support caching tesscut downloads
 
-        path = os.path.join(download_dir, cutout_path[0][0])
+        # build path string name and check if it exists
+        # this is necessary to ensure cutouts are not downloaded multiple times
+        sec = TesscutClass().get_sectors(coords)
+        sector_name = sec[sec['sector'] == 1]['sectorName'][0]
+        coords_str = str(round(coords.ra.value,5)) + '_' + str(round(coords.dec.value,5))
+        if isinstance(cutout_size, int):
+            size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
+        elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
+            size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
+
+        temp_path = os.path.join(download_dir, (sector_name + '_' + coords_str
+                                 + '_' + size_str + '_astrocut.fits'))
+
+        print(temp_path)
+        if os.path.isfile(temp_path):
+            path = temp_path
+            print('quick download')
+        else:
+            cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,
+                                                          sector=sector, path=tesscut_dir)
+
+            path = os.path.join(download_dir, cutout_path[0][0])
         return path
 
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -381,10 +381,11 @@ class SearchResult(object):
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):
             size_str = str(int(cutout_size[0])) + 'x' + str(int(cutout_size[1]))
 
-        temp_path = os.path.join(download_dir, (sector_name + '_' + coords_str
-                                 + '_' + size_str + '_astrocut.fits'))
+        fname = sector_name + '_' + coords_str + '_' + size_str + '_astrocut.fits'
+        temp_path = os.path.join(download_dir, fname)
 
-        if os.path.isfile(temp_path):
+        print(temp_path)
+        if os.path.exists(temp_path):
             path = temp_path
         else:
             cutout_path = TesscutClass().download_cutouts(coords, size=cutout_size,

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -380,7 +380,6 @@ class SearchResult(object):
 
         # if any files exist, return the path to them instead of downloading
         if len(cached_files) > 0:
-            print('zoom')
             path = cached_files[0]
             log.debug("Cached file found.")
         # otherwise the file will be downloaded

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -365,7 +365,6 @@ class SearchResult(object):
         # this is necessary to ensure cutouts are not downloaded multiple times
         sec = TesscutClass().get_sectors(coords)
         sector_name = sec[sec['sector'] == 1]['sectorName'][0]
-        coords_str = str(round(coords.ra.value,5)) + '_' + str(round(coords.dec.value,5))
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -86,7 +86,7 @@ def test_search_lightcurvefile(caplog):
 
 
 @pytest.mark.remote_data
-def test_search_tesscut(caplog):
+def test_search_tesscut():
     # Cutout by target name
     assert(len(search_tesscut("pi Mensae", sector=1).table) == 1)
     assert(len(search_tesscut("pi Mensae").table) > 1)
@@ -102,13 +102,10 @@ def test_search_tesscut(caplog):
     # The coordinates below are beyond the edge of the sector 4 (camera 1-4) FFI
     search_edge = search_tesscut('30.578761, 6.210593', sector=4)
     assert(len(search_edge.table) == 0)
-    tpf_download = search_coords.download(cutout_size=1)
-    tpf_cached = search_coords.download(cutout_size=1)
-    assert "Cached file found." in caplog.text
 
 
 @pytest.mark.remote_data
-def test_search_tesscut_download():
+def test_search_tesscut_download(caplog):
     """Can we download TESS cutouts via `search_cutout().download()?"""
     try:
         ra, dec = 30.578761, -83.210593
@@ -134,6 +131,10 @@ def test_search_tesscut_download():
         # Download with rectangular dimennsions?
         rect_tpf = search_string[0].download(cutout_size=(3, 5))
         assert(rect_tpf.flux[0].shape == (3, 5))
+        # access cached file?
+        caplog.clear() # clear log to check log message from next function
+        tpf_cached = search_string[0].download(cutout_size=(3, 5))
+        assert "Cached file found." in caplog.text
     except HTTPError as exc:
         # TESSCut will occasionally return a "504 Gateway Timeout error" when
         # it is overloaded.  We don't want this to trigger a test failure.

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -18,7 +18,7 @@ from astropy.table import Table
 
 from ..utils import LightkurveWarning
 from ..search import search_lightcurvefile, search_targetpixelfile, \
-                     search_tesscut, SearchResult, SearchError, open
+                     search_tesscut, SearchResult, SearchError, open, log
 from .. import KeplerTargetPixelFile, TessTargetPixelFile, TargetPixelFileCollection
 
 from .. import PACKAGEDIR
@@ -131,8 +131,9 @@ def test_search_tesscut_download(caplog):
         # Download with rectangular dimennsions?
         rect_tpf = search_string[0].download(cutout_size=(3, 5))
         assert(rect_tpf.flux[0].shape == (3, 5))
-        # access cached file?
-        caplog.clear() # clear log to check log message from next function
+        # If we ask for the exact same cutout, do we get it from cache?
+        caplog.clear()
+        log.setLevel("DEBUG")
         tpf_cached = search_string[0].download(cutout_size=(3, 5))
         assert "Cached file found." in caplog.text
     except HTTPError as exc:

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -86,7 +86,7 @@ def test_search_lightcurvefile(caplog):
 
 
 @pytest.mark.remote_data
-def test_search_tesscut():
+def test_search_tesscut(caplog):
     # Cutout by target name
     assert(len(search_tesscut("pi Mensae", sector=1).table) == 1)
     assert(len(search_tesscut("pi Mensae").table) > 1)
@@ -102,6 +102,9 @@ def test_search_tesscut():
     # The coordinates below are beyond the edge of the sector 4 (camera 1-4) FFI
     search_edge = search_tesscut('30.578761, 6.210593', sector=4)
     assert(len(search_edge.table) == 0)
+    tpf_download = search_coords.download(cutout_size=1)
+    tpf_cached = search_coords.download(cutout_size=1)
+    assert "Cached file found." in caplog.text
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
Fixes #474: Build path name for TESSCut files before downloading and check if they exist. If the desired TESSCut has previously been downloaded (with the same coordinates and cutout size), the path to the target will be returned instead of re-downloading.