### PR TITLE
Fix `TargetPixelFileCollection.__repr__` crash

### DIFF
--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -8,6 +8,7 @@ import numpy as np
 from . import MPLSTYLE
 from .utils import LightkurveWarning
 from .lightcurvefile import LightCurveFile
+from .targetpixelfile import TargetPixelFile
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +51,8 @@ class Collection(object):
         result = "{} of {} objects:\n".format(self.__class__.__name__, len(self.data))
         if (isinstance(self[0], LightCurveFile)):
             labels = np.asarray([lcf.SAP_FLUX.label for lcf in self])
+        elif (isinstance(self[0], TargetPixelFile)):
+            labels = np.asarray([tpf.targetid for tpf in self])
         else:
             labels = np.asarray([lcf.label for lcf in self])
 

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -93,7 +93,7 @@ def test_tpfcollection():
     assert(tpfc[1] == tpf3)
     tpfc.append(tpf2)
     assert(tpfc[2] == tpf2)
-    str(tpfc)  # Does repr work?
+    str(tpfc)  # Regression test for #564
 
 
 def test_tpfcollection_plot():

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -93,6 +93,7 @@ def test_tpfcollection():
     assert(tpfc[1] == tpf3)
     tpfc.append(tpf2)
     assert(tpfc[2] == tpf2)
+    str(tpfc)  # Does repr work?
 
 
 def test_tpfcollection_plot():


### PR DESCRIPTION
`TargetPixelFileCollection.__repr__` is currently failing.  This PR fixes the bug and adds a regression test.

```Python
>>> import lightkurve as lk
>>> lk.search_targetpixelfile("EPIC 211718120").download_all()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/bin/anaconda/lib/python3.7/site-packages/IPython/core/formatters.py in __call__(self, obj)
    700                 type_pprinters=self.type_printers,
    701                 deferred_pprinters=self.deferred_printers)
--> 702             printer.pretty(obj)
    703             printer.flush()
    704             return stream.getvalue()

~/bin/anaconda/lib/python3.7/site-packages/IPython/lib/pretty.py in pretty(self, obj)
    400                         if cls is not object \
    401                                 and callable(cls.__dict__.get('__repr__')):
--> 402                             return _repr_pprint(obj, self, cycle)
    403 
    404             return _default_pprint(obj, self, cycle)

~/bin/anaconda/lib/python3.7/site-packages/IPython/lib/pretty.py in _repr_pprint(obj, p, cycle)
    695     """A pprint that just redirects to the normal repr function."""
    696     # Find newlines and replace them with p.break_()
--> 697     output = repr(obj)
    698     for idx,output_line in enumerate(output.splitlines()):
    699         if idx:

~/dev/lightkurve/lightkurve/collections.py in __repr__(self)
     52             labels = np.asarray([lcf.SAP_FLUX.label for lcf in self])
     53         else:
---> 54             labels = np.asarray([lcf.label for lcf in self])
     55 
     56         try:

~/dev/lightkurve/lightkurve/collections.py in <listcomp>(.0)
     52             labels = np.asarray([lcf.SAP_FLUX.label for lcf in self])
     53         else:
---> 54             labels = np.asarray([lcf.label for lcf in self])
     55 
     56         try:

AttributeError: 'KeplerTargetPixelFile' object has no attribute 'label'
```