### PR TITLE
Bugfix: BLS periodogram was ignoring the `period` parameter

### DIFF
--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -354,6 +354,7 @@ def test_error_messages():
         assert("parameter must be one 'boxkernel' or 'logmedian'" in err.value.args[0])
 
 
+@pytest.mark.skipif(bad_optional_imports, reason="requires astropy.stats.bls")
 def test_bls_period():
     """Regression test for #514."""
     lc = LightCurve(time=[1, 2, 3], flux=[4, 5, 6])

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -1,7 +1,7 @@
 import pytest
 from astropy import units as u
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 from ..lightcurve import LightCurve
 from ..periodogram import Periodogram
@@ -352,3 +352,11 @@ def test_error_messages():
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).smooth(method="not-implemented")
         assert("parameter must be one 'boxkernel' or 'logmedian'" in err.value.args[0])
+
+
+def test_bls_period():
+    """Regression test for #514."""
+    lc = LightCurve(time=[1, 2, 3], flux=[4, 5, 6])
+    period = [1, 2, 3, 4, 5]
+    pg = lc.to_periodogram(method="bls", period=period)
+    assert_array_equal(pg.period.value, period)

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -215,24 +215,24 @@ def test_bls(caplog):
     p.compute_stats()
     for record in caplog.records:
         assert record.levelname == 'WARNING'
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 3
     assert 'No period specified.' in caplog.text
 
     # No more errors
     stats = p.compute_stats(1, 0.1, 0)
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 3
     assert isinstance(stats, dict)
 
     # Some errors should occur
     p.get_transit_model()
     for record in caplog.records:
         assert record.levelname == 'WARNING'
-    assert len(caplog.records) == 7
+    assert len(caplog.records) == 6
     assert 'No period specified.' in caplog.text
 
     model = p.get_transit_model(1, 0.1, 0)
     # No more errors
-    assert len(caplog.records) == 7
+    assert len(caplog.records) == 6
     # Model is LC
     assert isinstance(model, LightCurve)
     # Model is otherwise identical to LC
@@ -311,47 +311,47 @@ def test_error_messages():
         lc_with_nans = lc.copy()
         lc_with_nans.flux[0] = np.nan
         lc_with_nans.to_periodogram()
-        assert('Lightcurve contains NaN values.' in err.value.args[0])
+    assert('Lightcurve contains NaN values.' in err.value.args[0])
 
     # No unitless periodograms
     with pytest.raises(ValueError) as err:
         Periodogram([0], [1])
-        assert err.value.args[0] == 'frequency must be an `astropy.units.Quantity` object.'
+    assert err.value.args[0] == 'frequency must be an `astropy.units.Quantity` object.'
 
     # No unitless periodograms
     with pytest.raises(ValueError) as err:
         Periodogram([0]*u.Hz, [1])
-        assert err.value.args[0] == 'power must be an `astropy.units.Quantity` object.'
+    assert err.value.args[0] == 'power must be an `astropy.units.Quantity` object.'
 
     # No single value periodograms
     with pytest.raises(ValueError) as err:
         Periodogram([0]*u.Hz, [1]*u.K)
-        assert err.value.args[0] == 'frequency and power must have a length greater than 1.'
+    assert err.value.args[0] == 'frequency and power must have a length greater than 1.'
 
     # No uneven arrays
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2, 3]*u.Hz, [1, 1]*u.K)
-        assert err.value.args[0] == 'frequency and power must have the same length.'
+    assert err.value.args[0] == 'frequency and power must have the same length.'
 
     # Bad frequency units
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.K, [1, 1, 1]*u.K)
-        assert err.value.args[0] == 'Frequency must be in units of 1/time.'
+    assert err.value.args[0] == 'Frequency must be in units of 1/time.'
 
     # Bad binning
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).bin(binsize=-2)
-        assert err.value.args[0] == 'binsize must be larger than or equal to 1'
+    assert err.value.args[0] == 'binsize must be larger than or equal to 1'
 
     # Bad binning method
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).bin(method='not-implemented')
-        assert("is not a valid method, must be 'mean' or 'median'" in err.value.args[0])
+    assert("is not a valid method, must be 'mean' or 'median'" in err.value.args[0])
 
     # Bad smooth method
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).smooth(method="not-implemented")
-        assert("parameter must be one 'boxkernel' or 'logmedian'" in err.value.args[0])
+    assert("parameter must be one of 'boxkernel' or 'logmedian'" in err.value.args[0])
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires astropy.stats.bls")
@@ -361,3 +361,6 @@ def test_bls_period():
     period = [1, 2, 3, 4, 5]
     pg = lc.to_periodogram(method="bls", period=period)
     assert_array_equal(pg.period.value, period)
+    with pytest.raises(ValueError) as err:  # NaNs should raise a nice error message
+        lc.to_periodogram(method="bls", period=[1, 2, 3, np.nan, 4])
+    assert("period" in err.value.args[0])

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -245,7 +245,7 @@ def test_bls(caplog):
     assert mask.sum() > (~mask).sum()
 
     assert isinstance(p.period_at_max_power, u.Quantity)
-    assert isinstance(p.duration_at_max_power, float)
+    assert isinstance(p.duration_at_max_power, u.Quantity)
     assert isinstance(p.transit_time_at_max_power, float)
     assert isinstance(p.depth_at_max_power, float)
 


### PR DESCRIPTION
This PR fixes a bug in `BoxLeastSquaresPeriodogram` which causes the `period` parameter to be ignored, caused by the fact that `kwargs.pop("period")` was called multiple times.  A regression test is included as well.

### Example

```python
>>> lc = lk.LightCurve(time=[1, 2, 3], flux=[4, 5, 6])
>>> pg = lc.to_periodogram(method="bls", period=[1, 2, 3, 4, 5])
>>> pg.period
[0.66666667, 1.1428571, 4]d
```

The behavior expected above is for `pg.period` to return `[1, 2, 3, 4, 5]`.