### PR TITLE
Add a badge to run tutorials in Google Colab

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,19 +81,14 @@ nbsphinx_prolog = r"""
 
 .. only:: html
 
-    .. role:: raw-html(raw)
-        :format: html
+    .. raw:: html
 
-    .. nbinfo::
-        **This page is a static version of an interactive Jupyter notebook**
-
-        - Try the interactive version: :raw-html:`<a href="https://mybinder.org/v2/gh/KeplerGO/lightkurve/master?filepath=docs/source/{{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
-
-        - Download the source file: `{{ docname }}`__
-
-    __ https://github.com/KeplerGO/lightkurve/blob/master/docs/source/
-        {{ docname }}
-
+        <div style="float:right; margin-top:1em; margin-bottom:-1em;">
+            <a href="https://github.com/KeplerGO/lightkurve/tree/master/docs/source/{{ docname }}"><img src="https://img.shields.io/badge/Jupyter%20Notebook-Download-blue.svg"></a>
+            <a href=" https://colab.research.google.com/github/KeplerGO/lightkurve/blob/master/docs/source/{{ docname }}"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+            <a href="https://mybinder.org/v2/gh/KeplerGO/lightkurve/master?filepath=docs/source/{{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg"></a>
+        </div>
+        <br style="clear:both;">
 """
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -2,49 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "source": [
-    "# Preface\n",
-    "\n",
-    "If you are running this notebook on *Google Collaboratory* or a similar notebook server, you need to make sure Lightkurve and all its dependencies are installed using the following command:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install lightkurve[all]  # This may take a few minutes!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "source": [
-    "To match the Lightkurve docs, we also recommend to configure the default plotting style as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "plt.style.use(\"default\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Quickstart"
@@ -192,7 +149,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -2,6 +2,49 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "# Preface\n",
+    "\n",
+    "If you are running this notebook on *Google Collaboratory* or a similar notebook server, you need to make sure Lightkurve and all its dependencies are installed using the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install lightkurve[all]  # This may take a few minutes!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "To match the Lightkurve docs, we also recommend to configure the default plotting style as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.style.use(\"default\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Quickstart"
@@ -149,6 +192,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
This PR brings three changes:

1. It changes the Sphinx prologue of each tutorial to show badges instead of text (cf. [current behavior](https://docs.lightkurve.org/quickstart.html)).
2. It adds a Google Colab badge which takes the user straight to a Colab-hosted version of the notebook.
2. It adds a few cells at the top of the `quickstart.ipynb` notebook with installation instructions (i.e. a cell with `!pip install lightkurve` and some explainer text).  These extra cells are intended to make it easy for a user to install lightkurve when opening the notebook in Colab.  These extra cells have the metadata `"nbsphinx": "hidden"` so they are not shown in sphinx.  However these extra cells may confuse users who already have lightkurve installed, and they are inconsistent with our recommendation to install lightkurve using conda, so I'm not yet convinced this is the right solution.

Preview:
![Screenshot from 2019-04-02 08-08-17](https://user-images.githubusercontent.com/817669/55413617-8299ad00-551e-11e9-908e-05fffe5d3fdc.png)

/cc @gully 