### PR TITLE
include "ls_method" keyword in docstrings

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1359,7 +1359,7 @@ class LightCurve(object):
         ``minimum_frequency``, ``maximum_frequency``, ``mininum_period``,
         ``maximum_period``, ``frequency``, ``period``, ``nterms``,
         ``nyquist_factor``, ``oversample_factor``, ``freq_unit``,
-        ``normalization``.
+        ``normalization``, ``ls_method``.
 
         Optional keywords accepted if ``method='bls'`` are
         ``minimum_period``, ``maximum_period``, ``period``,

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -696,6 +696,9 @@ class LombScarglePeriodogram(Periodogram):
             Default: `'amplitude'`. The desired normalization of the spectrum.
             Can be either power spectral density (`'psd'`) or amplitude
             (`'amplitude'`).
+        ls_method : str
+            Default: `'fast'`. Passed to the `method` keyword of 
+            `astropy.stats.LombScargle()`.
         kwargs : dict
             Keyword arguments passed to `astropy.stats.LombScargle()`
 
@@ -811,9 +814,9 @@ class LombScarglePeriodogram(Periodogram):
         frequency = u.Quantity(frequency, freq_unit)
 
         if period is not None:
-            if ls_method is 'fastchi2':
+            if ls_method == 'fastchi2':
                 ls_method = 'chi2'
-            elif ls_method is 'fast':
+            elif ls_method == 'fast':
                 ls_method = 'slow'
 
             log.warning("You have passed an evenly-spaced grid of periods. "


### PR DESCRIPTION
Information about the `ls_method` keyword was missing from the documentation.