### PR TITLE
Fix estimate centroid bug

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -455,7 +455,7 @@ class TargetPixelFile(object):
             threshold.
         """
         if reference_pixel == 'center':
-            reference_pixel = (self.shape[1] / 2, self.shape[2] / 2)
+            reference_pixel = (self.shape[2] / 2, self.shape[1] / 2)
         # Calculate the median image
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')


### PR DESCRIPTION
There's a bug in `tpf.create_threshold_mask()` where the supposed centroid pixel is not actually in the center. We had the dimensions the wrong way around.

I've fixed it

# Pre fix:
![image](https://user-images.githubusercontent.com/14965634/56695202-5399d580-669d-11e9-82bb-149af8f38526.png)

# Post fix:
![image](https://user-images.githubusercontent.com/14965634/56695231-61e7f180-669d-11e9-8075-ecf3316439cd.png)
