### PR TITLE
Bugfix for `SFFCorrector` so that `breakindex` accepts a list

### DIFF
--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -407,9 +407,10 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
     thrusters = np.where(thrusters)[0]
 
     # Find the nearest point to each thruster firing, unless it's a user supplied break point
-    window_points = [thrusters[np.argmin(np.abs(wp - thrusters))] + 1
-                         for wp in window_points
-                         if wp not in breakindexes]
+    # I think this is not necessary anymore.
+    #window_points = [thrusters[np.argmin(np.abs(wp - thrusters))] + 1
+    #                     for wp in window_points
+    #                     if wp not in breakindexes]
     window_points = np.unique(np.hstack([window_points, breakindexes]))
 
     # If the first or last windows are very short (<40% median window length),

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -373,8 +373,6 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
     breakindex: int
         Cadence where there is a natural break. Windows will be automatically put here.
     """
-    if windows == 1:
-        return []
 
     if arclength is None:
         arclength = _estimate_arclength(centroid_col, centroid_row)
@@ -382,14 +380,18 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
     # Validate break indices
     if isinstance(breakindex, int):
         breakindexes = [breakindex]
-    elif breakindex is None:
+    if breakindex is None:
         breakindexes = []
-    elif breakindex == 0:
+    elif (breakindex[0] == 0) & (len(breakindex) == 1):
         breakindexes = []
     else:
         breakindexes = breakindex
+
     if not isinstance(breakindexes, list):
         raise ValueError('`breakindex` must be an int or a list')
+
+    if windows == 1:
+        return breakindexes
 
     # Find evenly spaced window points
     dt = len(centroid_col) / windows
@@ -400,7 +402,8 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
 
     # Get thruster firings
     thrusters = _get_thruster_firings(arclength)
-    thrusters[breakindex] = True
+    for b in breakindexes:
+        thrusters[b] = True
     thrusters = np.where(thrusters)[0]
 
     # Find the nearest point to each thruster firing, unless it's a user supplied break point

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -390,6 +390,8 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
     if not isinstance(breakindexes, list):
         raise ValueError('`breakindex` must be an int or a list')
 
+    # If the user asks for break indices we should still return them,
+    # even if there is only 1 window.
     if windows == 1:
         return breakindexes
 

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -407,10 +407,10 @@ def _get_window_points(centroid_col, centroid_row, windows, arclength=None, brea
     thrusters = np.where(thrusters)[0]
 
     # Find the nearest point to each thruster firing, unless it's a user supplied break point
-    # I think this is not necessary anymore.
-    #window_points = [thrusters[np.argmin(np.abs(wp - thrusters))] + 1
-    #                     for wp in window_points
-    #                     if wp not in breakindexes]
+    if len(thrusters) > 0:
+        window_points = [thrusters[np.argmin(np.abs(thrusters - wp))] + 1
+                             for wp in window_points
+                             if wp not in breakindexes]
     window_points = np.unique(np.hstack([window_points, breakindexes]))
 
     # If the first or last windows are very short (<40% median window length),

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from astropy.utils.data import get_pkg_data_filename
-
+from numpy.testing import assert_array_equal
 from ... import LightCurve, KeplerLightCurveFile, KeplerLightCurve
 from .. import SFFCorrector
 
@@ -162,3 +162,7 @@ def test_sff_breakindex():
                  centroid_row=np.random.randn(20))
     assert 5 in corr.window_points
     assert 10 in corr.window_points
+    corr.correct(breakindex=[5, 10],
+                 centroid_col=np.random.randn(20),
+                 centroid_row=np.random.randn(20), windows=1)
+    assert_array_equal(corr.window_points, np.asarray([5, 10]))


### PR DESCRIPTION
Previously `breakindex` was not accepting lists and did nothing if windows was set to 1. This fixes that.