### PR TITLE
Proposal to remove seven deprecated methods

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -677,14 +677,6 @@ class LightCurve(object):
 
         return binned_lc
 
-    def cdpp(self, **kwargs):
-        """DEPRECATED: use `estimate_cdpp()` instead."""
-        warnings.warn('`LightCurve.cdpp()` is deprecated and will be '
-                      'removed in Lightkurve v1.0.0, '
-                      'please use `LightCurve.estimate_cdpp()` instead.',
-                      LightkurveWarning)
-        return self.estimate_cdpp(**kwargs)
-
     def estimate_cdpp(self, transit_duration=13, savgol_window=101,
                       savgol_polyorder=2, sigma=5.):
         """Estimate the CDPP noise metric using the Savitzky-Golay (SG) method.
@@ -1431,43 +1423,6 @@ class KeplerLightCurve(LightCurve):
 
     def __repr__(self):
         return('KeplerLightCurve(ID: {})'.format(self.targetid))
-
-    def correct(self, method='sff', **kwargs):
-        """DEPRECATED: use `to_corrector(method).correct()` instead.
-
-        Parameters
-        ----------
-        method : str
-            Method used to correct the lightcurve.
-            Right now only 'sff' (Vanderburg's Self-Flat Fielding) is supported.
-        kwargs : dict
-            Dictionary of keyword arguments to be passed to the function
-            defined by `method`.
-
-        Returns
-        -------
-        new_lc : KeplerLightCurve object
-            Corrected lightcurve
-        """
-        warnings.warn('`KeplerLightCurve.correct()` is deprecated and will be '
-                      'removed in Lightkurve v1.0.0, '
-                      'please use `LightCurve.to_corrector("sff").correct()` instead.',
-                      LightkurveWarning)
-
-        not_nan = np.isfinite(self.flux)
-        if method == 'sff':
-            from .correctors import SFFCorrector
-            self.corrector = SFFCorrector(self[not_nan])
-            corrected_lc = self.corrector.correct(centroid_col=self.centroid_col[not_nan],
-                                                  centroid_row=self.centroid_row[not_nan],
-                                                  **kwargs)
-        else:
-            raise ValueError("method {} is not available.".format(method))
-        new_lc = self[not_nan].copy()
-        new_lc.time = corrected_lc.time
-        new_lc.flux = corrected_lc.flux
-        new_lc.flux_err = self.normalize().flux_err[not_nan]
-        return new_lc
 
     def to_pandas(self, columns=['time', 'flux', 'flux_err', 'quality',
                                  'centroid_col', 'centroid_row']):

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -74,17 +74,6 @@ class LightCurveFile(object):
         """Cadence number"""
         return self.hdu[1].data['CADENCENO'][self.quality_mask]
 
-    @classmethod
-    def from_fits(cls, path_or_url, **kwargs):
-        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
-
-        Please use `lightkurve.open()` instead.
-        """
-        warnings.warn('`LightCurveFile.from_fits()` is deprecated and will be '
-                      'removed soon, please use `lightkurve.open()` instead.',
-                      LightkurveWarning)
-        return cls(path_or_url, **kwargs)
-
     def _flux_types(self):
         """Returns a list of available flux types for this light curve file"""
         types = [n for n in self.hdu[1].data.columns.names if 'FLUX' in n]
@@ -185,66 +174,6 @@ class KeplerLightCurveFile(LightCurveFile):
             self.targetid = self.header()['KEPLERID']
         except KeyError:
             self.targetid = None
-
-    @staticmethod
-    def from_archive(target, cadence='long', quarter=None, month=None,
-                     campaign=None, quality_bitmask="default", **kwargs):
-        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
-        Use `lightkurve.search_lightcurvefile()` instead.
-
-        Parameters
-        ----------
-        target : str or int
-            KIC/EPIC ID or object name.
-        cadence : str
-            'long' or 'short'.
-        quarter, campaign : int, list of ints, or 'all'
-            Kepler Quarter or K2 Campaign number.
-        month : 1, 2, 3, list of int, or 'all'
-            For Kepler's prime mission, there are three short-cadence
-            LightCurveFile objects for each quarter, each covering one month.
-            Hence, if cadence='short' you need to specify month=1, 2, or 3.
-        quality_bitmask : str or int
-            Bitmask (integer) which identifies the quality flag bitmask that should
-            be used to mask out bad cadences. If a string is passed, it has the
-            following meaning:
-
-                * "none": no cadences will be ignored (`quality_bitmask=0`).
-                * "default": cadences with severe quality issues will be ignored
-                  (`quality_bitmask=1130799`).
-                * "hard": more conservative choice of flags to ignore
-                  (`quality_bitmask=1664431`). This is known to remove good data.
-                * "hardest": removes all data that has been flagged
-                  (`quality_bitmask=2096639`). This mask is not recommended.
-
-            See the :class:`KeplerQualityFlags` class for details on the bitmasks.
-        kwargs : dict
-            Keywords arguments passed to `KeplerLightCurveFile`.
-
-        Returns
-        -------
-        lcf : KeplerLightCurveFile or LightCurveFileCollection
-        """
-        warnings.warn("`LightCurveFile.from_archive()` is deprecated and will be removed soon, "
-                      "please use `lightkurve.search_lightcurvefile()` instead.",
-                      LightkurveWarning)
-
-        # Be tolerant if a direct path or url is passed to this function by accident
-        if os.path.exists(str(target)) or str(target).startswith('http'):
-            log.warning('Warning: from_archive() is not intended to accept a '
-                        'direct path, use KeplerLightCurveFile(path) instead.')
-            KeplerLightCurveFile(target)
-        else:
-            from .search import search_lightcurvefile
-            sr = search_lightcurvefile(target, cadence=cadence,
-                                       quarter=quarter, month=month,
-                                       campaign=campaign)
-            if len(sr) == 1:
-                return sr.download(quality_bitmask=quality_bitmask, **kwargs)
-            elif len(sr) > 1:
-                return sr.download_all(quality_bitmask=quality_bitmask, **kwargs)
-            else:
-                raise ValueError("No light curve files found that match the search criteria.")
 
     def __repr__(self):
         return('KeplerLightCurveFile(ID: {})'.format(self.targetid))

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -691,16 +691,6 @@ class LombScarglePeriodogram(Periodogram):
         Periodogram : `Periodogram` object
             Returns a Periodogram object extracted from the lightcurve.
         """
-        # If the defaults are used, issue a warning to point out they changed!
-        if normalization == 'amplitude' and freq_unit is None and oversample_factor is None:
-            warnings.warn("As of Lightkurve v1.0.0 (Apr 2019), the default behavior "
-                          "of Lomb Scargle periodograms changed to use "
-                          "normalization='amplitude' and oversample_factor=5 "
-                          "(the previous defaults were normalization='psd' and "
-                          "oversample_factor=1). You can suppress this warning using "
-                          "`warnings.filterwarnings('ignore', category=lk.LightkurveWarning)`.",
-                          LightkurveWarning)
-
         # Input validation for spectrum type
         if normalization not in ('psd', 'amplitude'):
             raise ValueError("The `normalization` parameter must be one of "

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -244,17 +244,6 @@ class TargetPixelFile(object):
                    mywcs[newkey] = self.hdu[1].header[oldkey]
             return WCS(mywcs)
 
-    @classmethod
-    def from_fits(cls, path_or_url, **kwargs):
-        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
-
-        Please use `lightkurve.open()` instead.
-        """
-        warnings.warn('`TargetPixelFile.from_fits()` is deprecated and will be '
-                      'removed soon, please use `lightkurve.open()` instead.',
-                      LightkurveWarning)
-        return cls(path_or_url, **kwargs)
-
     def get_coordinates(self, cadence='all'):
         """Returns two 3D arrays of RA and Dec values in decimal degrees.
 
@@ -480,14 +469,6 @@ class TargetPixelFile(object):
             closest_arg = label_args[np.argmin(distances)]
             closest_label = labels[closest_arg[0], closest_arg[1]]
             return labels == closest_label
-
-    def centroids(self, **kwargs):
-        """DEPRECATED: use `estimate_cdpp()` instead."""
-        warnings.warn('`TargetPixelFile.centroids()` is deprecated and will be '
-                      'removed in Lightkurve v1.0.0, '
-                      'please use `TargetPixelFile.estimate_centroids()` instead.',
-                      LightkurveWarning)
-        return self.estimate_centroids(**kwargs)
 
     def estimate_centroids(self, aperture_mask='pipeline'):
         """Returns centroid positions estimated using sample moments.
@@ -751,65 +732,6 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 self.targetid = self.header['KEPLERID']
             except KeyError:
                 pass
-
-    @staticmethod
-    def from_archive(target, cadence='long', quarter=None, month=None,
-                     campaign=None, quality_bitmask='default', **kwargs):
-        """WARNING: THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED VERY SOON.
-        Use `lightkurve.search_targetpixelfile()` instead.
-
-        Parameters
-        ----------
-        target : str or int
-            KIC/EPIC ID or object name.
-        cadence : str
-            'long' or 'short'.
-        quarter, campaign : int, list of ints, or 'all'
-            Kepler Quarter or K2 Campaign number.
-        month : 1, 2, 3, list or 'all'
-            For Kepler's prime mission, there are three short-cadence
-            Target Pixel Files for each quarter, each covering one month.
-            Hence, if cadence='short' you need to specify month=1, 2, or 3.
-        quality_bitmask : str or int
-            Bitmask (integer) which identifies the quality flag bitmask that should
-            be used to mask out bad cadences. If a string is passed, it has the
-            following meaning:
-
-                * "none": no cadences will be ignored (`quality_bitmask=0`).
-                * "default": cadences with severe quality issues will be ignored
-                  (`quality_bitmask=1130799`).
-                * "hard": more conservative choice of flags to ignore
-                  (`quality_bitmask=1664431`). This is known to remove good data.
-                * "hardest": removes all data that has been flagged
-                  (`quality_bitmask=2096639`). This mask is not recommended.
-
-            See the :class:`KeplerQualityFlags` class for details on the bitmasks.
-        kwargs : dict
-            Keywords arguments passed to the constructor of
-            :class:`KeplerTargetPixelFile`.
-
-        Returns
-        -------
-        tpf : :class:`KeplerTargetPixelFile` or :class:`TargetPixelFileCollection` object.
-        """
-        warnings.warn('`TargetPixelFile.from_archive` is deprecated and will be removed soon, '
-                      'please use `lightkurve.search_targetpixelfile()` instead.',
-                      LightkurveWarning)
-        if os.path.exists(str(target)) or str(target).startswith('http'):
-            log.warning('Warning: from_archive() is not intended to accept a '
-                        'direct path, use KeplerTargetPixelFile(path) instead.')
-            return KeplerTargetPixelFile(target)
-        else:
-            from .search import search_targetpixelfile
-            sr = search_targetpixelfile(target, cadence=cadence,
-                                        quarter=quarter, month=month,
-                                        campaign=campaign)
-            if len(sr) == 1:
-                return sr.download(quality_bitmask=quality_bitmask, **kwargs)
-            elif len(sr) > 1:
-                return sr.download_all(quality_bitmask=quality_bitmask, **kwargs)
-            else:
-                raise ValueError("No target pixel files found that match the search criteria.")
 
     def __repr__(self):
         return('KeplerTargetPixelFile Object (ID: {})'.format(self.targetid))

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -77,8 +77,8 @@ def test_sff_corrector():
     # test using KeplerLightCurve interface
     klc = KeplerLightCurve(time=time, flux=raw_flux, centroid_col=centroid_col,
                            centroid_row=centroid_row)
-    klc = klc.correct(niters=1, windows=1)
-    sff = klc.corrector
+    sff = klc.to_corrector("sff")
+    klc = sff.correct(niters=1, windows=1)
 
     assert_almost_equal(klc.flux*sff.bspline(time),
                         corrected_flux, decimal=3)
@@ -103,7 +103,7 @@ def test_sff_knots():
                           flux=np.random.normal(1.0, 0.1, n_points),
                           centroid_col=np.random.normal(1.0, 0.1, n_points),
                           centroid_row=np.random.normal(1.0, 0.1, n_points))
-    lc.correct()  # should not raise an exception
+    lc.to_corrector(method="sff").correct()  # should not raise an exception
 
 
 @pytest.mark.remote_data

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -749,15 +749,6 @@ def test_regression_346():
     KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct().estimate_cdpp()
 
 
-def test_new_corrector_api():
-    """This test can be remove after we remove the deprecated `LightCurve.correct()` method"""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", LightkurveWarning)  # Deprecation warning
-        lc1 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.correct()
-    lc2 = KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.to_corrector().correct()
-    assert_allclose(lc1.flux, lc2.flux)
-
-
 def test_to_timeseries():
     """Test the `LightCurve.to_timeseries()` method."""
     time, flux, flux_err = range(3), np.ones(3), np.zeros(3)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -5,8 +5,6 @@ with the `@pytest.mark.remote_data` decorator below will only run if the
 `--remote-data` argument is passed to py.test.  This allows tests to pass
 if no internet connection is available.
 """
-from __future__ import division, print_function
-
 import os
 import sys
 import pytest
@@ -222,65 +220,6 @@ def test_empty_searchresult():
         sr.download()
     with pytest.warns(LightkurveWarning, match='empty search'):
         sr.download_all()
-
-
-###
-# DEPRECATED TESTS
-# The tests below verify the DEPRECATED `from_archive` methods.
-# These can be removed once `from_archive` is removed.
-###
-
-@pytest.mark.remote_data
-@pytest.mark.filterwarnings('ignore:Query returned no results')
-def test_kepler_tpf_from_archive_DEPRECATED():
-    # Ignore all deprecation warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", LightkurveWarning)
-        # Request an object name that does not exist
-        with pytest.raises(ValueError):
-            KeplerTargetPixelFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
-        # Request an EPIC ID that was not observed
-        with pytest.raises(ValueError):
-            KeplerTargetPixelFile.from_archive(246000000)
-        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11)
-        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, cadence='short')
-        KeplerTargetPixelFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
-        # If we request 2 quarters it should give a list of two TPFs, ordered by quarter
-        tpfs = KeplerTargetPixelFile.from_archive(5728079, cadence='long', quarter=[1, 2])
-        assert(isinstance(tpfs, TargetPixelFileCollection))
-        assert(isinstance(tpfs[0], KeplerTargetPixelFile))
-        assert(tpfs[0].quarter == 1)
-
-
-@pytest.mark.remote_data
-@pytest.mark.filterwarnings('ignore:Query returned no results')
-def test_kepler_lightcurve_from_archive_DEPRECATED():
-    # Ignore all deprecation warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", LightkurveWarning)
-        # Request an object name that does not exist
-        with pytest.raises(ValueError):
-            KeplerLightCurveFile.from_archive("LightKurve_Unit_Test_Invalid_Target")
-        # Request an EPIC ID that was not observed
-        with pytest.raises(ValueError):
-            KeplerLightCurveFile.from_archive(246000000)
-        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11)
-        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, cadence='short')
-        KeplerLightCurveFile.from_archive('Kepler-10', quarter=11, month=1, cadence='short')
-
-
-@pytest.mark.remote_data
-def test_source_confusion_DEPRECATED():
-    # Regression test for issue #148.
-    # When obtaining the TPF for target 6507433, @benmontet noticed that
-    # a target 4 arcsec away was returned instead.
-    # See https://github.com/KeplerGO/lightkurve/issues/148
-    # Ignore all deprecation warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", LightkurveWarning)
-        desired_target = 6507433
-        tpf = KeplerTargetPixelFile.from_archive(desired_target, quarter=8)
-        assert tpf.targetid == desired_target
 
 
 def test_open():


### PR DESCRIPTION
I propose to remove the following features, which have been deprecated for 6+ months and have had clear warnings announcing their removal in v1.0 during that period:
* `lc.cdpp()` was replaced by `lc.estimate_cdpp()`
* `lc.correct()` was replaced by `lc.to_corrector().correct()`
* `lcf.from_fits()` was replaced by `open()`
* `tpf.from_fits()` was replaced by `open()`
* `lcf.from_archive()` was replaced by `search_lightcurvefile()`
* `tpf.from_archive()` was replaced by `search_targetpixelfile()`
* `tpf.centroids()` was replaced by `tpf.estimate_centroids()`

The pros of doing this are:
* We can remove and stop maintaining 277 lines of code.
* The `from_archive` unit tests can be removed, which will speed up testing.
* The docs will no longer list outdated methods.

The cons are:
* We may break people's code.  Is anyone aware of examples?  Are we removing these features too quickly? Please speak up in the next few days if so!