### PR TITLE
fix typo in btjd parameter explanation

### DIFF
--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -358,7 +358,7 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
     Parameters
     ----------
     btjd : array of floats
-        Barycentric Kepler Julian Day
+        Barycentric TESS Julian Day
     bjdref : float
         BJD reference date.
 


### PR DESCRIPTION
For function `btjd_to_astropy_time()`, the `btjd` parameter was incorrectly stated as Barycentric Kepler Julian Day. The PR fixed it.