### PR TITLE
Fixed fits file writing so that it also writes the centroid_col and centroid_row attributes

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1706,7 +1706,9 @@ class TessLightCurve(LightCurve):
             'CCD': self.ccd,
             'SECTOR': self.sector,
             'TARGETID': self.targetid,
-            'DEC_OBJ': self.dec}
+            'DEC_OBJ': self.dec,
+            'MOM_CENTR1': self.centroid_col,
+            'MOM_CENTR2': self.centroid_row}
 
         for kw in tess_specific_data:
             if ~np.asarray([kw.lower == k.lower() for k in extra_data]).any():

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1317,8 +1317,8 @@ class LightCurve(object):
                 cols.append(fits.Column(name=flux_column_name, format='E',
                                         unit='counts', array=self.flux))
             if 'flux_err' in dir(self):
-                if ~np.asarray(['FLUX_ERR' in k.upper() for k in extra_data.keys()]).any():
-                    cols.append(fits.Column(name='FLUX_ERR', format='E',
+                if ~np.asarray([flux_column_name.lower() + '_err' in k.upper() for k in extra_data.keys()]).any():
+                    cols.append(fits.Column(name=flux_column_name.lower() + '_err', format='E',
                                             unit='counts', array=self.flux_err))
             if 'cadenceno' in dir(self):
                 if ~np.asarray(['CADENCENO' in k.upper() for k in extra_data.keys()]).any():
@@ -1581,7 +1581,9 @@ class KeplerLightCurve(LightCurve):
             'DEC_OBJ': self.dec,
             'EQUINOX': 2000,
             'DATE-OBS': Time(self.time[0]+2454833., format=('jd')).isot,
-            'SAP_QUALITY': self.quality}
+            'SAP_QUALITY': self.quality,
+            'MOM_CENTR1': self.centroid_col,
+            'MOM_CENTR2': self.centroid_row}
 
         for kw in kepler_specific_data:
             if ~np.asarray([kw.lower == k.lower() for k in extra_data]).any():

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1317,8 +1317,8 @@ class LightCurve(object):
                 cols.append(fits.Column(name=flux_column_name, format='E',
                                         unit='counts', array=self.flux))
             if 'flux_err' in dir(self):
-                if ~np.asarray([flux_column_name.lower() + '_err' in k.upper() for k in extra_data.keys()]).any():
-                    cols.append(fits.Column(name=flux_column_name.lower() + '_err', format='E',
+                if ~(flux_column_name.upper() + '_ERR' in extra_data.keys()):
+                    cols.append(fits.Column(name=flux_column_name.upper() + '_ERR', format='E',
                                             unit='counts', array=self.flux_err))
             if 'cadenceno' in dir(self):
                 if ~np.asarray(['CADENCENO' in k.upper() for k in extra_data.keys()]).any():

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -59,6 +59,11 @@ class LightCurveFile(object):
         return self.hdu[0].header['DEC_OBJ']
 
     @property
+    def FLUX(self):
+        """Returns a LightCurve object for FLUX"""
+        return self.get_lightcurve('FLUX')
+
+    @property
     def SAP_FLUX(self):
         """Returns a LightCurve object for SAP_FLUX"""
         return self.get_lightcurve('SAP_FLUX')


### PR DESCRIPTION
When we save light curves with `to_fits` we are not passing along `MOM_CENTRX`, which we use for the centroids. This fixes that bug.