### PR TITLE
Configure `pytest` to use all processors by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 test=pytest
 
 [tool:pytest]
-addopts = -x --doctest-modules --ignore=setup.py --cov=lightkurve
+addopts = -x --doctest-modules --ignore=setup.py --cov=lightkurve -n auto

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ exec(open('lightkurve/version.py').read())
 with open('requirements.txt') as f:
     install_requires = f.read().splitlines()
 # 2. What dependencies required to run the unit tests? (i.e. `pytest --remote-data`)
-tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov']
+tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov', 'pytest-xdist']
 # 3. What dependencies are required for optional features?
 # `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.


### PR DESCRIPTION
I modified the `pytest` configuration to run the unit tests in parallel by default, using as many processors as available.  This significantly speeds up running the unit tests on a local multi-core machine.

I'm opening this PR to see if CI (Azure) is ok with this change!