### PR TITLE
DOC: update kepler-10 doc index page example

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,8 @@
 
     import lightkurve as lk
 
-    pixels = lk.search_targetpixelfile("Kepler-10", quarter=5).download()
+    pixels = lk.search_targetpixelfile("Kepler-10",
+                                       quarter=5).download()
     pixels.plot()
 
     lightcurve = pixels.to_lightcurve()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,13 +37,13 @@
 
     import lightkurve as lk
 
-    pixels = lk.search_targetpixelfile("Kepler-10").download()
+    pixels = lk.search_targetpixelfile("Kepler-10", quarter=5).download()
     pixels.plot()
 
     lightcurve = pixels.to_lightcurve()
     lightcurve.plot()
 
-    exoplanet = lightcurve.flatten().fold(period=0.838)
+    exoplanet = lightcurve.flatten().fold(period=0.8375)
     exoplanet.plot()
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,10 +25,10 @@
           in particular NASA’s Kepler and TESS exoplanet missions.
         </p>
         <p>
-          It intends to lowers the barrier for <i>anyone</i> to analyze
+          It intends to lower the barrier for <i>anyone</i> to analyze
           NASA data by providing a well-tested, well-documented, and fluent <a href="api/index.html">API</a> and <a href="tutorials/index.html">tutorials</a>.
         </p>
-      </div> 
+      </div>
 
       <div class="col-md-6">
 


### PR DESCRIPTION
Hi all,

the current example on the index page gives me the following plot:
![Screen Shot 2019-07-08 at 1 36 26 PM](https://user-images.githubusercontent.com/13077051/60827088-c89d8700-a185-11e9-9fb3-95a6ef252f3d.png)

I propose we tweak the example by using the light curve from quarter 5, which has more data points:
![Screen Shot 2019-07-08 at 1 35 41 PM](https://user-images.githubusercontent.com/13077051/60827165-f4b90800-a185-11e9-9a4a-67a02bc5d126.png)
