### PR TITLE
Added an interactive Bokeh widget to create an interactive echelle diagram.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.8.0 (unreleased)
 ==================
 
+- Added the ``Seismology.interact_echelle()`` method for creating interactive
+  asteroseismic echelle diagrams. [#625]
+
 - Added ``odd_mask`` and ``even_mask`` properties to ``FoldedLightCurve`` to
   make it easy to plot odd- and even-numbered transits. [#425]
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -448,6 +448,9 @@ class Seismology(object):
         else:
             dnu = self.deltanu
 
+        if (not hasattr(dnu, 'unit')):
+            dnu = dnu * self.periodogram.frequency.unit
+
         def create_interact_ui(doc):
             fig_tpf, stretch_slider = self._make_echelle_elements(dnu,
                                                 maximum_frequency=maximum_frequency,

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from matplotlib import pyplot as plt
+from scipy.signal import find_peaks
 
 from astropy import units as u
 from astropy.units import cds
@@ -14,18 +15,16 @@ from ..periodogram import SNRPeriodogram
 from ..utils import LightkurveWarning, validate_method
 from .utils import  SeismologyQuantity
 
-from scipy.signal import find_peaks
-
-# Import the optional Bokeh dependency, or print a friendly error otherwise.
+# Import the optional Bokeh dependency required by ``interact_echelle```,
+# or print a friendly error otherwise.
 try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
-    from bokeh.io import show, output_notebook, push_notebook
+    from bokeh.io import show, output_notebook
     from bokeh.plotting import figure
-    from bokeh.models import LogColorMapper, Slider, RangeSlider, \
-                             Span, LogTicker, Range1d, Button
+    from bokeh.models import LogColorMapper, Slider, RangeSlider, Button
     from bokeh.layouts import layout, Spacer
 except:
-    # Nice error when interact_echelle is called.
+    # Nice error will be raised when ``interact_echelle``` is called.
     pass
 
 log = logging.getLogger(__name__)
@@ -156,8 +155,6 @@ class Seismology(object):
         y_f : np.ndarray
             frequencies for Y axis
         """
-        #if numax is None:
-
         if (minimum_frequency is None) & (maximum_frequency is None):
             numax = self._validate_numax(numax)
         deltanu = self._validate_deltanu(deltanu)
@@ -166,7 +163,6 @@ class Seismology(object):
             numax = numax * self.periodogram.frequency.unit
         if (not hasattr(deltanu, 'unit')) & (deltanu is not None):
             deltanu = deltanu * self.periodogram.frequency.unit
-
 
         if smooth_filter_width:
             pgsmooth = self.periodogram.smooth(filter_width=smooth_filter_width)
@@ -206,13 +202,13 @@ class Seismology(object):
         if minimum_frequency is not None:
             fmin =  u.Quantity(minimum_frequency, freq.unit).value
             if fmin > freq[-1].value:
-                raise ValueError("You can't pass in a limit outside the"
+                raise ValueError("You can't pass in a limit outside the "
                                  "frequency range of the periodogram.")
 
         if maximum_frequency is not None:
             fmax = u.Quantity(maximum_frequency, freq.unit).value
             if fmax > freq[-1].value:
-                raise ValueError("You can't pass in a limit outside the"
+                raise ValueError("You can't pass in a limit outside the "
                                  "frequency range of the periodogram.")
 
         # Make sure fmin and fmax are Quantities or code below will break
@@ -259,15 +255,14 @@ class Seismology(object):
         if scale=='log':
             ep = np.log10(ep)
 
-        #Reshape the freq into n_rowss of n_columnss & create arays
+        # Reshape the freq into n_rowss of n_columnss & create arays
         ef = np.reshape(ff[start : end], (n_rows, n_columns))
         x_f = ((ef[0,:]-ef[0,0]) % deltanu)
         y_f = (ef[:,0])
         return ep, x_f, y_f
 
-    def plot_echelle(self, deltanu=None, numax=None,
-                     minimum_frequency=None, maximum_frequency=None,
-                     smooth_filter_width=.1,
+    def plot_echelle(self, deltanu=None, numax=None, minimum_frequency=None,
+                     maximum_frequency=None, smooth_filter_width=.1,
                      scale='linear', ax=None, cmap='Blues'):
         """Plots an echelle diagram of the periodogram by stacking the
         periodogram in slices of deltanu.

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -12,8 +12,21 @@ from .. import MPLSTYLE
 from . import utils, stellar_estimators
 from ..periodogram import SNRPeriodogram
 from ..utils import LightkurveWarning, validate_method
+from .utils import  SeismologyQuantity
 
 from scipy.signal import find_peaks
+
+# Import the optional Bokeh dependency, or print a friendly error otherwise.
+try:
+    import bokeh  # Import bokeh first so we get an ImportError we can catch
+    from bokeh.io import show, output_notebook, push_notebook
+    from bokeh.plotting import figure
+    from bokeh.models import LogColorMapper, Slider, RangeSlider, \
+                             Span, LogTicker, Range1d, Button
+    from bokeh.layouts import layout, Spacer
+except:
+    # Nice error when interact_echelle is called.
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -98,18 +111,11 @@ class Seismology(object):
         return deltanu
 
 
-    def plot_echelle(self, deltanu=None, numax=None,
-                     minimum_frequency=None, maximum_frequency=None,
-                     smooth_filter_width=.1, ax=None,
-                     scale='linear', cmap='Blues'):
-        """Plots an echelle diagram of the periodogram by stacking the
-        periodogram in slices of deltanu.
-
-        Modes of equal radial degree should appear approximately vertically aligned.
-        If no structure is present, you are likely dealing with a faulty deltanu
-        value or a low signal to noise case.
-
-        This method is adapted from work by Daniel Hey & Guy Davies.
+    def _clean_echelle(self, deltanu=None, numax=None,
+                         minimum_frequency=None, maximum_frequency=None,
+                         smooth_filter_width=.1, scale='linear'):
+        """Takes input seismology object and creates the necessary arrays for an echelle
+        diagram. Validates all the inputs.
 
         Parameters
         ----------
@@ -140,20 +146,27 @@ class Seismology(object):
             a new one will be created.
         scale: str
             Set z axis to be "linear" or "log". Default is linear.
-        cmap : str
-            The name of the matplotlib colourmap to use in the echelle diagram.
 
         Returns
         -------
-        ax : `~matplotlib.axes.Axes`
-            The matplotlib axes object.
+        ep : np.ndarray
+            Echelle diagram power
+        x_f : np.ndarray
+            frequencies for X axis
+        y_f : np.ndarray
+            frequencies for Y axis
         """
-        numax = self._validate_numax(numax)
-        if not hasattr(numax, 'unit'):
-            numax = numax * self.periodogram.frequency.unit
+        #if numax is None:
+
+        if (minimum_frequency is None) & (maximum_frequency is None):
+            numax = self._validate_numax(numax)
         deltanu = self._validate_deltanu(deltanu)
-        if not hasattr(deltanu, 'unit'):
+
+        if (not hasattr(numax, 'unit')) & (numax is not None):
+            numax = numax * self.periodogram.frequency.unit
+        if (not hasattr(deltanu, 'unit')) & (deltanu is not None):
             deltanu = deltanu * self.periodogram.frequency.unit
+
 
         if smooth_filter_width:
             pgsmooth = self.periodogram.smooth(filter_width=smooth_filter_width)
@@ -250,11 +263,75 @@ class Seismology(object):
         ef = np.reshape(ff[start : end], (n_rows, n_columns))
         x_f = ((ef[0,:]-ef[0,0]) % deltanu)
         y_f = (ef[:,0])
+        return ep, x_f, y_f
+
+    def plot_echelle(self, deltanu=None, numax=None,
+                     minimum_frequency=None, maximum_frequency=None,
+                     smooth_filter_width=.1,
+                     scale='linear', ax=None, cmap='Blues'):
+        """Plots an echelle diagram of the periodogram by stacking the
+        periodogram in slices of deltanu.
+
+        Modes of equal radial degree should appear approximately vertically aligned.
+        If no structure is present, you are likely dealing with a faulty deltanu
+        value or a low signal to noise case.
+
+        This method is adapted from work by Daniel Hey & Guy Davies.
+
+        Parameters
+        ----------
+        deltanu : float
+            Value for the large frequency separation of the seismic mode
+            frequencies in the periodogram. Assumed to have the same units as
+            the frequencies, unless given an Astropy unit.
+            Is assumed to be in the same units as frequency if not given a unit.
+        numax : float
+            Value for the frequency of maximum oscillation. If a numax is
+            passed, a suitable range one FWHM of the mode envelope either side
+            of the will be shown. This is overwritten by custom frequency ranges.
+            Is assumed to be in the same units as frequency if not given a unit.
+        minimum_frequency : float
+            The minimum frequency at which to display the echelle
+            Is assumed to be in the same units as frequency if not given a unit.
+        maximum_frequency : float
+            The maximum frequency at which to display the echelle.
+            Is assumed to be in the same units as frequency if not given a unit.
+        smooth_filter_width : float
+            If given a value, will smooth periodogram used to plot the echelle
+            diagram using the periodogram.smooth(method='boxkernel') method with
+            a filter width of `smooth_filter_width`. This helps visualise the
+            echelle diagram. Is assumed to be in the same units as the
+            periodogram frequency.
+        scale: str
+            Set z axis to be "linear" or "log". Default is linear.
+        cmap : str
+            The name of the matplotlib colourmap to use in the echelle diagram.
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`
+            The matplotlib axes object.
+        """
+
+
+        if (minimum_frequency is None) & (maximum_frequency is None):
+            numax = self._validate_numax(numax)
+        deltanu = self._validate_deltanu(deltanu)
+
+        if (not hasattr(numax, 'unit')) & (numax is not None):
+            numax = numax * self.periodogram.frequency.unit
+        if (not hasattr(deltanu, 'unit')) & (deltanu is not None):
+            deltanu = deltanu * self.periodogram.frequency.unit
+
+
+        ep, x_f, y_f = self._clean_echelle(numax=numax, deltanu=deltanu,
+                             minimum_frequency=minimum_frequency, maximum_frequency=maximum_frequency,
+                             smooth_filter_width=smooth_filter_width)
 
         #Plot the echelle diagram
         with plt.style.context(MPLSTYLE):
             if ax is None:
-                fig, ax = plt.subplots()
+                _, ax = plt.subplots()
             extent = (x_f[0].value, x_f[-1].value, y_f[0].value, y_f[-1].value)
             figsize = plt.rcParams['figure.figsize']
             a = figsize[1] / figsize[0]
@@ -280,11 +357,167 @@ class Seismology(object):
 
             cbar.set_label(ylabel)
             ax.set_xlabel(r'Frequency mod. {:.2f}'.format(deltanu))
-            ax.set_ylabel(r'Frequency [{}]'.format(freq.unit.to_string('latex')))
+            ax.set_ylabel(r'Frequency [{}]'.format(self.periodogram.frequency.unit.to_string('latex')))
             ax.set_title('Echelle diagram for {}'.format(self.periodogram.label))
 
         return ax
 
+    def _make_echelle_elements(self, deltanu, cmap='viridis',
+                         minimum_frequency=None, maximum_frequency=None,
+                         smooth_filter_width=.1,
+                         scale='linear', plot_width=490, plot_height=340, title='Echelle'):
+        """Helper function to make the elements of the echelle diagram for bokeh plotting.
+        """
+
+        if not hasattr(deltanu, 'unit'):
+            deltanu = deltanu * self.periodogram.frequency.unit
+
+        if smooth_filter_width:
+            pgsmooth = self.periodogram.smooth(filter_width=smooth_filter_width)
+            freq = pgsmooth.frequency  # Makes code below more readable below
+            power = pgsmooth.power     # Makes code below more readable below
+        else:
+            freq = self.periodogram.frequency  # Makes code below more readable
+            power = self.periodogram.power     # Makes code below more readable
+
+
+        ep, x_f, y_f = self._clean_echelle(deltanu=deltanu,
+                         minimum_frequency=minimum_frequency, maximum_frequency=maximum_frequency,
+                         smooth_filter_width=smooth_filter_width,
+                         scale=scale)
+
+        fig = figure(plot_width=plot_width, plot_height=plot_height,
+                     x_range=(0, 1), y_range=(y_f[0].value, y_f[-1].value),
+                     title=title, tools='pan,box_zoom,reset',
+                     toolbar_location="above",
+                     border_fill_color="white")
+
+        fig.yaxis.axis_label = r'Frequency [{}]'.format(freq.unit.to_string())
+        fig.xaxis.axis_label = r'Frequency / {:.3f} Mod. 1'.format(deltanu)
+
+        lo, hi = np.nanpercentile(ep.value, [0.1, 99.9])
+        vlo, vhi = 0.3 * lo, 1.7 * hi
+        vstep = (lo - hi)/500
+        color_mapper = LogColorMapper(palette="RdYlGn10", low=lo, high=hi)
+
+        fig.image(image=[ep.value], x=0, y=y_f[0].value,
+                  dw=1, dh=y_f[-1].value,
+                  color_mapper=color_mapper, name='img')
+
+        stretch_slider = RangeSlider(start=vlo,
+                                     end=vhi,
+                                     step=vstep,
+                                     title='',
+                                     value=(lo, hi),
+                                     orientation='vertical',
+                                     width=10,
+                                     height=230,
+                                     direction='rtl',
+                                     show_value=False,
+                                     sizing_mode='fixed',
+                                     name='stretch')
+
+        def stretch_change_callback(attr, old, new):
+            """TPF stretch slider callback."""
+            fig.select('img')[0].glyph.color_mapper.high = new[1]
+            fig.select('img')[0].glyph.color_mapper.low = new[0]
+
+        stretch_slider.on_change('value', stretch_change_callback)
+        return fig, stretch_slider
+
+
+    def interact_echelle(self, notebook_url='localhost:8888', **kwargs):
+        """ Shows an interactive Echelle diagram based on a Seismology object.
+        """
+
+        try:
+            import bokeh
+            if bokeh.__version__[0] == '0':
+                warnings.warn("interact() requires Bokeh version 1.0 or later", LightkurveWarning)
+        except ImportError:
+            log.error("The interact() tool requires the `bokeh` Python package; "
+                      "you can install bokeh using e.g. `conda install bokeh`.")
+            return None
+
+        maximum_frequency = kwargs.pop('maximum_frequency', self.periodogram.frequency.max().value)
+        minimum_frequency = kwargs.pop('minimum_frequency', self.periodogram.frequency. min().value)
+
+        if not hasattr(self, 'deltanu'):
+            dnu = SeismologyQuantity(quantity=self.periodogram.frequency.max()/30,
+                                                       name='deltanu', method='echelle')
+        else:
+            dnu = self.deltanu
+
+        def create_interact_ui(doc):
+            fig_tpf, stretch_slider = self._make_echelle_elements(dnu,
+                                                maximum_frequency=maximum_frequency,
+                                                minimum_frequency=minimum_frequency,
+                                                **kwargs)
+            maxdnu = self.periodogram.frequency.max().value/5
+            # Interactive slider widgets
+            dnu_slider = Slider(start=0.01,
+                                end=maxdnu,
+                                value=dnu.value,
+                                step=0.01,
+                                title="Delta Nu",
+                                width=290)
+            r_button = Button(label=">", button_type="default", width=30)
+            l_button = Button(label="<", button_type="default", width=30)
+            rr_button = Button(label=">>", button_type="default", width=30)
+            ll_button = Button(label="<<", button_type="default", width=30)
+
+
+            def update(attr, old, new):
+                """Callback to take action when dnu slider changes"""
+                dnu = SeismologyQuantity(quantity=dnu_slider.value*u.microhertz,
+                                                       name='deltanu', method='echelle')
+                ep, x_f, y_f = self._clean_echelle(deltanu=dnu,
+                                                    minimum_frequency=minimum_frequency,
+                                                    maximum_frequency=maximum_frequency,
+                                                    **kwargs)
+                fig_tpf.select('img')[0].data_source.data['image'] = [ep.value]
+                fig_tpf.xaxis.axis_label = r'Frequency / {:.3f} Mod. 1'.format(dnu)
+                #fig_tpf.select('img')[0].data_source.data['x'] = x_f[0].value
+                #, y=y_f[0].value,
+                #  dw=x_f[-1].value, dh=y_f[-1].value,
+
+            def go_right_by_one_small():
+                """Step forward in time by a single cadence"""
+                existing_value = dnu_slider.value
+                if existing_value < 200:
+                    dnu_slider.value = existing_value + 0.002
+
+            def go_left_by_one_small():
+                """Step back in time by a single cadence"""
+                existing_value = dnu_slider.value
+                if existing_value > 0:
+                    dnu_slider.value = existing_value - 0.002
+
+
+            def go_right_by_one():
+                """Step forward in time by a single cadence"""
+                existing_value = dnu_slider.value
+                if existing_value < maxdnu:
+                    dnu_slider.value = existing_value + 0.01
+
+            def go_left_by_one():
+                """Step back in time by a single cadence"""
+                existing_value = dnu_slider.value
+                if existing_value > 0:
+                    dnu_slider.value = existing_value - 0.01
+
+            dnu_slider.on_change('value', update)
+            r_button.on_click(go_right_by_one_small)
+            l_button.on_click(go_left_by_one_small)
+            rr_button.on_click(go_right_by_one)
+            ll_button.on_click(go_left_by_one)
+
+            widgets_and_figures = layout([fig_tpf, [Spacer(height=20), stretch_slider]],
+                                         [ll_button, Spacer(width=30), l_button, Spacer(width=25), dnu_slider, Spacer(width=30), r_button, Spacer(width=23), rr_button])
+            doc.add_root(widgets_and_figures)
+
+        output_notebook(verbose=False, hide_banner=True)
+        return show(create_interact_ui, notebook_url='http://localhost:8900')
 
     def estimate_numax(self, method="acf2d", **kwargs):
         """Returns the frequency of the peak of the seismic oscillation modes envelope.

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -461,7 +461,7 @@ class Seismology(object):
             dnu_slider = Slider(start=0.01,
                                 end=maxdnu,
                                 value=dnu.value,
-                                step=0.01,
+                                step=0.001,
                                 title="Delta Nu",
                                 width=290)
             r_button = Button(label=">", button_type="default", width=30)
@@ -488,20 +488,20 @@ class Seismology(object):
                 """Step forward in time by a single cadence"""
                 existing_value = dnu_slider.value
                 if existing_value < 200:
-                    dnu_slider.value = existing_value + 0.002
+                    dnu_slider.value = existing_value + 0.01
 
             def go_left_by_one_small():
                 """Step back in time by a single cadence"""
                 existing_value = dnu_slider.value
                 if existing_value > 0:
-                    dnu_slider.value = existing_value - 0.002
+                    dnu_slider.value = existing_value - 0.01
 
 
             def go_right_by_one():
                 """Step forward in time by a single cadence"""
                 existing_value = dnu_slider.value
                 if existing_value < maxdnu:
-                    dnu_slider.value = existing_value + 0.01
+                    dnu_slider.value = existing_value + 0.1
 
             def go_left_by_one():
                 """Step back in time by a single cadence"""

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -520,7 +520,7 @@ class Seismology(object):
             doc.add_root(widgets_and_figures)
 
         output_notebook(verbose=False, hide_banner=True)
-        return show(create_interact_ui, notebook_url='http://localhost:8900')
+        return show(create_interact_ui, notebook_url=notebook_url)
 
     def estimate_numax(self, method="acf2d", **kwargs):
         """Returns the frequency of the peak of the seismic oscillation modes envelope.

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -19,13 +19,13 @@ from scipy.signal import find_peaks
 # Import the optional Bokeh dependency, or print a friendly error otherwise.
 try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
-    from bokeh.io import show, output_notebook
+    from bokeh.io import show, output_notebook, push_notebook
     from bokeh.plotting import figure
     from bokeh.models import LogColorMapper, Slider, RangeSlider, \
-                             LogTicker, Button
+                             Span, LogTicker, Range1d, Button
     from bokeh.layouts import layout, Spacer
-except ImportError:
-    # There is a nice error when interact_echelle is called and bokeh is not avail.
+except:
+    # Nice error when interact_echelle is called.
     pass
 
 log = logging.getLogger(__name__)
@@ -152,9 +152,9 @@ class Seismology(object):
         ep : np.ndarray
             Echelle diagram power
         x_f : np.ndarray
-            delta nu frequencies for X axis of echelle diagram
+            frequencies for X axis
         y_f : np.ndarray
-            numax frequencies for Y axis of echelle diagram
+            frequencies for Y axis
         """
         #if numax is None:
 
@@ -171,11 +171,10 @@ class Seismology(object):
         if smooth_filter_width:
             pgsmooth = self.periodogram.smooth(filter_width=smooth_filter_width)
             freq = pgsmooth.frequency  # Makes code below more readable below
-            power = pgsmooth.power  # Makes code below more readable below
-
+            power = pgsmooth.power     # Makes code below more readable below
         else:
             freq = self.periodogram.frequency  # Makes code below more readable
-            power = self.periodogram.power  # Makes code below more readable
+            power = self.periodogram.power     # Makes code below more readable
 
         fmin = freq[0]
         fmax = freq[-1]
@@ -325,7 +324,7 @@ class Seismology(object):
             deltanu = deltanu * self.periodogram.frequency.unit
 
 
-        ep, x_f, y_f = self._clean_echelle(numax=numax, deltanu=deltanu,
+        ep, _, _ = self._clean_echelle(numax=numax, deltanu=deltanu,
                              minimum_frequency=minimum_frequency, maximum_frequency=maximum_frequency,
                              smooth_filter_width=smooth_filter_width)
 
@@ -363,10 +362,10 @@ class Seismology(object):
 
         return ax
 
-    def _make_echelle_elements(self, deltanu,
+    def _make_echelle_elements(self, deltanu, cmap='viridis',
                          minimum_frequency=None, maximum_frequency=None,
                          smooth_filter_width=.1,
-                         scale='linear', plot_width=550, plot_height=340, title='Echelle diagram'):
+                         scale='linear', plot_width=490, plot_height=340, title='Echelle'):
         """Helper function to make the elements of the echelle diagram for bokeh plotting.
         """
 
@@ -376,8 +375,10 @@ class Seismology(object):
         if smooth_filter_width:
             pgsmooth = self.periodogram.smooth(filter_width=smooth_filter_width)
             freq = pgsmooth.frequency  # Makes code below more readable below
+            power = pgsmooth.power     # Makes code below more readable below
         else:
             freq = self.periodogram.frequency  # Makes code below more readable
+            power = self.periodogram.power     # Makes code below more readable
 
 
         ep, x_f, y_f = self._clean_echelle(deltanu=deltanu,
@@ -397,9 +398,7 @@ class Seismology(object):
         lo, hi = np.nanpercentile(ep.value, [0.1, 99.9])
         vlo, vhi = 0.3 * lo, 1.7 * hi
         vstep = (lo - hi)/500
-        from bokeh.palettes import Blues8
-        Blues8.reverse()
-        color_mapper = LogColorMapper(palette=Blues8, low=lo, high=hi)
+        color_mapper = LogColorMapper(palette="RdYlGn10", low=lo, high=hi)
 
         fig.image(image=[ep.value], x=0, y=y_f[0].value,
                   dw=1, dh=y_f[-1].value,
@@ -429,42 +428,6 @@ class Seismology(object):
 
     def interact_echelle(self, notebook_url='localhost:8888', **kwargs):
         """ Shows an interactive Echelle diagram based on a Seismology object.
-
-        Optional keywords are the same as the `plot_echelle` function.
-
-        Parameters
-        ----------
-        notebook_url: str
-            Location of the Jupyter notebook page (default: “localhost:8888”)
-            When showing Bokeh applications, the Bokeh server must be explicitly
-            configured to allow connections originating from different URLs.
-            This parameter defaults to the standard notebook host and port.
-            If you are running on a different location, you will need to supply this
-            value for the application to display properly. If no protocol is
-            supplied in the URL, e.g. if it is of the form “localhost:8888”,
-            then “http” will be used.
-        deltanu : float
-            Value for the large frequency separation of the seismic mode
-            frequencies in the periodogram. Assumed to have the same units as
-            the frequencies, unless given an Astropy unit.
-            Is assumed to be in the same units as frequency if not given a unit.
-        numax : float
-            Value for the frequency of maximum oscillation. If a numax is
-            passed, a suitable range one FWHM of the mode envelope either side
-            of the will be shown. This is overwritten by custom frequency ranges.
-            Is assumed to be in the same units as frequency if not given a unit.
-        minimum_frequency : float
-            The minimum frequency at which to display the echelle
-            Is assumed to be in the same units as frequency if not given a unit.
-        maximum_frequency : float
-            The maximum frequency at which to display the echelle.
-            Is assumed to be in the same units as frequency if not given a unit.
-        smooth_filter_width : float
-            If given a value, will smooth periodogram used to plot the echelle
-            diagram using the periodogram.smooth(method='boxkernel') method with
-            a filter width of `smooth_filter_width`. This helps visualise the
-            echelle diagram. Is assumed to be in the same units as the
-            periodogram frequency.
         """
 
         try:
@@ -477,33 +440,27 @@ class Seismology(object):
             return None
 
         maximum_frequency = kwargs.pop('maximum_frequency', self.periodogram.frequency.max().value)
-        minimum_frequency = kwargs.pop('minimum_frequency', self.periodogram.frequency.min().value)
-        maximum_deltanu = kwargs.pop('maximum_deltanu', maximum_frequency/5)
-        minimum_deltanu = kwargs.pop('minimum_deltanu', 0.01)
+        minimum_frequency = kwargs.pop('minimum_frequency', self.periodogram.frequency. min().value)
 
         if not hasattr(self, 'deltanu'):
-            dnu = SeismologyQuantity(quantity=np.mean([minimum_deltanu, maximum_deltanu]) * self.periodogram.frequency.unit,
+            dnu = SeismologyQuantity(quantity=self.periodogram.frequency.max()/30,
                                                        name='deltanu', method='echelle')
         else:
             dnu = self.deltanu
-
-        if (not hasattr(dnu, 'unit')):
-            dnu = dnu * self.periodogram.frequency.unit
 
         def create_interact_ui(doc):
             fig_tpf, stretch_slider = self._make_echelle_elements(dnu,
                                                 maximum_frequency=maximum_frequency,
                                                 minimum_frequency=minimum_frequency,
                                                 **kwargs)
-
+            maxdnu = self.periodogram.frequency.max().value/5
             # Interactive slider widgets
-            dnu_slider = Slider(start=minimum_deltanu,
-                                end=maximum_deltanu,
+            dnu_slider = Slider(start=0.01,
+                                end=maxdnu,
                                 value=dnu.value,
-                                step=0.001,
+                                step=0.01,
                                 title="Delta Nu",
                                 width=290)
-
             r_button = Button(label=">", button_type="default", width=30)
             l_button = Button(label="<", button_type="default", width=30)
             rr_button = Button(label=">>", button_type="default", width=30)
@@ -514,7 +471,7 @@ class Seismology(object):
                 """Callback to take action when dnu slider changes"""
                 dnu = SeismologyQuantity(quantity=dnu_slider.value*u.microhertz,
                                                        name='deltanu', method='echelle')
-                ep, x_f, y_f = self._clean_echelle(deltanu=dnu,
+                ep, _, _ = self._clean_echelle(deltanu=dnu,
                                                     minimum_frequency=minimum_frequency,
                                                     maximum_frequency=maximum_frequency,
                                                     **kwargs)
@@ -528,20 +485,20 @@ class Seismology(object):
                 """Step forward in time by a single cadence"""
                 existing_value = dnu_slider.value
                 if existing_value < 200:
-                    dnu_slider.value = existing_value + 0.01
+                    dnu_slider.value = existing_value + 0.002
 
             def go_left_by_one_small():
                 """Step back in time by a single cadence"""
                 existing_value = dnu_slider.value
                 if existing_value > 0:
-                    dnu_slider.value = existing_value - 0.01
+                    dnu_slider.value = existing_value - 0.002
 
 
             def go_right_by_one():
                 """Step forward in time by a single cadence"""
                 existing_value = dnu_slider.value
-                if existing_value < maximum_deltanu:
-                    dnu_slider.value = existing_value + 0.1
+                if existing_value < maxdnu:
+                    dnu_slider.value = existing_value + 0.01
 
             def go_left_by_one():
                 """Step back in time by a single cadence"""
@@ -556,14 +513,11 @@ class Seismology(object):
             ll_button.on_click(go_left_by_one)
 
             widgets_and_figures = layout([fig_tpf, [Spacer(height=20), stretch_slider]],
-                                         [ll_button, Spacer(width=30), l_button, Spacer(width=25),
-                                            dnu_slider, Spacer(width=30), r_button,
-                                            Spacer(width=23), rr_button]
-                                         )
+                                         [ll_button, Spacer(width=30), l_button, Spacer(width=25), dnu_slider, Spacer(width=30), r_button, Spacer(width=23), rr_button])
             doc.add_root(widgets_and_figures)
 
         output_notebook(verbose=False, hide_banner=True)
-        return show(create_interact_ui, notebook_url=notebook_url)
+        return show(create_interact_ui, notebook_url='http://localhost:8900')
 
     def estimate_numax(self, method="acf2d", **kwargs):
         """Returns the frequency of the peak of the seismic oscillation modes envelope.


### PR DESCRIPTION
I added a new widget that lets users create an interactive echelle diagram. This is very useful for exploring the data and hunting for oscillation modes. Because it's bokeh, it's very responsive. This is totally based on the idea and success of @danhey's tool for interactive echelle diagrams, but uses lightkurve and bokeh.

![image](https://user-images.githubusercontent.com/14965634/68521192-6c419580-0253-11ea-9659-6bf9b7a057ac.png)

`interact_echelle` takes the same keyword arguments as `plot_echelle`. 

### Changes:

* Refactored the `plot_echelle` function into a plotting function and a helper function
* Added some bokeh helper functions to create the widget
* Added an `interact_echelle` function.


### API:

```python
seis = lc.to_periodogram(freq_unit='microhertz').to_seismology()
seis.interact_echelle()
```