### PR TITLE
Log a warning if a large number of cadences are masked out by `quality_bitmask`

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -85,8 +85,17 @@ class QualityFlags(object):
                                  "".format(bitmask, valid_options))
         # The bitmask is applied using the bitwise AND operator
         quality_mask = (quality_array & bitmask) == 0
-        log.info("{} cadences will be ignored (bitmask={})"
-                 "".format((~quality_mask).sum(), bitmask))
+        # Log the quality masking as info or warning
+        n_cadences = len(quality_array)
+        n_cadences_masked = (~quality_mask).sum()
+        percent_masked = 100. * n_cadences_masked / n_cadences
+        logmsg = "{:.0f}% ({}/{}) of the cadences will be ignored due to the " \
+                 "quality mask (quality_bitmask={})." \
+                 "".format(percent_masked, n_cadences_masked, n_cadences, bitmask)
+        if percent_masked > 20:
+            log.warning("Warning: " + logmsg)
+        else:
+            log.info(logmsg)
         return quality_mask
 
 


### PR DESCRIPTION
I propose to issue a warning when more than 20% of the cadences are masked out by `quality_bitmask`, which is the case for K2 C0 and C19. (In contrast, e.g. C12 has 12% bad cadences using the default mask).  I hope this won't make Lightkurve too noisy.

This PR addresses #489.  

### Example:

```python
>>> import lightkurve as lk
>>> tpf = lk.search_targetpixelfile("K2-20", campaign=0).download(quality_bitmask="default")
Warning: 56% (2112/3753) of the cadences will be ignored due to the quality mask (quality_bitmask=1130799).
```