### PR TITLE
Add separate aperture for design matrix construction to PLDCorrector

### DIFF
--- a/lightkurve/correctors.py
+++ b/lightkurve/correctors.py
@@ -632,10 +632,14 @@ class PLDCorrector(object):
             when performing Principal Component Analysis for models higher than
             first order. Increasing this value may provide higher precision at
             the expense of computational time.
-        pld_aperture : array-like or None
+        pld_aperture : array-like, 'pipeline', 'all', 'threshold', or None
             A boolean array describing the aperture such that `True` means
             that the pixel will be used when selecting the PLD basis vectors.
-            If `None` is passed in, all pixels will be used.
+            If `None` or `all` are passed in, all pixels will be used.
+            If 'pipeline' is passed, the mask suggested by the official pipeline
+            will be returned.
+            If 'threshold' is passed, all pixels brighter than 3-sigma above
+            the median flux will be used.
 
         Returns
         -------


### PR DESCRIPTION
When applying the `PLDCorrector`, it is sometimes desired to use one aperture mask to generate the light curve and a separate aperture mask to select pixels to use as basis vectors in the PLD design matrix. `PLDCorrector.correct()` now takes two aperture mask arguments:

 - `aperture_mask`: pixels used in aperture photometry to generate the raw flux light curve
- `pld_aperture`: pixels used when selecting PLD basis vectors

Both of these can take the default lightkurve aperture_mask options: `array-like, 'pipeline', 'all', 'threshold', or None`. 

Thank you @christinahedges for this feature request! Do you think the `aperture_mask` argument should be renamed? I'm hesitant to veer away from the naming convention we use in other functions. Feedback welcome!