### PR TITLE
Improve the treatment of the `view` parameter in Periodograms

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -85,8 +85,8 @@ class Periodogram(object):
             view = self.default_view
         allowed_views = ["frequency", "period"]
         if view not in allowed_views:
-            raise ValueError(("'{}' is an invalid value for view; \n"
-                              "allowed values are: {}")
+            raise ValueError(("'{}' is an invalid value for view, "
+                              "allowed values are: {}.")
                              .format(view, allowed_views))
         return view
 


### PR DESCRIPTION
This PR suggests two very minor changes to the `periodogram` module:
1. Ensure that the `view` parameter is validated in a consistent way in both the `Periodogram.__init__()` and `Periodogram.plot()` methods by introducing a single `_validate_view()` method.
2. When `period`, `minimum_period`, or `maximum_period` are passed to `LombScarglePeriodogram.from_lightcurve()`, I propose we set `default_view=period`.  The resulting change in behavior is shown below.

## Old behavior
![Screenshot from 2019-05-22 11-25-14](https://user-images.githubusercontent.com/817669/58199284-04879600-7c85-11e9-9dc7-21dff7c7dcd6.png)

## New behavior
![Screenshot from 2019-05-22 11-26-14](https://user-images.githubusercontent.com/817669/58199304-0cdfd100-7c85-11e9-9ab2-51d27df75979.png)


@ojhall94 Would you be willing to review?