### PR TITLE
Make `centroid_quadratic()` more robust

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -413,7 +413,8 @@ class TargetPixelFile(object):
                 aperture_mask = self.pipeline_mask
             elif aperture_mask == 'threshold':
                 aperture_mask = self.create_threshold_mask()
-            elif (aperture_mask.dtype == int) and ((aperture_mask & 2) == 2).any():
+            elif np.issubdtype(aperture_mask.dtype, np.integer) and \
+                ((aperture_mask & 2) == 2).any():
                 # Kepler and TESS pipeline style integer flags
                 aperture_mask = (aperture_mask & 2) == 2
         self._last_aperture_mask = aperture_mask

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -397,6 +397,12 @@ class TargetPixelFile(object):
         aperture_mask : ndarray
             2D boolean numpy array containing `True` for selected pixels.
         """
+        # Input validation
+        if hasattr(aperture_mask, 'shape') and (aperture_mask.shape != self.flux[0].shape):
+            raise ValueError("`aperture_mask` has shape {}, "
+                             "but the flux data has shape {}"
+                             "".format(aperture_mask.shape, self.flux[0].shape))
+
         with warnings.catch_warnings():
             # `aperture_mask` supports both arrays and string values; these yield
             # uninteresting FutureWarnings when compared, so let's ignore that.
@@ -407,7 +413,8 @@ class TargetPixelFile(object):
                 aperture_mask = self.pipeline_mask
             elif aperture_mask == 'threshold':
                 aperture_mask = self.create_threshold_mask()
-            elif ((aperture_mask & 2) == 2).any(): # Kepler-pipeline style
+            elif (aperture_mask.dtype == int) and ((aperture_mask & 2) == 2).any():
+                # Kepler and TESS pipeline style integer flags
                 aperture_mask = (aperture_mask & 2) == 2
         self._last_aperture_mask = aperture_mask
         return aperture_mask
@@ -513,7 +520,7 @@ class TargetPixelFile(object):
         -------
         columns, rows : array, array
             Arrays containing the column and row positions for the centroid
-            for each cadence.
+            for each cadence, or NaN for cadences where the estimation failed.
         """
         method = validate_method(method, ['moments', 'quadratic'])
         if method == 'moments':

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -123,12 +123,14 @@ def test_btjd_bkjd_input():
 
 
 def test_centroid_quadratic():
+    """Test basic operation of the quadratic centroiding function."""
     # Single bright pixel in the center
     data = np.ones((9, 9))
     data[2, 5] = 10
     col, row = centroid_quadratic(data)
     assert np.isclose(row, 2) & np.isclose(col, 5)
 
+    # Two equally-bright pixels side by side
     data = np.zeros((9, 9))
     data[5, 1] = 5
     data[5, 2] = 5
@@ -143,14 +145,17 @@ def test_centroid_quadratic():
 
 
 def test_centroid_quadratic_robustness():
+    """Test quadratic centroids in edge cases; regression test for #610."""
     # Brightest pixel in upper left
     data = np.zeros((5, 5))
     data[0, 0] = 1
     centroid_quadratic(data)
+
     # Brightest pixel in bottom right
     data = np.zeros((5, 5))
     data[-1, -1] = 1
     centroid_quadratic(data)
+
     # Data contains a NaN
     data = np.zeros((5, 5))
     data[0, 0] = np.nan

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -123,11 +123,23 @@ def test_btjd_bkjd_input():
 
 
 def test_centroid_quadratic():
+    # Single bright pixel in the center
     data = np.ones((9, 9))
     data[2, 5] = 10
     col, row = centroid_quadratic(data)
-    assert np.isclose(row, 2)
-    assert np.isclose(col, 5)
+    assert np.isclose(row, 2) & np.isclose(col, 5)
+
+    data = np.zeros((9, 9))
+    data[5, 1] = 5
+    data[5, 2] = 5
+    col, row = centroid_quadratic(data)
+    assert np.isclose(row, 5) & np.isclose(col, 1.5)
+
+    # Single bright pixel near the edge -- FAILS
+    #data = np.ones((9, 9))
+    #data[5, 0] = 10
+    #col, row = centroid_quadratic(data)
+    #assert np.isclose(row, 5) & np.isclose(col, 0)
 
 
 def test_centroid_quadratic_robustness():

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -137,12 +137,6 @@ def test_centroid_quadratic():
     col, row = centroid_quadratic(data)
     assert np.isclose(row, 5) & np.isclose(col, 1.5)
 
