### PR TITLE
Suppress warnings during tests

### DIFF
--- a/lightkurve/tests/test_interact.py
+++ b/lightkurve/tests/test_interact.py
@@ -90,7 +90,7 @@ def test_custom_exported_filename():
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_max_cadences():
-    """Can we provide a custom lightcurve to show?"""
+    """Test what is the max number of cadences allowed"""
     import bokeh
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -290,7 +290,8 @@ def test_custom_lightcurve_file(path, mission):
     if mission == "K2":
         lcf_custom = KeplerLightCurveFile(path)
     elif mission == "TESS":
-        lcf_custom = TessLightCurveFile(path)
+        with pytest.warns(LightkurveWarning):
+            lcf_custom = TessLightCurveFile(path)
     assert lcf_custom.hdu[2].name == 'APERTURE'
     assert lcf_custom.cadenceno[0] >= 0
     assert lcf_custom.dec == lcf_custom.dec
@@ -774,7 +775,7 @@ def test_regression_346():
 
 def test_to_timeseries():
     """Test the `LightCurve.to_timeseries()` method."""
-    time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
+    time, flux, flux_err = np.arange(3)+2457576.4, np.ones(3), np.ones(3)*0.01
     lc = LightCurve(time, flux, flux_err, time_format="jd")
     try:
         ts = lc.to_timeseries()

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 from ..lightcurve import LightCurve
 from ..search import search_lightcurvefile
 from ..periodogram import Periodogram
+from ..utils import LightkurveWarning
 import sys
 
 
@@ -20,7 +21,8 @@ def test_periodogram_basics():
     """Sanity check to verify that periodogram plotting works"""
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
-    pg = lc.normalize().to_periodogram()
+    lc = lc.normalize()
+    pg = lc.to_periodogram()
     pg.plot()
     pg.plot(view='period')
     pg.show_properties()
@@ -32,6 +34,7 @@ def test_periodogram_normalization():
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
     # Test amplitude normalization and correct units
+    lc = lc.normalize()
     pg = lc.to_periodogram(normalization='amplitude')
     assert pg.power.unit == u.cds.ppm
 
@@ -39,12 +42,25 @@ def test_periodogram_normalization():
     pg = lc.to_periodogram(freq_unit=u.microhertz, normalization='psd')
     assert pg.power.unit == u.cds.ppm**2 / u.microhertz
 
+def test_periodogram_warnings():
+    """Tests if warnings are raised for non-normalized periodogram input"""
+    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
+                    flux_err=np.zeros(1000)+0.1)
+    # Test amplitude normalization and correct units
+    with pytest.warns(LightkurveWarning):
+        pg = lc.to_periodogram(normalization='amplitude')
+        assert pg.power.unit == u.cds.ppm
+
+    with pytest.warns(LightkurveWarning):
+        pg = lc.to_periodogram(freq_unit=u.microhertz, normalization='psd')
+        assert pg.power.unit == u.cds.ppm**2 / u.microhertz
+
 def test_periodogram_units():
     """Tests whether periodogram has correct units"""
     # Fake, noisy data
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
-    p = lc.to_periodogram(normalization='amplitude')
+    p = lc.normalize().to_periodogram(normalization='amplitude')
     # Has units
     assert hasattr(p.frequency, 'unit')
 
@@ -63,6 +79,7 @@ def test_periodogram_can_find_periods():
                     flux_err=np.zeros(1000)+0.1)
     # Add a 100 day period signal
     lc.flux += np.sin((lc.time/float(lc.time.max())) * 20 * np.pi)
+    lc = lc.normalize()
     p = lc.to_periodogram(normalization='amplitude')
     assert np.isclose(p.period_at_max_power.value, 100, rtol=1e-3)
 
@@ -72,6 +89,7 @@ def test_periodogram_slicing():
     # Fake, noisy data
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
+    lc = lc.normalize()
     p = lc.to_periodogram()
     assert len(p[0:200].frequency) == 200
 
@@ -98,6 +116,7 @@ def test_assign_periods():
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000) + 0.1)
     periods = np.arange(1, 100) * u.day
+    lc = lc.normalize()
     p = lc.to_periodogram(period=periods)
     # Get around the floating point error
     assert np.isclose(np.sum(periods - p.period).value, 0, rtol=1e-14)
@@ -110,6 +129,7 @@ def test_bin():
     """Test if you can bin the periodogram."""
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000) + 0.1)
+    lc = lc.normalize()
     p = lc.to_periodogram()
     assert len(p.bin(binsize=10, method='mean').frequency) == len(p.frequency)//10
     assert len(p.bin(binsize=10, method='median').frequency) == len(p.frequency)//10
