### PR TITLE
Fixes #520: lc.fold() fails if AstroPy Quantities are passed

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -402,10 +402,13 @@ class LightCurve(object):
             A new light curve object in which the data are folded and sorted by
             phase. The object contains an extra ``phase`` attribute.
         """
-        # Input validation
+        # Input validation.  (Note: Quantities are simply ignored for now;
+        # we should consider adding extra validation here.)
         if isinstance(period, u.quantity.Quantity):
             period = period.value
-    
+        if isinstance(t0, u.quantity.Quantity):
+            t0 = t0.value
+
         # `transit_midpoint` is deprecated
         if transit_midpoint is not None:
             warnings.warn('`transit_midpoint` is deprecated, please use `t0` instead.',

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 
 from astropy.io import fits as pyfits
 from astropy.utils.data import get_pkg_data_filename
+from astropy import units as u
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -187,6 +188,10 @@ def test_lightcurve_fold():
     with pytest.warns(LightkurveWarning, match='appears to be given in JD'):
         lc.fold(10, 2456600)
 
+def test_lightcurve_fold_issue520():
+    """Regression test for #520; accept quantities in `fold()`."""
+    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1)
+    lc.fold(period=1*u.day, t0=5*u.day)
 
 def test_lightcurve_append():
     """Test ``LightCurve.append()``."""


### PR DESCRIPTION
This PR addresses #520.  Last week 6969f92a2d43662f488067d0a0ffd1d4b3e6e1a6 already ensured that the `period` parameter of `fold` can be a Quantity, but this PR also ensures `t0` can be a quantity, and adds a regression test.