### PR TITLE
Restore the unit test that was failing due to #507

### DIFF
--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -39,8 +39,8 @@ def test_search_targetpixelfile():
     assert(len(search_targetpixelfile(11904151, quarter=11).unique_targets) == 1)
     assert(len(search_targetpixelfile(11904151, quarter=12).table) == 0)
     # should work for all split campaigns
-    campaigns = [[91, 92, 9], [101, 102, 10]]
-    ids = [200068780, 200071712]
+    campaigns = [[91, 92, 9], [101, 102, 10], [111, 112, 11]]
+    ids = [200068780, 200071712, 202975993]
     for c, idx in zip(campaigns, ids):
         ca = search_targetpixelfile(idx, campaign=c[0]).table
         cb = search_targetpixelfile(idx, campaign=c[1]).table


### PR DESCRIPTION
A few moments ago I disabled the unit test that was failing due to the minor issue with C11 data at MAST described in #507 (commit: 211f134a969756e6935b078e2930013decef1a67).

This PR restores the unit test that has been temporarily disabled.  We should merge this PR as soon as #507 is resolved, i.e. as soon as MAST removed the duplicate entries for C11 data from its API.