### PR TITLE
Add a warning about the new defaults in `LombScarglePeriodogram`

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -682,6 +682,15 @@ class LombScarglePeriodogram(Periodogram):
         Periodogram : `Periodogram` object
             Returns a Periodogram object extracted from the lightcurve.
         """
+        # If the defaults are used, issue a warning to point out they changed!
+        if normalization == 'amplitude' and freq_unit is None and oversample_factor is None:
+            warnings.warn("As of Lightkurve v1.0.0 (Apr 2019), the default behavior "
+                          "of Lomb Scargle periodograms changed to use "
+                          "normalization='amplitude' and oversample_factor=5 "
+                          "(the previous defaults were normalization='psd' and "
+                          "oversample_factor=1). You can suppress this warning using "
+                          "`warnings.filterwarnings('ignore', category=lk.LightkurveWarning)`.",
+                          LightkurveWarning)
 
         # Input validation for spectrum type
         if normalization not in ('psd', 'amplitude'):


### PR DESCRIPTION
Over in #416 we changed the default settings of the Lomb Scargle periodogram created by `lc.to_periodogram()`.  There was a consensus amongst the authors that users should be alerted of the new default settings using a warning.  This PR adds such a warning, which can be suppressed using: `warnings.filterwarnings('ignore', category=lk.LightkurveWarning)`.

@danielhey @keatonb @ojhall94 Would one of you be willing to review?

### New behavior:
```python
In [1]: import lightkurve as lk 
   ...: tpf = lk.search_targetpixelfile("Kepler-10", quarter=4).download() 
   ...: pg = tpf.to_lightcurve().to_periodogram()                               
/home/gb/dev/lightkurve/lightkurve/periodogram.py:693: LightkurveWarning: As of Lightkurve v1.0.0 (Apr 2019), the default behavior of Lomb Scargle periodograms changed to use normalization='amplitude' and oversample_factor=5 (the previous defaults were normalization='psd' and oversample_factor=1). You can suppress this warning using `warnings.filterwarnings('ignore', category=lk.LightkurveWarning)`.
  LightkurveWarning)
```