### PR TITLE
Search: add a warning when a target ID is ambiguous.

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -556,6 +556,10 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
     -------
     SearchResult : :class:`SearchResult` object.
     """
+    if isinstance(target, int) and (200000000 < target) and (target < 300000000):
+        log.warning("Warning: {} is an ambiguous target identifier. "
+                    "Please add the prefix 'TIC' or 'EPIC' to ensure you are "
+                    "searching for the correct target.".format(target))
     observations = _query_mast(target, project=mission, radius=radius)
     log.debug("MAST found {} observations. "
               "Now querying MAST for the corresponding data products."

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -556,10 +556,16 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
     -------
     SearchResult : :class:`SearchResult` object.
     """
-    if isinstance(target, int) and (200000000 < target) and (target < 300000000):
-        log.warning("Warning: {} is an ambiguous target identifier. "
-                    "Please add the prefix 'TIC' or 'EPIC' to ensure you are "
-                    "searching for the correct target.".format(target))
+    if isinstance(target, int):
+        if (0 < target) and (target < 13161030):
+            log.warning("Warning: {} may refer to a different Kepler or TESS target. "
+                        "Please add the prefix 'KIC' or 'TIC' to disambiguate."
+                        "".format(target))
+        elif (0 < 200000000) and (target < 251813739):
+            log.warning("Warning: {} may refer to a different K2 or TESS target. "
+                        "Please add the prefix 'EPIC' or 'TIC' to disambiguate."
+                        "".format(target))
+
     observations = _query_mast(target, project=mission, radius=radius)
     log.debug("MAST found {} observations. "
               "Now querying MAST for the corresponding data products."


### PR DESCRIPTION
This PR addresses #505, #543, #554 by adding a warning when someone searches for an integer TIC ID that could also be an EPIC ID.

Example:
![Screenshot from 2019-08-01 13-55-11](https://user-images.githubusercontent.com/817669/62326909-15623e00-b464-11e9-9523-3cc4a26622ef.png)
