### PR TITLE
Add separate aperture for design matrix construction to PLDCorrector

### DIFF
--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -91,14 +91,14 @@ class PLDCorrector(object):
         self.time = tpf.time
 
     def correct(self, aperture_mask=None, cadence_mask=None, gp_timescale=30,
-                use_gp=True, pld_order=2, n_pca_terms=10):
+                use_gp=True, pld_order=2, n_pca_terms=10, pld_aperture_mask=None):
         r"""Returns a PLD systematics-corrected LightCurve.
 
         Parameters
         ----------
         aperture_mask : array-like, 'pipeline', 'all', 'threshold', or None
             A boolean array describing the aperture such that `True` means
-            that the pixel will be used.
+            that the pixel will be used to generate the raw flux light curve.
             If `None` or 'all' are passed, all pixels will be used.
             If 'pipeline' is passed, the mask suggested by the official pipeline
             will be returned.
@@ -129,6 +129,14 @@ class PLDCorrector(object):
             when performing Principal Component Analysis for models higher than
             first order. Increasing this value may provide higher precision at
             the expense of computational time.
+        pld_aperture_mask : array-like, 'pipeline', 'all', 'threshold', or None
+            A boolean array describing the aperture such that `True` means
+            that the pixel will be used when selecting the PLD basis vectors.
+            If `None` or `all` are passed in, all pixels will be used.
+            If 'pipeline' is passed, the mask suggested by the official pipeline
+            will be returned.
+            If 'threshold' is passed, all pixels brighter than 3-sigma above
+            the median flux will be used.
 
         Returns
         -------
@@ -169,15 +177,18 @@ class PLDCorrector(object):
         self.flux_err = self.flux_err[nanmask]
         self.time = self.time[nanmask]
 
+        # parse the PLD aperture mask
+        pld_pixel_mask = self.tpf._parse_aperture_mask(pld_aperture_mask)
+
         # find pixel bounds of aperture on tpf
-        xmin, xmax = min(np.where(aperture)[0]),  max(np.where(aperture)[0])
-        ymin, ymax = min(np.where(aperture)[1]),  max(np.where(aperture)[1])
+        xmin, xmax = min(np.where(pld_pixel_mask)[0]),  max(np.where(pld_pixel_mask)[0])
+        ymin, ymax = min(np.where(pld_pixel_mask)[1]),  max(np.where(pld_pixel_mask)[1])
 
         # crop data cube to include only desired pixels
         # this is required for superstamps to ensure matrix is invertable
         flux_crop = self.flux[:, xmin:xmax+1, ymin:ymax+1]
         flux_err_crop = self.flux_err[:, xmin:xmax+1, ymin:ymax+1]
-        aperture_crop = aperture[xmin:xmax+1, ymin:ymax+1]
+        aperture_crop = pld_pixel_mask[xmin:xmax+1, ymin:ymax+1]
 
         # calculate errors (ignore warnings related to zero or negative errors)
         with warnings.catch_warnings():

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -150,3 +150,19 @@ def test_to_corrector():
     tpf = KeplerTargetPixelFile(TABBY_TPF)
     lc = tpf.to_corrector("pld").correct()
     assert len(lc.flux) == len(tpf.time)
+
+
+@pytest.mark.remote_data
+@pytest.mark.skipif(bad_optional_imports, reason="PLD requires celerite and fbpca")
+def test_pld_aperture_mask():
+    """Regression test for #523: does PLDCorrector.correct() accept separate
+    apertures for PLD pixels?"""
+    from .. import KeplerTargetPixelFile
+    from .test_targetpixelfile import TABBY_TPF
+    tpf = KeplerTargetPixelFile(TABBY_TPF)
+    # use only the pixels in the pipeline mask
+    lc_pipeline = tpf.to_corrector("pld").correct(pld_aperture_mask='pipeline')
+    # use all pixels in the tpf
+    lc_all = tpf.to_corrector("pld").correct(pld_aperture_mask='all')
+    # does this improve the correction?
+    assert(lc_all.estimate_cdpp() < lc_pipeline.estimate_cdpp())

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -156,8 +156,8 @@ def test_to_corrector():
 @pytest.mark.remote_data
 @pytest.mark.skipif(bad_optional_imports, reason="PLD requires celerite and fbpca")
 def test_pld_aperture_mask():
-    """Regression test for #523: does PLDCorrector.correct() accept separate
-    apertures for PLD pixels?"""
+    """Test for #523: does PLDCorrector.correct() accept separate apertures for
+    PLD pixels?"""
     from .. import KeplerTargetPixelFile
     from .test_targetpixelfile import TABBY_TPF
     tpf = KeplerTargetPixelFile(TABBY_TPF)

--- a/lightkurve/tests/test_correctors.py
+++ b/lightkurve/tests/test_correctors.py
@@ -127,8 +127,9 @@ def test_pld_corrector():
     # reduce using fewer principle components
     corrected_lc = pld.correct(n_pca_terms=20)
     # try PLD on a TESS observation
-    tess_target = 273985862
-    tess_tpf = search_targetpixelfile(tess_target, mission='TESS').download()
+    from .. import TessTargetPixelFile
+    from .test_targetpixelfile import TESS_SIM
+    tess_tpf = TessTargetPixelFile(TESS_SIM)
     # instantiate PLD corrector object
     pld = PLDCorrector(tess_tpf[:500])
     # produce a PLD-corrected light curve with a pipeline aperture mask

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -54,8 +54,8 @@ def test_search_targetpixelfile():
     search_targetpixelfile(11904151, quarter=11).download()
     # with mission='TESS', it should return TESS observations
     target = "pi Mensae"
-    assert(len(search_targetpixelfile(target, mission='TESS').table) == 1)
-    assert(len(search_targetpixelfile(target, mission='TESS', radius=100).table) == 2)
+    assert(len(search_targetpixelfile(target, mission='TESS').unique_targets) == 1)
+    assert(len(search_targetpixelfile(target, mission='TESS', radius=100).unique_targets) == 2)
     search_targetpixelfile(target, mission='TESS').download()
     # Issue #445: indexing with -1 should return the last index of the search result
     assert(len(search_targetpixelfile("pi Men")[-1]) == 1)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -53,10 +53,11 @@ def test_search_targetpixelfile():
         assert(len(cc) == 2)
     search_targetpixelfile(11904151, quarter=11).download()
     # with mission='TESS', it should return TESS observations
-    target = "pi Mensae"
-    assert(len(search_targetpixelfile(target, mission='TESS').unique_targets) == 1)
-    assert(len(search_targetpixelfile(target, mission='TESS', radius=100).unique_targets) == 2)
-    search_targetpixelfile(target, mission='TESS').download()
+    tic = 273985862
+    assert(len(search_targetpixelfile(tic, mission='TESS').table) == 1)
+    assert(len(search_targetpixelfile(tic, mission='TESS', radius=100).table) == 2)
+    search_targetpixelfile(tic, mission='TESS').download()
+    assert(len(search_targetpixelfile("pi Mensae", sector=1).table) == 1)
     # Issue #445: indexing with -1 should return the last index of the search result
     assert(len(search_targetpixelfile("pi Men")[-1]) == 1)
 
@@ -81,10 +82,10 @@ def test_search_lightcurvefile(caplog):
     assert(len(search_lightcurvefile(c, quarter=6).table) == 1)
     search_lightcurvefile(c, quarter=6).download()
     # with mission='TESS', it should return TESS observations
-    target = "pi Mensae"
-    assert(len(search_lightcurvefile(target, mission='TESS').table) == 1)
-    assert(len(search_lightcurvefile(target, mission='TESS', radius=100).table) == 2)
-    search_lightcurvefile(target, mission='TESS').download()
+    tic = 273985862
+    assert(len(search_lightcurvefile(tic, mission='TESS').table) == 1)
+    assert(len(search_lightcurvefile(tic, mission='TESS', radius=100).table) == 2)
+    search_lightcurvefile(tic, mission='TESS').download()
     assert(len(search_lightcurvefile("pi Mensae", sector=1).table) == 1)
 
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -53,11 +53,10 @@ def test_search_targetpixelfile():
         assert(len(cc) == 2)
     search_targetpixelfile(11904151, quarter=11).download()
     # with mission='TESS', it should return TESS observations
-    tic = 273985862
-    assert(len(search_targetpixelfile(tic, mission='TESS').table) == 1)
-    assert(len(search_targetpixelfile(tic, mission='TESS', radius=100).table) == 2)
-    search_targetpixelfile(tic, mission='TESS').download()
-    assert(len(search_targetpixelfile("pi Mensae", sector=1).table) == 1)
+    target = "pi Mensae"
+    assert(len(search_targetpixelfile(target, mission='TESS').table) == 1)
+    assert(len(search_targetpixelfile(target, mission='TESS', radius=100).table) == 2)
+    search_targetpixelfile(target, mission='TESS').download()
     # Issue #445: indexing with -1 should return the last index of the search result
     assert(len(search_targetpixelfile("pi Men")[-1]) == 1)
 
@@ -82,10 +81,10 @@ def test_search_lightcurvefile(caplog):
     assert(len(search_lightcurvefile(c, quarter=6).table) == 1)
     search_lightcurvefile(c, quarter=6).download()
     # with mission='TESS', it should return TESS observations
-    tic = 273985862
-    assert(len(search_lightcurvefile(tic, mission='TESS').table) == 1)
-    assert(len(search_lightcurvefile(tic, mission='TESS', radius=100).table) == 2)
-    search_lightcurvefile(tic, mission='TESS').download()
+    target = "pi Mensae"
+    assert(len(search_lightcurvefile(target, mission='TESS').table) == 1)
+    assert(len(search_lightcurvefile(target, mission='TESS', radius=100).table) == 2)
+    search_lightcurvefile(target, mission='TESS').download()
     assert(len(search_lightcurvefile("pi Mensae", sector=1).table) == 1)
 
 


### PR DESCRIPTION
_(Reopened from #522 to avoid merge conflicts)_

When applying the `PLDCorrector`, it is sometimes desired to use one aperture mask to generate the light curve and a separate aperture mask to select pixels to use as basis vectors in the PLD design matrix. `PLDCorrector.correct()` now takes two aperture mask arguments:

 - `aperture_mask`: pixels used in aperture photometry to generate the raw flux light curve
 - `pld_aperture_mask`: pixels used when selecting PLD basis vectors
Both of these can take the default lightkurve aperture_mask options: `array-like, 'pipeline', 'all', 'threshold', or None`.

Thank you @christinahedges for this feature request! 