-    # Single bright pixel near the edge -- FAILS
-    #data = np.ones((9, 9))
-    #data[5, 0] = 10
-    #col, row = centroid_quadratic(data)
-    #assert np.isclose(row, 5) & np.isclose(col, 0)
-
 
 def test_centroid_quadratic_robustness():
     """Test quadratic centroids in edge cases; regression test for #610."""

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -12,6 +12,7 @@ from ..utils import module_output_to_channel, channel_to_module_output
 from ..utils import LightkurveWarning
 from ..utils import running_mean, detect_filetype, validate_method
 from ..utils import bkjd_to_astropy_time, btjd_to_astropy_time
+from ..utils import centroid_quadratic
 from ..lightcurve import LightCurve
 
 from .. import PACKAGEDIR
@@ -119,3 +120,28 @@ def test_btjd_bkjd_input():
     assert btjd_to_astropy_time(0).value == 2457000.
     for user_input in [[0], np.array([0])]:
         assert_array_equal(btjd_to_astropy_time(user_input).value, np.array([2457000.]))
+
+
+def test_centroid_quadratic():
+    data = np.ones((9, 9))
+    data[2, 5] = 10
+    col, row = centroid_quadratic(data)
+    assert np.isclose(row, 2)
+    assert np.isclose(col, 5)
+
+
+def test_centroid_quadratic_robustness():
+    # Brightest pixel in upper left
+    data = np.zeros((5, 5))
+    data[0, 0] = 1
+    centroid_quadratic(data)
+    # Brightest pixel in bottom right
+    data = np.zeros((5, 5))
+    data[-1, -1] = 1
+    centroid_quadratic(data)
+    # Data contains a NaN
+    data = np.zeros((5, 5))
+    data[0, 0] = np.nan
+    data[-1, -1] = 10
+    col, row = centroid_quadratic(data)
+    assert np.isfinite(col) & np.isfinite(row)

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -567,6 +567,9 @@ def centroid_quadratic(data, mask=None):
     For the motivation and the details around this technique, please refer
     to Vakili, M., & Hogg, D. W. 2016, ArXiv, 1610.05873.
 
+    Caveat: if the brightest pixel falls on the edge of the data array, the fit
+    will tend to fail or be inaccurate.
+
     Parameters
     ----------
     data : 2D array
@@ -578,7 +581,8 @@ def centroid_quadratic(data, mask=None):
     Returns
     -------
     column, row : tuple
-        The coordinates of the centroid in column and row.
+        The coordinates of the centroid in column and row.  If the fit failed,
+        then (NaN, NaN) will be returned.
     """
     # Step 1: identify the patch of 3x3 pixels (z_)
     # that is centered on the brightest pixel (xx, yy)
@@ -625,7 +629,7 @@ def centroid_quadratic(data, mask=None):
     # following https://en.wikipedia.org/wiki/Quadratic_function
     det = 4 * d * f - e ** 2
     if abs(det) < 1e-6:
-        return None, None  # No solution
+        return np.nan, np.nan  # No solution
     xm = - (2 * f * b - c * e) / det
     ym = - (2 * d * c - b * e) / det
     return xx + xm, yy + ym

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -584,8 +584,18 @@ def centroid_quadratic(data, mask=None):
     # that is centered on the brightest pixel (xx, yy)
     if mask is not None:
         data = data * mask
-    arg_data_max = np.argmax(data)
+    arg_data_max = np.nanargmax(data)
     yy, xx = np.unravel_index(arg_data_max, data.shape)
+    # Make sure the 3x3 patch does not leave the TPF bounds
+    if yy < 1:
+        yy = 1
+    if xx < 1:
+        xx = 1
+    if yy > (data.shape[0] - 2):
+        yy = data.shape[0] - 2
+    if xx > (data.shape[1] - 2):
+        xx = data.shape[1] - 2
+
     z_ = data[yy-1:yy+2, xx-1:xx+2]
 
     # Next, we will fit the coefficients of the bivariate quadratic with the


### PR DESCRIPTION
The new `centroid_quadratic()` function added by #544 appears to raise exceptions in specific edge cases, e.g.:
* source falls on the edge;
* source falls in a corner;
* flux data contains NaNs.

This PR adds a few tests and bugfixes to make the new feature more robust.