### PR TITLE
Ensure the signature of `lc.remove_outliers()` matches the docstring

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -502,7 +502,8 @@ class LightCurve(object):
         nlc.time = np.asarray(ts.index)
         return nlc
 
-    def remove_outliers(self, sigma=5., return_mask=False, **kwargs):
+    def remove_outliers(self, sigma=5., sigma_lower=None, sigma_upper=None,
+                        return_mask=False, maxiters=5, **kwargs):
         """Removes outlier data points using sigma-clipping.
 
         This method returns a new `LightCurve` object from which data
@@ -518,6 +519,8 @@ class LightCurve(object):
         .. note::
             This function is a convenience wrapper around
             `astropy.stats.sigma_clip()` and provides the same functionality.
+            Any extra arguments passed to this method will be passed on to
+            ``sigma_clip``.
 
         Parameters
         ----------
@@ -539,14 +542,10 @@ class LightCurve(object):
             Whether or not to return a mask (i.e. a boolean array) indicating
             which data points were removed. Entries marked as `True` in the
             mask are considered outliers. Defaults to `True`.
-        iters : int or `None`
+        maxiters : int or `None`
             The number of iterations to perform sigma clipping, or `None` to
             clip until convergence is achieved (i.e., continue until the
             last iteration clips nothing). Defaults to 5.
-        cenfunc : callable
-            The function used to compute the center for the clipping. Must
-            be a callable that takes in a masked array and outputs the
-            central value. Defaults to the median (`numpy.ma.median`).
         **kwargs : dict
             Dictionary of arguments to be passed to `astropy.stats.sigma_clip`.
 
@@ -582,7 +581,12 @@ class LightCurve(object):
         # First, we create the outlier mask using AstroPy's sigma_clip function
         with warnings.catch_warnings():  # Ignore warnings due to NaNs or Infs
             warnings.simplefilter("ignore")
-            outlier_mask = sigma_clip(data=self.flux, sigma=sigma, **kwargs).mask
+            outlier_mask = sigma_clip(data=self.flux,
+                                      sigma=sigma,
+                                      sigma_lower=sigma_lower,
+                                      sigma_upper=sigma_upper,
+                                      maxiters=maxiters,
+                                      **kwargs).mask
         # Second, we return the masked light curve and optionally the mask itself
         if return_mask:
             return self[~outlier_mask], outlier_mask

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -503,7 +503,7 @@ class LightCurve(object):
         return nlc
 
     def remove_outliers(self, sigma=5., sigma_lower=None, sigma_upper=None,
-                        return_mask=False, maxiters=5, **kwargs):
+                        return_mask=False, **kwargs):
         """Removes outlier data points using sigma-clipping.
 
         This method returns a new `LightCurve` object from which data
@@ -542,10 +542,6 @@ class LightCurve(object):
             Whether or not to return a mask (i.e. a boolean array) indicating
             which data points were removed. Entries marked as `True` in the
             mask are considered outliers. Defaults to `True`.
-        maxiters : int or `None`
-            The number of iterations to perform sigma clipping, or `None` to
-            clip until convergence is achieved (i.e., continue until the
-            last iteration clips nothing). Defaults to 5.
         **kwargs : dict
             Dictionary of arguments to be passed to `astropy.stats.sigma_clip`.
 
@@ -585,7 +581,6 @@ class LightCurve(object):
                                       sigma=sigma,
                                       sigma_lower=sigma_lower,
                                       sigma_upper=sigma_upper,
-                                      maxiters=maxiters,
                                       **kwargs).mask
         # Second, we return the masked light curve and optionally the mask itself
         if return_mask:

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -506,9 +506,9 @@ class LightCurve(object):
                         return_mask=False, **kwargs):
         """Removes outlier data points using sigma-clipping.
 
-        This method returns a new `LightCurve` object from which data
-        points are removed if their flux values are greater or smaller than
-        the median flux by at least ``sigma`` times the standard deviation.
+        This method returns a new `LightCurve` object from which data points
+        are removed if their flux values are greater or smaller than the median
+        flux by at least ``sigma`` times the standard deviation.
 
         Sigma-clipping works by iterating over data points, each time rejecting
         values that are discrepant by more than a specified number of standard

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -627,7 +627,7 @@ def test_remove_outliers():
     assert(outlier_mask.sum() == 1)
     # Can we set sigma_lower, sigma_upper, and maxiters?
     lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
-    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1, maxiters=2)
+    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
     assert_array_equal(lc_clean.time, [1, 3, 4, 5])
     assert_array_equal(lc_clean.flux, [1, 1, -1000, 1])
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -625,7 +625,7 @@ def test_remove_outliers():
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
     assert(len(outlier_mask) == len(lc.flux))
     assert(outlier_mask.sum() == 1)
-    # Can we set sigma_lower, sigma_upper, and maxiters?
+    # Can we set sigma_lower and sigma_upper?
     lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
     lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
     assert_array_equal(lc_clean.time, [1, 3, 4, 5])

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -625,9 +625,9 @@ def test_remove_outliers():
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
     assert(len(outlier_mask) == len(lc.flux))
     assert(outlier_mask.sum() == 1)
-    # Can we set sigma_lower and sigma_upper?
+    # Can we set sigma_lower, sigma_upper, and maxiters?
     lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
-    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
+    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1, maxiters=2)
     assert_array_equal(lc_clean.time, [1, 3, 4, 5])
     assert_array_equal(lc_clean.flux, [1, 1, -1000, 1])
 


### PR DESCRIPTION
The function signature of `LightCurve.remove_outliers()` did not exactly match the arguments advertised in the docstring.  This PR fixes the issue.

This PR should not alter the behavior of `remove_outliers` because all optional keywords (kwargs) were already passed on to `astropy.stats.sigma_clip`.  This PR solves the issue that this wasn't advertised in a consistent way.