### PR TITLE
Allow `bkjd_to_astropy_time` and `btjd_to_astropy_time` to accept any iterable (fixes #607)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,4 +1,4 @@
-Direct code contributions:
+Direct code contributions and bugfixes:
 
 - `Geert Barentsen <https://github.com/barentsen>`_
 - `Christina Hedges <https://github.com/christinahedges>`_
@@ -21,6 +21,7 @@ Direct code contributions:
 - `Zachory K. Berta-Thompson <https://github.com/zkbt>`_
 - `Peter Williams <https://github.com/pkgw>`_
 - `Szabo Pal <https://github.com/zabop>`_
+- `Sam Lee <https://github.com/orionlee>`_
 
 
 Comments, corrections & suggestions:
@@ -52,4 +53,3 @@ Comments, corrections & suggestions:
 - `Richard Elkins <https://github.com/texadactyl>`_
 - `Daniel Foreman-Mackey <https://github.com/dfm>`_
 - `Saeed Hojjatpanah <https://github.com/saeedm31>`_
-- `Sam Lee <https://github.com/orionlee>`_

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -111,7 +111,11 @@ def test_import():
 
 def test_btjd_bkjd_input():
     """Regression test for #607: are the bkjd/btjd functions tolerant?"""
-    for user_input in [0, [0], np.array([0])]:
+    # Kepler
+    assert bkjd_to_astropy_time(0).value == 2454833.
+    for user_input in [[0], np.array([0])]:
         assert_array_equal(bkjd_to_astropy_time(user_input).value, np.array([2454833.]))
-    for user_input in [0, [0], np.array([0])]:
+    # TESS
+    assert btjd_to_astropy_time(0).value == 2457000.
+    for user_input in [[0], np.array([0])]:
         assert_array_equal(btjd_to_astropy_time(user_input).value, np.array([2457000.]))

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 from astropy.io import fits
 import pytest
 import warnings
@@ -11,6 +11,7 @@ from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
 from ..utils import LightkurveWarning
 from ..utils import running_mean, detect_filetype, validate_method
+from ..utils import bkjd_to_astropy_time, btjd_to_astropy_time
 from ..lightcurve import LightCurve
 
 from .. import PACKAGEDIR
@@ -106,3 +107,11 @@ def test_import():
     """Regression test for #605; `lk.utils` resolved to `lk.seismology.utils`"""
     from .. import utils
     assert hasattr(utils, "btjd_to_astropy_time")
+
+
+def test_btjd_bkjd_input():
+    """Regression test for #607: are the bkjd/btjd functions tolerant?"""
+    for user_input in [0, [0], np.array([0])]:
+        assert_array_equal(bkjd_to_astropy_time(user_input).value, np.array([2454833.]))
+    for user_input in [0, [0], np.array([0])]:
+        assert_array_equal(btjd_to_astropy_time(user_input).value, np.array([2457000.]))

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -344,6 +344,8 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
     # Some data products have missing time values;
     # we need to set these to zero or `Time` cannot be instantiated.
     jd[~np.isfinite(jd)] = 0
+    if isinstance(bkjd, float):  # If user entered a float, return a float
+        jd = jd[0]
     return Time(jd, format='jd', scale='tdb')
 
 
@@ -371,6 +373,8 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
     btjd = np.atleast_1d(btjd)
     jd = btjd + bjdref
     jd[~np.isfinite(jd)] = 0
+    if isinstance(btjd, float):  # If user entered a float, return a float
+        jd = jd[0]
     return Time(jd, format='jd', scale='tdb')
 
 

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -329,7 +329,7 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
 
     Parameters
     ----------
-    bkjd : array of floats
+    bkjd : float or array of floats
         Barycentric Kepler Julian Day.
     bjdref : float
         BJD reference date, for Kepler this is 2454833.
@@ -339,6 +339,7 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
     time : astropy.time.Time object
         Resulting time object
     """
+    bkjd = np.atleast_1d(bkjd)
     jd = bkjd + bjdref
     # Some data products have missing time values;
     # we need to set these to zero or `Time` cannot be instantiated.
@@ -357,7 +358,7 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
 
     Parameters
     ----------
-    btjd : array of floats
+    btjd : float or array of floats
         Barycentric TESS Julian Day
     bjdref : float
         BJD reference date.
@@ -367,6 +368,7 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
     time : astropy.time.Time object
         Resulting time object
     """
+    btjd = np.atleast_1d(btjd)
     jd = btjd + bjdref
     jd[~np.isfinite(jd)] = 0
     return Time(jd, format='jd', scale='tdb')

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -317,7 +317,8 @@ def running_mean(data, window_size):
 
 
 def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
-    """Converts BKJD time values to an `astropy.time.Time` object.
+    """Converts Kepler Barycentric Julian Day (BKJD) time values to an
+    `astropy.time.Time` object.
 
     Kepler Barycentric Julian Day (BKJD) is a Julian day minus 2454833.0
     (UTC=January 1, 2009 12:00:00) and corrected to the arrival times
@@ -336,8 +337,8 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
 
     Returns
     -------
-    time : astropy.time.Time object
-        Resulting time object
+    time : `astropy.time.Time` object
+        Resulting time object.
     """
     bkjd = np.atleast_1d(bkjd)
     jd = bkjd + bjdref
@@ -350,7 +351,8 @@ def bkjd_to_astropy_time(bkjd, bjdref=2454833.):
 
 
 def btjd_to_astropy_time(btjd, bjdref=2457000.):
-    """Converts BTJD time values to an `astropy.time.Time` object.
+    """Converts TESS Barycentric Julian Day (BTJD) values to an
+    `astropy.time.Time` object.
 
     TESS Barycentric Julian Day (BTJD) is a Julian day minus 2457000.0
     and corrected to the arrival times at the barycenter of the Solar System.
@@ -367,8 +369,8 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
 
     Returns
     -------
-    time : astropy.time.Time object
-        Resulting time object
+    time : `astropy.time.Time` object
+        Resulting time object.
     """
     btjd = np.atleast_1d(btjd)
     jd = btjd + bjdref


### PR DESCRIPTION
This PR addresses #607.