### PR TITLE
Fix Astropy LombScarglePeriodogram and BoxLeastSquares imports

### DIFF
--- a/lightkurve/interact_bls.py
+++ b/lightkurve/interact_bls.py
@@ -7,10 +7,16 @@ from astropy.convolution import convolve, Box1DKernel
 log = logging.getLogger(__name__)
 
 # Import the optional AstroPy dependency, or print a friendly error otherwise.
+# BoxLeastSquares was added to `astropy.stats` in AstroPy v3.1 and then
+# moved to `astropy.timeseries` in v3.2, which makes the import below
+# somewhat complicated.
 try:
-    from astropy.stats.bls import BoxLeastSquares
+    from astropy.timeseries import BoxLeastSquares
 except ImportError:
-    pass  # we will print an error message in `show_interact_widget` instead
+    try:
+        from astropy.stats import BoxLeastSquares
+    except ImportError:
+        pass  # we will print an error message in `show_interact_widget` instead
 
 # Import the optional Bokeh dependency, or print a friendly error otherwise.
 try:
@@ -415,10 +421,12 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         return None
 
     try:
-        from astropy.stats.bls import BoxLeastSquares
+        from astropy.timeseries import BoxLeastSquares
     except ImportError:
-        log.error("The `interact_bls()` tool requires the `astropy.stats.bls` module; "
-                  "this requires AstroPy v3.1 or later.")
+        try:
+            from astropy.stats import BoxLeastSquares
+        except ImportError:
+            log.error("The `interact_bls()` tool requires AstroPy v3.1 or later.")
 
     def _create_interact_ui(doc, minp=minimum_period, maxp=maximum_period, resolution=resolution):
         """Create BLS interact user interface."""

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -11,10 +11,15 @@ from matplotlib import pyplot as plt
 
 import astropy
 from astropy.table import Table
-from astropy.stats import LombScargle
 from astropy import units as u
 from astropy.units import cds
 from astropy.convolution import convolve, Box1DKernel
+
+# LombScargle was moved from astropy.stats to astropy.timeseries in AstroPy v3.2
+try:
+    from astropy.timeseries import LombScargle
+except ImportError:
+    from astropy.stats import LombScargle
 
 from . import MPLSTYLE
 from .utils import LightkurveWarning
@@ -868,10 +873,16 @@ class BoxLeastSquaresPeriodogram(Periodogram):
     @staticmethod
     def from_lightcurve(lc, **kwargs):
         """Creates a Periodogram from a LightCurve using the Box Least Squares (BLS) method."""
+        # BoxLeastSquares was added to `astropy.stats` in AstroPy v3.1 and then
+        # moved to `astropy.timeseries` in v3.2, which makes the import below
+        # somewhat complicated.
         try:
-            from astropy.stats import BoxLeastSquares
+            from astropy.timeseries import BoxLeastSquares
         except ImportError:
-            raise ImportError("BLS requires AstroPy v3.1 or later")
+            try:
+                from astropy.stats import BoxLeastSquares
+            except ImportError:
+                raise ImportError("BLS requires AstroPy v3.1 or later")
 
         # Validate user input for `lc`
         # (BoxLeastSquares will not work if flux or flux_err contain NaNs)


### PR DESCRIPTION
AstroPy v3.2 has moved the `LombScargle` and `BoxLeastSquares` classes from `astropy.stats` to `astropy.timeseries` (cf. #535).

This PR updates Lightkurve accordingly!