@@ -122,6 +142,7 @@ def test_smooth():
     lc = LightCurve(time=np.arange(1000),
                     flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
+    lc = lc.normalize()
     p = lc.to_periodogram(normalization='psd', freq_unit=u.microhertz)
     # Test boxkernel and logmedian methods
     assert all(p.smooth(method='boxkernel').frequency == p.frequency)
@@ -161,6 +182,7 @@ def test_flatten():
     lc = LightCurve(time=np.arange(npts),
                     flux=np.random.normal(1, 0.1, npts),
                     flux_err=np.zeros(npts)+0.1)
+    lc = lc.normalize()
     p = lc.to_periodogram(normalization='psd', freq_unit=1/u.day)
 
     # Check method returns equal frequency
@@ -183,6 +205,7 @@ def test_index():
     """
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
+    lc = lc.normalize()
     p = lc.to_periodogram()
     mask = (p.frequency > 0.1*(1/u.day)) & (p.frequency < 0.2*(1/u.day))
     assert len(p[mask].frequency) == mask.sum()

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -20,7 +20,7 @@ def test_periodogram_basics():
     """Sanity check to verify that periodogram plotting works"""
     lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
                     flux_err=np.zeros(1000)+0.1)
-    pg = lc.to_periodogram()
+    pg = lc.normalize().to_periodogram()
     pg.plot()
     pg.plot(view='period')
     pg.show_properties()

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -36,7 +36,7 @@ def test_search_targetpixelfile():
     assert(len(search_targetpixelfile('KIC 11904151', mission='Kepler', quarter=12).table) == 0)
     # should work for all split campaigns
     campaigns = [[91, 92, 9], [101, 102, 10], [111, 112, 11]]
-    ids = ['EPIC 200068780', 'EPIC 200071712', 'EPIC 202975993']
+    ids = ['EPIC 228162462', 'EPIC 228726301', 'EPIC 202975993']
     for c, idx in zip(campaigns, ids):
         ca = search_targetpixelfile(idx, campaign=c[0]).table
         cb = search_targetpixelfile(idx, campaign=c[1]).table

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -114,7 +114,7 @@ def test_search_tesscut_download():
     ra, dec = 30.578761, -83.210593
     search_string = search_tesscut('{}, {}'.format(ra, dec), sector=[1, 12])
     # Make sure they can be downloaded with default size
-    tpf = search_string.download()
+    tpf = search_string[0].download()
     # Ensure the correct object has been read in
     assert(isinstance(tpf, TessTargetPixelFile))
     # Ensure default size is 5x5
@@ -132,26 +132,26 @@ def test_search_tesscut_download():
     # Ensure correct dimensions
     assert(tpfc[0].flux[0].shape == (4, 4))
     # Download with rectangular dimennsions?
-    rect_tpf = search_string.download(cutout_size=(3, 5))
+    rect_tpf = search_string[0].download(cutout_size=(3, 5))
     assert(rect_tpf.flux[0].shape == (3, 5))
 
 
 @pytest.mark.remote_data
 def test_search_with_skycoord():
     """Can we pass both names, SkyCoord objects, and coordinate strings?"""
-    sr_name = search_targetpixelfile("Kepler-10")
+    sr_name = search_targetpixelfile("Kepler-10", mission='Kepler')
     assert len(sr_name) == 15  # Kepler-10 as observed during 15 quarters in long cadence
     # Can we search using a SkyCoord objects?
-    sr_skycoord = search_targetpixelfile(SkyCoord.from_name("Kepler_10"))
+    sr_skycoord = search_targetpixelfile(SkyCoord.from_name("Kepler_10"), mission='Kepler')
     assert_array_equal(sr_name.table['productFilename'], sr_skycoord.table['productFilename'])
     # Can we search using a string of "ra dec" decimals?
-    sr_decimal = search_targetpixelfile("285.67942179 +50.24130576")
+    sr_decimal = search_targetpixelfile("285.67942179 +50.24130576", mission='Kepler')
     assert_array_equal(sr_name.table['productFilename'], sr_decimal.table['productFilename'])
     # Can we search using a sexagesimal string?
-    sr_sexagesimal = search_targetpixelfile("19:02:43.1 +50:14:28.7")
+    sr_sexagesimal = search_targetpixelfile("19:02:43.1 +50:14:28.7", mission='Kepler')
     assert_array_equal(sr_name.table['productFilename'], sr_sexagesimal.table['productFilename'])
     # Can we search using the KIC ID?
-    sr_kic = search_targetpixelfile('KIC 11904151')
+    sr_kic = search_targetpixelfile('KIC 11904151', mission='Kepler')
     assert_array_equal(sr_name.table['productFilename'], sr_kic.table['productFilename'])
 
 


### PR DESCRIPTION
This PR is aimed at suppressing warnings when running the unit test.  See Issues #586, #585, and others.