### PR TITLE
Allow LightCurve objects to be added and multiplied

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@
 - Fixed an issue which caused the search functions to be incompatible with the
   current development version of astroquery (v0.3.10). [#598]
 
+- Added support for performing mathematical operations involving `LightCurve`
+  objects, e.g. two `LightCurve` objects can now be added together. [#532]
+
 
 1.1.1 (2019-08-19)
 ==================

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -85,9 +85,9 @@ def test_math_operators_on_objects():
     assert_array_equal((lc2 / lc1).flux, lc2.flux / lc1.flux)
     # LightCurve objects can only be added or multiplied if they have equal length
     with pytest.raises(ValueError):
-        lc1 + lc1[0:-5]
+        lc = lc1 + lc1[0:-5]
     with pytest.raises(ValueError):
-        lc1 * lc1[0:-5]
+        lc = lc1 * lc1[0:-5]
 
 
 def test_rmath_operators():

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -71,6 +71,25 @@ def test_math_operators():
     assert_array_equal(lc_div.flux, lc.flux / 2)
 
 
+def test_math_operators_on_objects():
+    lc1 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
+    lc2 = LightCurve(time=np.arange(1, 5), flux=np.arange(11, 15), flux_err=np.arange(1, 5))
+    assert_array_equal((lc1 + lc2).flux, lc1.flux + lc2.flux)
+    assert_array_equal((lc1 - lc2).flux, lc1.flux - lc2.flux)
+    assert_array_equal((lc1 * lc2).flux, lc1.flux * lc2.flux)
+    assert_array_equal((lc1 / lc2).flux, lc1.flux / lc2.flux)
+    # Change order
+    assert_array_equal((lc2 + lc1).flux, lc2.flux + lc1.flux)
+    assert_array_equal((lc2 - lc1).flux, lc2.flux - lc1.flux)
+    assert_array_equal((lc2 * lc1).flux, lc2.flux * lc1.flux)
+    assert_array_equal((lc2 / lc1).flux, lc2.flux / lc1.flux)
+    # LightCurve objects can only be added or multiplied if they have equal length
+    with pytest.raises(ValueError):
+        lc1 + lc1[0:-5]
+    with pytest.raises(ValueError):
+        lc1 * lc1[0:-5]
+
+
 def test_rmath_operators():
     lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
     lc_add = 1 + lc


### PR DESCRIPTION
## Problem

At present, it is possible to perform math operations involving a `LightCurve` object and a number or array of numbers, e.g.:

```python
>>> from lightkurve import LightCurve
>>> lc = LightCurve(time=[1, 2, 3], flux=[1, 2, 3])
>>> (lc + 5).flux
array([6, 7, 8])
```

However, adding adding or multiplying two LightCurve objects together yields nonsensical results. Example:

```python
>>> lcsum = lc + lc
>>> lcsum.flux
array([<lightkurve.lightcurve.LightCurve object at 0x7f29b06589e8>,
       <lightkurve.lightcurve.LightCurve object at 0x7f29b0658a20>,
       <lightkurve.lightcurve.LightCurve object at 0x7f29b0658cf8>],
      dtype=object)
>>> lcsum.flux[0].flux
array([2, 3, 4])
``` 

## Solution

This PR fixes support for math operations involving two LightCurve objects.  Example:

```python
>>> lcsum = lc + lc
>>> lcsum.flux
array([2, 4, 6])
```

## Notes

* Standard [uncertainty propagation rules](https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae) are being applied.
* If the two `LightCurve` objects being added or multiplied together do not have the same length, a `ValueError` will be raised.
* If the two `LightCurve` objects do not have the same `time` values, a `LightkurveWarning` will be raised.