### PR TITLE
lightkurve.utils incorrectly resolved to lightkurve.seismology.utils (fixes #605)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,4 +52,4 @@ Comments, corrections & suggestions:
 - `Richard Elkins <https://github.com/texadactyl>`_
 - `Daniel Foreman-Mackey <https://github.com/dfm>`_
 - `Saeed Hojjatpanah <https://github.com/saeedm31>`_
-
+- `Sam Lee <https://github.com/orionlee>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 - Fixed a bug in `Seismology.plot_echelle()` which caused the Echelle diagram
   of a power spectrum to be rendered incorrectly. [#602]
 
+- Fixed a bug which caused `lightkurve.utils` to be incorrectly resolved to
+  `lightkurve.seismology.utils`. [#606]
+
 
 
 1.2.0 (2019-10-01)

--- a/lightkurve/seismology/__init__.py
+++ b/lightkurve/seismology/__init__.py
@@ -1,5 +1,10 @@
 """The `lightkurve.seismology` sub-package provides classes and functions for
 quick-look asteroseismic analyses."""
+
+# Do not export the modules in this subpackage to the root namespace, important
+# because `lightkurve.utils` collides with `lightkurve.seismology.utils`.
+__all__ = []
+
 from .core import *
 from .utils import *
 

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -100,3 +100,9 @@ def test_validate_method():
     assert validate_method("FOO", ["foo", "bar"]) == "foo"
     with pytest.raises(ValueError):
           validate_method("foo", ["bar"])
+
+
+def test_import():
+    """Regression test for #605; `lk.utils` resolved to `lk.seismology.utils`"""
+    from .. import utils
+    assert hasattr(utils, "btjd_to_astropy_time")


### PR DESCRIPTION
This PR intends to fix #605 (lightkurve.utils incorrectly resolved to lightkurve.seismology.utils).