### PR TITLE
Have a single `utils.validate_method` function to be re-used across Lightkurve

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -24,7 +24,7 @@ from astropy import units as u
 from . import PACKAGEDIR, MPLSTYLE
 from .utils import (
     running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
-    LightkurveWarning
+    LightkurveWarning, validate_method
 )
 
 __all__ = ['LightCurve', 'KeplerLightCurve', 'TessLightCurve']
@@ -759,9 +759,7 @@ class LightCurve(object):
         - If the original lightcurve contains a quality attribute, then the
           bitwise OR of the quality flags will be returned per bin.
         """
-        available_methods = ['mean', 'median']
-        if method not in available_methods:
-            raise ValueError("method must be one of: {}".format(available_methods))
+        method = validate_method(method, supported_methods=['mean', 'median'])
         methodf = np.__dict__['nan' + method]
 
         n_bins = self.flux.size // binsize
@@ -1221,13 +1219,9 @@ class LightCurve(object):
         Periodogram : `~lightkurve.periodogram.Periodogram` object
             The power spectrum object extracted from the light curve.
         """
-        method_clean = method.replace(' ', '').lower()
-        allowed_methods = ["ls", "bls", "lombscargle", "boxleastsquares"]
-        if method_clean not in allowed_methods:
-            raise ValueError(("Unrecognized method '{0}'\n"
-                              "allowed methods are: {1}")
-                             .format(method, allowed_methods))
-        if method_clean in ["bls", "boxleastsquares"]:
+        supported_methods = ["ls", "bls", "lombscargle", "boxleastsquares"]
+        method = validate_method(method.replace(' ', ''), supported_methods)
+        if method in ["bls", "boxleastsquares"]:
             from . import BoxLeastSquaresPeriodogram
             return BoxLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
         else:

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -28,7 +28,7 @@ from scipy.signal import find_peaks
 
 from . import MPLSTYLE
 
-from .utils import LightkurveWarning
+from .utils import LightkurveWarning, validate_method
 from .lightcurve import LightCurve
 
 log = logging.getLogger(__name__)
@@ -143,8 +143,7 @@ class Periodogram(object):
         # Input validation
         if binsize < 1:
             raise ValueError('binsize must be larger than or equal to 1')
-        if method not in ('mean', 'median'):
-            raise ValueError("{} is not a valid method, must be 'mean' or 'median'.".format(method))
+        method = validate_method(method, ['mean', 'median'])
 
         m = int(len(self.power) / binsize)  # length of the binned arrays
         if method == 'mean':
@@ -213,10 +212,7 @@ class Periodogram(object):
             Returns a new `Periodogram` object in which the power spectrum
             has been smoothed.
         """
-        # Input validation
-        if method not in ('boxkernel', 'logmedian'):
-            raise ValueError("the `method` parameter must be one of "
-                             "'boxkernel' or 'logmedian'.")
+        method = validate_method(method, ['boxkernel', 'logmedian'])
 
         if method == 'boxkernel':
             if filter_width <= 0.:

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -11,7 +11,7 @@ from astropy.units import cds
 from .. import MPLSTYLE
 from . import utils, stellar_estimators
 from ..periodogram import LombScarglePeriodogram, SNRPeriodogram
-from ..utils import LightkurveWarning
+from ..utils import LightkurveWarning, validate_method
 
 log = logging.getLogger(__name__)
 
@@ -76,14 +76,6 @@ class Seismology(object):
                  "uses default periodogram parameters. For further tuneability, "
                  "create a periodogram object first, using `to_periodogram`.")
         return Seismology(periodogram=lc.normalize().remove_nans().fill_gaps().to_periodogram(**kwargs).flatten())
-
-    def _validate_method(self, method, supported_methods):
-        """Raises ValueError if a method is not supported."""
-        method = method.lower()
-        if method in supported_methods:
-            return method
-        raise ValueError("method {} is not supported; "
-                         "must be one of {}".format(method, supported_methods))
 
     def _validate_numax(self, numax):
         """Raises exception if `numax` is None and `self.numax` is not set."""
@@ -281,7 +273,7 @@ class Seismology(object):
         numax : `~lightkurve.seismology.SeismologyQuantity`
             Numax of the periodogram, including details on the units and method.
         """
