### PR TITLE
Label reprs

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -401,7 +401,7 @@ class Periodogram(object):
         return copy.deepcopy(self)
 
     def __repr__(self):
-        return('Periodogram(ID: {})'.format(self.targetid))
+        return('Periodogram(Source: {})'.format(self.label))
 
     def __getitem__(self, key):
         copy_self = self.copy()
@@ -538,7 +538,7 @@ class SNRPeriodogram(Periodogram):
         super(SNRPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('SNRPeriodogram(ID: {})'.format(self.targetid))
+        return('SNRPeriodogram(Source: {})'.format(self.label))
 
     def plot(self, **kwargs):
         """Plot the SNR spectrum using matplotlib's `plot` method.
@@ -570,7 +570,8 @@ class LombScarglePeriodogram(Periodogram):
         super(LombScarglePeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('LombScarglePeriodogram(ID: {})'.format(self.targetid))
+        return('LombScarglePeriodogram(Source: {})'.format(self.label))
+        
 
     @staticmethod
     def from_lightcurve(lc, minimum_frequency=None, maximum_frequency=None,
@@ -907,7 +908,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         super(BoxLeastSquaresPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('BoxLeastSquaresPeriodogram(ID: {})'.format(self.targetid))
+        return('BoxLeastSquaresPeriodogram(Source: {})'.format(self.label))
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -401,7 +401,7 @@ class Periodogram(object):
         return copy.deepcopy(self)
 
     def __repr__(self):
-        return('Periodogram(Source: {})'.format(self.label))
+        return('Periodogram(ID: {})'.format(self.label))
 
     def __getitem__(self, key):
         copy_self = self.copy()
@@ -538,7 +538,7 @@ class SNRPeriodogram(Periodogram):
         super(SNRPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('SNRPeriodogram(Source: {})'.format(self.label))
+        return('SNRPeriodogram(ID: {})'.format(self.label))
 
     def plot(self, **kwargs):
         """Plot the SNR spectrum using matplotlib's `plot` method.
@@ -570,8 +570,8 @@ class LombScarglePeriodogram(Periodogram):
         super(LombScarglePeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('LombScarglePeriodogram(Source: {})'.format(self.label))
-        
+        return('LombScarglePeriodogram(ID: {})'.format(self.label))
+
 
     @staticmethod
     def from_lightcurve(lc, minimum_frequency=None, maximum_frequency=None,
@@ -908,7 +908,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         super(BoxLeastSquaresPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('BoxLeastSquaresPeriodogram(Source: {})'.format(self.label))
+        return('BoxLeastSquaresPeriodogram(ID: {})'.format(self.label))
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -67,7 +67,7 @@ class Seismology(object):
             tray_str = " - no values have been computed so far."
         else:
             tray_str = " - computed values:\n * " + "\n * ".join([getattr(self, attr).__repr__() for attr in attrs[tray]])
-        return 'Seismology(ID: {}){}'.format(self.periodogram.targetid, tray_str)
+        return 'Seismology(Source: {}){}'.format(self.periodogram.label, tray_str)
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -67,7 +67,7 @@ class Seismology(object):
             tray_str = " - no values have been computed so far."
         else:
             tray_str = " - computed values:\n * " + "\n * ".join([getattr(self, attr).__repr__() for attr in attrs[tray]])
-        return 'Seismology(Source: {}){}'.format(self.periodogram.label, tray_str)
+        return 'Seismology(ID: {}){}'.format(self.periodogram.label, tray_str)
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):


### PR DESCRIPTION
Replace `targetid` with `label` in the reprs of Periodogram and Seismology for disambiguation of mission.  Closes #549 