### PR TITLE
Fix for Issue #594-- rectify before the reshape in echelle_plot

### DIFF
--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -13,6 +13,8 @@ from . import utils, stellar_estimators
 from ..periodogram import SNRPeriodogram
 from ..utils import LightkurveWarning, validate_method
 
+from scipy.signal import find_peaks
+
 log = logging.getLogger(__name__)
 
 __all__ = ['Seismology']
@@ -94,6 +96,7 @@ class Seismology(object):
             except AttributeError:
                 raise AttributeError("You need to call `Seismology.estimate_deltanu()` first.")
         return deltanu
+
 
     def plot_echelle(self, deltanu=None, numax=None,
                      minimum_frequency=None, maximum_frequency=None,
@@ -210,17 +213,25 @@ class Seismology(object):
         ff = freq[int(fmin/fs)-x0:int(fmax/fs)-x0] # Selected frequency range
         pp = power[int(fmin/fs)-x0:int(fmax/fs)-x0] # Power range
 
-        n_rows = int((ff[-1]-ff[0])/deltanu) # Number of stacks to use
-        n_columns = int(deltanu/fs)          # Number of elements in each stack
-
         # Reshape the power into n_rows of n_columns
-        ep = np.reshape(pp[:(n_rows*n_columns)], (n_rows, n_columns))
+        #  Must start and end where the modulus approximately equals zero,
+        #  Otherwise you get a phase shift from the correct (x,y) extents
+        # This implementation will truncate any partially-filled rows.
+
+        mod_zeros = find_peaks( -1.0*(ff % deltanu) )[0]
+        start, approx_end = mod_zeros[0], mod_zeros[-1]
+        approx_samples = (approx_end - start)
+        n_rows = len(mod_zeros) - 1
+        n_columns =  approx_samples // n_rows
+        end = start + n_columns*n_rows
+
+        ep = np.reshape(pp[start : end], (n_rows, n_columns))
 
         if scale=='log':
             ep = np.log10(ep)
 
         #Reshape the freq into n_rowss of n_columnss & create arays
-        ef = np.reshape(ff[:(n_rows*n_columns)],(n_rows,n_columns))
+        ef = np.reshape(ff[start : end], (n_rows, n_columns))
         x_f = ((ef[0,:]-ef[0,0]) % deltanu)
         y_f = (ef[:,0])
 
@@ -233,8 +244,10 @@ class Seismology(object):
             b = (extent[3] - extent[2]) / (extent[1] - extent[0])
             vmin = np.nanpercentile(ep.value, 1)
             vmax = np.nanpercentile(ep.value, 99)
+
             im = ax.imshow(ep.value, cmap=cmap, aspect=a/b, origin='lower',
-                      extent=extent, vmin=vmin, vmax=vmax)
+                        extent=extent, vmin=vmin, vmax=vmax)
+
             cbar = plt.colorbar(im, ax=ax, extend='both', pad=.01)
 
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -214,15 +214,28 @@ class Seismology(object):
         pp = power[int(fmin/fs)-x0:int(fmax/fs)-x0] # Power range
 
         # Reshape the power into n_rows of n_columns
-        #  Must start and end where the modulus approximately equals zero,
-        #  Otherwise you get a phase shift from the correct (x,y) extents
-        # This implementation will truncate any partially-filled rows.
-
+        #  When modulus ~ zero, deltanu divides into frequency without remainder
         mod_zeros = find_peaks( -1.0*(ff % deltanu) )[0]
-        start, approx_end = mod_zeros[0], mod_zeros[-1]
-        approx_samples = (approx_end - start)
+
+        # The bottom left corner of the plot is the lowest frequency that
+        # divides into deltanu with almost zero remainder
+        start = mod_zeros[0]
+
+        # The top left corner of the plot is the highest frequency that
+        # divides into deltanu with almost zero remainder.  This index is the
+        # approximate end, because we fix an integer number of rows and columns
+        approx_end = mod_zeros[-1]
+
+        # The number of rows is the number of times you can partition your
+        #  frequency range into chunks of size deltanu, start and ending at
+        #  frequencies that divide nearly evenly into deltanu
         n_rows = len(mod_zeros) - 1
-        n_columns =  approx_samples // n_rows
+
+        # The number of columns is the total number of frequency points divided
+        #  by the number of rows, floor divided to the nearest integer value
+        n_columns =  int( (approx_end - start) / n_rows )
+
+        # The exact end point is therefore the ncolumns*nrows away from the start
         end = start + n_columns*n_rows
 
         ep = np.reshape(pp[start : end], (n_rows, n_columns))


### PR DESCRIPTION
Hi all,

This PR fixes #594.  Basically what was happening is that if you reshape with partially-filled rows, the faction of filled row phase shifts all subsequent rows by the size of the fraction.  You need to start and end your frequency array near where the modulus is zero.  

An alternative solution would have been to pad the partially-filled rows with NaNs up to the previous modulus=0 frequency.  That approach has some advantages, and could be implemented instead of this one if there is user interest.

Here is the revised figure.

![image](https://user-images.githubusercontent.com/860227/66168207-74256e80-e5f1-11e9-842b-b1badb9951df.png)

Thanks to @danhey for raising this issue, and thanks for making `echelle` source code available.  I used it in the debugging process for this PR.

Cheers,
-gully
