### PR TITLE
Ensure `lk.open()` raises a `FileNotFoundError` when necessary

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -899,20 +899,14 @@ def open(path_or_url, **kwargs):
 
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
-    # Python 2 uses IOError instead of FileNotFoundError;
-    # the block below can be removed when we drop Python 2 support.
-    try:
-        FileNotFoundError
-    except NameError:
-        FileNotFoundError = IOError
-    
     # pass header into `detect_filetype()`
     try:
         with fits.open(path_or_url) as temp:
             filetype = detect_filetype(temp[0].header)
     except OSError as e:
         filetype = None
-        if type(e) == 'FileNotFoundError':
+        # Raise an explicit FileNotFoundError if file not found
+        if 'No such file' in str(e):
             raise e
 
     # if the filetype is recognized, instantiate a class of that name

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -899,6 +899,13 @@ def open(path_or_url, **kwargs):
 
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
+    # Python 2 uses IOError instead of FileNotFoundError;
+    # the block below can be removed when we drop Python 2 support. 
+    try:
+        FileNotFoundError
+    except NameError:
+        FileNotFoundError = IOError
+    
     # pass header into `detect_filetype()`
     try:
         with fits.open(path_or_url) as temp:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -903,6 +903,8 @@ def open(path_or_url, **kwargs):
     try:
         with fits.open(path_or_url) as temp:
             filetype = detect_filetype(temp[0].header)
+    except FileNotFoundError as e:
+        raise e
     except OSError:  # Raised if not a fits file ("Header missing END card")
         filetype = None
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -910,10 +910,10 @@ def open(path_or_url, **kwargs):
     try:
         with fits.open(path_or_url) as temp:
             filetype = detect_filetype(temp[0].header)
-    except FileNotFoundError as e:
-        raise e
-    except OSError:  # Raised if not a fits file ("Header missing END card")
+    except OSError as e:
         filetype = None
+        if type(e) == 'FileNotFoundError':
+            raise e
 
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -900,7 +900,7 @@ def open(path_or_url, **kwargs):
         >>> tpf = open("mytpf.fits")  # doctest: +SKIP
     """
     # Python 2 uses IOError instead of FileNotFoundError;
-    # the block below can be removed when we drop Python 2 support. 
+    # the block below can be removed when we drop Python 2 support.
     try:
         FileNotFoundError
     except NameError:

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -337,5 +337,11 @@ def test_corrupt_download_handling():
 
 def test_filenotfound():
     """Regression test for #540; ensure lk.open() yields `FileNotFoundError`."""
+    # Python 2 uses IOError instead of FileNotFoundError;
+    # the block below can be removed when we drop Python 2 support.
+    try:
+        FileNotFoundError
+    except NameError:
+        FileNotFoundError = IOError
     with pytest.raises(FileNotFoundError):
         open("DOESNOTEXIST")

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -333,3 +333,9 @@ def test_corrupt_download_handling():
         with pytest.raises(SearchError) as err:
             search_targetpixelfile("Kepler-10", quarter=4).download(download_dir=tmpdirname)
         assert "The file was likely only partially downloaded." in err.value.args[0]
+
+
+def test_filenotfound():
+    """Regression test for #540; ensure lk.open() yields `FileNotFoundError`."""
+    with pytest.raises(FileNotFoundError):
+        open("DOESNOTEXIST")


### PR DESCRIPTION
This PR improves the error message when an incorrect path is passed to `lightkurve.open()`.

### Current behavior:

```python
>>> lk.open("DOESNOTEXIST")
ValueError: Not recognized as a Kepler or TESS data product: DOESNOTEXIST
```

### New behavior when this PR is merged:
```python
>>> lk.open("DOESNOTEXIST")
FileNotFoundError: [Errno 2] No such file or directory: 'DOESNOTEXIST'
```

@nksaunders Can you review and merge when tests pass? Thx++.