### PR TITLE
[bugfix] Fix PLD NaN bug

### DIFF
--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -716,7 +716,6 @@ class PLDCorrector(object):
         # X has shape (n_components_first + n_components_higher_order + 1, n_cadences)
         X = np.concatenate(X_sections, axis=1)
 
-
         # set default transit mask
         if cadence_mask is None:
             cadence_mask = np.ones_like(self.time, dtype=bool)

--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -690,7 +690,9 @@ class PLDCorrector(object):
         # first order PLD design matrix
         pld_flux = flux_crop[:, aperture_crop]
         f1 = np.reshape(pld_flux, (len(pld_flux), -1))
-        X1 = f1 / np.sum(pld_flux, axis=-1)[:, None]
+        X1 = f1 / np.nansum(pld_flux, axis=-1)[:, None]
+        # No NaN pixels
+        X1 = X1[:, np.isfinite(X1).all(axis=0)]
 
         # higher order PLD design matrices
         X_sections = [np.ones((len(flux_crop), 1)), X1]
@@ -713,6 +715,7 @@ class PLDCorrector(object):
         # adding a column vector of 1s for numerical stability (see Luger et al.).
         # X has shape (n_components_first + n_components_higher_order + 1, n_cadences)
         X = np.concatenate(X_sections, axis=1)
+
 
         # set default transit mask
         if cadence_mask is None:


### PR DESCRIPTION
Sometimes there are TPFs with a few NaN pixels. This currently breaks the PLD implementation, as it tries to make those pixels into components that are always nans, and then `fbpca` breaks (see below). This fixes that issue by just clipping out any NaN pixels when we make the components.

![image](https://user-images.githubusercontent.com/14965634/55448265-f9b15e80-557b-11e9-84d1-c7ee1f961e0e.png)
 