### PR TITLE
Issue a warning when normalization makes no sense

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -23,7 +23,7 @@ from astropy import units as u
 from . import PACKAGEDIR, MPLSTYLE
 from .utils import (
     running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
-    LightkurveWarning, validate_method
+    LightkurveWarning, LightkurveError, validate_method
 )
 
 __all__ = ['LightCurve', 'KeplerLightCurve', 'TessLightCurve']
@@ -539,10 +539,32 @@ class LightCurve(object):
         normalized_lightcurve : `LightCurve`
             A new light curve object in which ``flux`` and ``flux_err`` have
             been divided by the median flux.
+
+        Raises
+        ------
+        LightkurveError
+            If the median flux is negative or within one standard deviation
+            from zero.
         """
+        median_flux = np.nanmedian(self.flux)
+        std_flux = np.nanstd(self.flux)
+
+        # If the median flux is separated from zero by less than one standard
+        # deviation, the light curve is likely zero-centered and normalization
+        # makes no sense.
+        if (median_flux == 0) or (np.isfinite(std_flux) and (np.abs(median_flux) < std_flux)):
+            raise LightkurveError("The light curve appears to be zero-centered and cannot be normalized"
+                                  " (median_flux={}, std_flux={}).".format(median_flux, std_flux))
+        # If the median flux is negative, normalization will invert the light
+        # curve and makes no sense.
+        if median_flux < 0:
+            raise LightkurveError("The light curve has a negative median flux and cannot be normalized"
+                                  " (median_flux={}).".format(median_flux))
+        
+        # Create a new light curve instance and normalize its values
         lc = self.copy()
-        lc.flux_err = lc.flux_err / np.nanmedian(lc.flux)
-        lc.flux = lc.flux / np.nanmedian(lc.flux)
+        lc.flux_err = lc.flux_err / median_flux
+        lc.flux = lc.flux / median_flux
         return lc
 
     def remove_nans(self):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -555,14 +555,14 @@ class LightCurve(object):
             warnings.warn("The light curve appears to be zero-centered; "
                           "`normalize()` will divide the light curve by zero "
                           "or a value close to zero. "
-                          "(median_flux={}, std_flux={}).".format(median_flux, std_flux),
+                          "(median_flux={:.2e}, std_flux={:.2e}).".format(median_flux, std_flux),
                           LightkurveWarning)
         # If the median flux is negative, normalization will invert the light
         # curve and makes no sense.
         if median_flux < 0:
             warnings.warn("The light curve has a negative median flux; "
                           "`normalize()` will invert the light curve. "
-                          "(median_flux={})".format(median_flux),
+                          "(median_flux={:.2e})".format(median_flux),
                           LightkurveWarning)
         
         # Create a new light curve instance and normalize its values

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -15,7 +15,7 @@ import warnings
 from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..lightcurvefile import LightCurveFile, KeplerLightCurveFile, TessLightCurveFile
 from ..targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
-from ..utils import LightkurveWarning, LightkurveError
+from ..utils import LightkurveWarning
 from .test_targetpixelfile import TABBY_TPF
 
 # 8th Quarter of Tabby's star
@@ -436,21 +436,18 @@ def test_invalid_normalize():
     """Normalization makes no sense if the light curve is negative or zero-centered."""
     # zero-centered light curve
     lc = LightCurve(time=np.arange(10), flux=np.zeros(10))
-    with pytest.raises(LightkurveError) as err:
+    with pytest.warns(LightkurveWarning, match='zero-centered'):
         lc.normalize()
-    assert "zero-centered" in err.value.args[0]
 
     # zero-centered light curve with flux errors
     lc = LightCurve(time=np.arange(10), flux=np.zeros(10), flux_err=0.05*np.ones(10))
-    with pytest.raises(LightkurveError) as err:
+    with pytest.warns(LightkurveWarning, match='zero-centered'):
         lc.normalize()
-    assert "zero-centered" in err.value.args[0]
 
     # negative light curve
     lc = LightCurve(time=np.arange(10), flux=-np.ones(10), flux_err=0.05*np.ones(10))
-    with pytest.raises(LightkurveError) as err:
+    with pytest.warns(LightkurveWarning, match='negative'):
         lc.normalize()
-    assert "negative" in err.value.args[0]
 
 
 def test_to_pandas():

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -62,7 +62,7 @@ def test_periodogram_can_find_periods():
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
     # Add a 100 day period signal
-    lc.flux *= np.sin((lc.time/float(lc.time.max())) * 20 * np.pi)
+    lc.flux += np.sin((lc.time/float(lc.time.max())) * 20 * np.pi)
     p = lc.to_periodogram(normalization='amplitude')
     assert np.isclose(p.period_at_max_power.value, 100, rtol=1e-3)
 

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -15,7 +15,7 @@ from functools import wraps
 
 log = logging.getLogger(__name__)
 
-__all__ = ['LightkurveWarning', 'LightkurveError',
+__all__ = ['LightkurveWarning',
            'KeplerQualityFlags', 'TessQualityFlags',
            'bkjd_to_astropy_time', 'btjd_to_astropy_time']
 
@@ -443,12 +443,7 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 
 
 class LightkurveWarning(Warning):
-    """Class for Lightkurve warnings."""
-    pass
-
-
-class LightkurveError(Exception):
-    """Class for Lightkurve exceptions."""
+    """Class for all Lightkurve warnings."""
     pass
 
 

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -15,7 +15,7 @@ from functools import wraps
 
 log = logging.getLogger(__name__)
 
-__all__ = ['LightkurveWarning',
+__all__ = ['LightkurveWarning', 'LightkurveError',
            'KeplerQualityFlags', 'TessQualityFlags',
            'bkjd_to_astropy_time', 'btjd_to_astropy_time']
 
@@ -443,7 +443,12 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 
 
 class LightkurveWarning(Warning):
-    """Class for all Lightkurve warnings."""
+    """Class for Lightkurve warnings."""
+    pass
+
+
+class LightkurveError(Exception):
+    """Class for Lightkurve exceptions."""
     pass
 
 


### PR DESCRIPTION
The `LightCurve.normalize()` method normalizes a light curve by dividing the flux by the median value.  However, this does operation does not make any sense for zero-centered light curves, or for light curves with a negative median.

This PR modifies `normalize()` such that an exception is raised in the following situations:
* the median flux is zero, or within one standard deviation from zero;
* the median flux is negative.

Question for feedback: is raising a `LightkurveError` exception the right behavior?  Alternative options are:
* issue a warning and divide by the median anyway;
* issue a warning and return the original light curve.

Thoughts?