### PR TITLE
[Bugfix] Carefully handle TIC / EPIC ID overlap

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -711,12 +711,16 @@ def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS')):
         # `target_name` under which MAST will know the object to prevent
         # source confusion (see GitHub issue #148).
         target = int(target)
-        if (target > 0) and (target < 200000000):
-            target_name = 'kplr{:09d}'.format(target)
-        elif (target > 200000000) and (target < 300000000):
-            target_name = 'ktwo{:09d}'.format(target)
+        if isinstance(target, str) and target.lower().startswith(('epic', 'kic')):
+            target = int(''.join(filter(str.isdigit, target)))
+            if (target > 0) and (target < 200000000):
+                target_name = 'kplr{:09d}'.format(target)
+            elif (target > 200000000) and (target < 300000000):
+                target_name = 'ktwo{:09d}'.format(target)
+        elif isinstance(target, str) and target.lower().startswith(('tic')):
+            target_name = int(''.join(filter(str.isdigit, target)))
         else:
-            raise ValueError("{:09d}: not in the KIC or EPIC ID range".format(target))
+            raise ValueError("{:09d}: not in the KIC, TIC, or EPIC ID range".format(target))
 
         # query_criteria does not allow a cone search when target_name is passed in
         # so first grab desired target with ~0 arcsecond radius

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -295,11 +295,10 @@ def test_indexerror_631():
     # This previously triggered an exception:
     result = search_lightcurvefile("KIC 8462852", sector=15)
     assert len(result) == 1
-    len(search) == 0
 
 
 def test_overlap():
-    """Regression test for ..."""
+    """Regression test for #505."""
     # The following search previously returned two targets when given a single
     # ID, and should now return only the desired target.
     search = search_targetpixelfile("EPIC 203348744")

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -295,3 +295,14 @@ def test_indexerror_631():
     # This previously triggered an exception:
     result = search_lightcurvefile("KIC 8462852", sector=15)
     assert len(result) == 1
+    len(search) == 0
+
+
+def test_overlap():
+    """Regression test for ..."""
+    # The following search previously returned two targets when given a single
+    # ID, and should now return only the desired target.
+    search = search_targetpixelfile("EPIC 203348744")
+    assert(len(search) == 1)
+    # it should return the same result when searching for just the int ID
+    assert(len(search) == len(search_targetpixelfile(203348744)))


### PR DESCRIPTION
This PR addresses a couple of issues. First, @christinahedges pointed out that certain searches returned overlapping targets and claimed a distance of 0 between them.

**Example:**
![image](https://user-images.githubusercontent.com/17130840/56842253-656bac00-6848-11e9-990d-e2b37ff08ff2.png)

Now, the `_query_mast()` function parses the ID from queries beginning in `EPIC` or `KIC`, and assigns them their `kplr...` or `ktwo...` names. These queries now resolve to the correct objects.

**🚨New bug alert 🚨**
While fixing this issue, I found that there are targets observed by TESS with overlapping TIC and EPIC IDs. Depending on the syntax of the search, either one can be returned.

**Example:**
<img width="587" alt="Screen Shot 2019-04-26 at 5 29 58 PM" src="https://user-images.githubusercontent.com/17130840/56842350-0d817500-6849-11e9-8bc0-c9a91790a300.png">

**Next step:**
Provide a warning when a target ID is within the overlap range of TIC and EPIC. Also, set the default formatting to `TIC #` when an int is passed into `search_tesscut()`.