### PR TITLE
Ensure `LightCurve.bin()` reports standard deviations in the absence of `flux_err`

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -636,8 +636,9 @@ class LightCurve(object):
                  for a in indexes]
             ) / binsize
         else:
-            # Make them zeros.
-            binned_lc.flux_err = np.zeros(len(binned_lc.flux))
+            # If the original light curve does not provide `flux_err`,
+            # then report the standard deviations of the fluxes in each bin.
+            binned_lc.flux_err = np.array([np.nanstd(self.flux[a]) for a in indexes])
 
         if hasattr(binned_lc, 'quality'):
             # Note: np.bitwise_or only works if there are no NaNs

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -400,6 +400,10 @@ def test_bin():
                           flux=1*np.ones(1000) + np.random.normal(0, 1e-6, 1000),
                           cadenceno=np.arange(1000))
     assert np.isclose(lc.bin(2).estimate_cdpp(), 1, rtol=1)
+    # Regression test for #500
+    lc = LightCurve(time=np.arange(2000),
+                    flux=np.random.normal(loc=42, scale=0.01, size=2000))
+    assert np.round(lc.bin(2000).flux_err[0], 2) == 0.01
 
 
 def test_bin_quality():


### PR DESCRIPTION
The docstring of `LightCurve.bin()` promises that `If no uncertainties are included, the binned curve will return the standard deviation of the data.`.  However it was pointed out in #500 that this was not the true behavior of the code yet. This PR implements the advertised behavior.