### PR TITLE
[Bugfix] Use `quality_bitmask` keyword in download_all

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -235,9 +235,9 @@ class SearchResult(object):
         tpf_extensions = ['lpd-targ.fits', 'spd-targ.fits', '_tp.fits', 'n/a']
         lcf_extensions = ['llc.fits', 'slc.fits', '_lc.fits']
         if any(e in self.table['productFilename'][0] for e in tpf_extensions):
-            return TargetPixelFileCollection([open(p) for p in path])
+            return TargetPixelFileCollection([open(p, quality_bitmask=quality_bitmask) for p in path])
         elif any(e in self.table['productFilename'][0] for e in lcf_extensions):
-            return LightCurveFileCollection([open(p) for p in path])
+            return LightCurveFileCollection([open(p, quality_bitmask=quality_bitmask) for p in path])
 
     def _default_download_dir(self):
         """Returns the default path to the directory where files will be downloaded.

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -131,13 +131,14 @@ def test_search_tesscut_download():
     assert_almost_equal(ra, center_ra, decimal=1)
     assert_almost_equal(dec, center_dec, decimal=1)
     # Download with different dimensions
-    tpfc = search_string.download_all(cutout_size=4)
+    tpfc = search_string.download_all(cutout_size=4, quality_bitmask='hard')
     assert(isinstance(tpfc, TargetPixelFileCollection))
+    assert(tpfc[0].quality_bitmask == 'hard')  # Regression test for #494
     # Ensure correct dimensions
     assert(tpfc[0].flux[0].shape == (4, 4))
     # Download with rectangular dimennsions?
-    rect_tpf = search_string.download(cutout_size=(3,5))
-    assert(rect_tpf.flux[0].shape == (3,5))
+    rect_tpf = search_string.download(cutout_size=(3, 5))
+    assert(rect_tpf.flux[0].shape == (3, 5))
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
The `download_all()` function accepted a `quality_bitmask` keyword, but never used it when opening the downloaded files. This PR actually applies the keyword when calling the `open()` function.