-        method = self._validate_method(method, supported_methods=["acf2d"])
+        method = validate_method(method, supported_methods=["acf2d"])
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
             result = estimate_numax_acf2d(self.periodogram, **kwargs)
@@ -314,7 +306,7 @@ class Seismology(object):
         deltanu : `~lightkurve.seismology.SeismologyQuantity`
             DeltaNu of the periodogram, including details on the units and method.
         """
-        method = self._validate_method(method, supported_methods=["acf2d"])
+        method = validate_method(method, supported_methods=["acf2d"])
         numax = self._validate_numax(numax)
 
         if method == "acf2d":

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -349,12 +349,12 @@ def test_error_messages():
     # Bad binning method
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).bin(method='not-implemented')
-    assert("is not a valid method, must be 'mean' or 'median'" in err.value.args[0])
+    assert("method 'not-implemented' is not supported" in err.value.args[0])
 
     # Bad smooth method
     with pytest.raises(ValueError) as err:
         Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).smooth(method="not-implemented")
-    assert("parameter must be one of 'boxkernel' or 'logmedian'" in err.value.args[0])
+    assert("method 'not-implemented' is not supported" in err.value.args[0])
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires astropy.stats.bls")

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -9,9 +9,8 @@ import os
 
 from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
-from ..utils import running_mean
 from ..utils import LightkurveWarning
-from ..utils import detect_filetype
+from ..utils import running_mean, detect_filetype, validate_method
 from ..lightcurve import LightCurve
 
 from .. import PACKAGEDIR
@@ -87,9 +86,17 @@ def test_lightkurve_warning():
         lc = LightCurve(time=time, flux=flux)
         assert len(warns) == 0
 
+
 def test_detect_filetype():
     """Can we detect the correct filetype?"""
     k2_path = os.path.join(PACKAGEDIR, "tests", "data", "test-tpf-star.fits")
     tess_path = os.path.join(PACKAGEDIR, "tests", "data", "tess25155310-s01-first-cadences.fits.gz")
     assert detect_filetype(fits.open(k2_path)[0].header) == 'KeplerTargetPixelFile'
     assert detect_filetype(fits.open(tess_path)[0].header) == 'TessTargetPixelFile'
+
+
+def test_validate_method():
+    assert validate_method("foo", ["foo", "bar"]) == "foo"
+    assert validate_method("FOO", ["foo", "bar"]) == "foo"
+    with pytest.raises(ValueError):
+          validate_method("foo", ["bar"])

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -526,7 +526,7 @@ def detect_filetype(header):
 
 def validate_method(method, supported_methods):
     """Raises a `ValueError` if a method is not supported.
-    
+
     Parameters
     ----------
     method : str

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -533,7 +533,7 @@ def validate_method(method, supported_methods):
         The method specified by the user.
     supported_methods : list of str
         The methods supported.  All method names must be lowercase.
-    
+
     Returns
     -------
     method : str

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -522,3 +522,25 @@ def detect_filetype(header):
     # if one of them is Undefined we expect `.lower()` to yield an AttributeError.
     except (KeyError, AttributeError):
         return None
+
+
+def validate_method(method, supported_methods):
+    """Raises a `ValueError` if a method is not supported.
+    
+    Parameters
+    ----------
+    method : str
+        The method specified by the user.
+    supported_methods : list of str
+        The methods supported.  All method names must be lowercase.
+    
+    Returns
+    -------
+    method : str
+        Will return the method name if it is supported.
+    """
+    method = method.lower()
+    if method in supported_methods:
+        return method
+    raise ValueError("method '{}' is not supported; "
+                     "must be one of {}".format(method, supported_methods))


### PR DESCRIPTION
A number of Lightkurve features accepted a `method` argument (e.g. `method="mean"`) and carry out input validation to check that the user requested a supported method. This PR adds a single `utils.validate_method(method, supported_methods)` function which takes care of vetting the method and raising a `ValueError` if needed.  This reduces code duplication.