### PR TITLE
`IndexError` is raised for TESS data searches in the Kepler field

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -910,7 +910,7 @@ def _mask_tess_products(products, sector=None, filetype='Target Pixel'):
     if sector is not None:
         sector_mask = np.zeros(len(products), dtype=bool)
         for s in np.atleast_1d(sector):
-            sector_mask |= np.array([fn.split('-')[1] == 's{:04d}'.format(s)
+            sector_mask |= np.array([("-" in fn) and (fn.split('-')[1] == 's{:04d}'.format(s))
                                      for fn in products['productFilename']])
         mask &= sector_mask
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -288,3 +288,11 @@ def test_filenotfound():
         FileNotFoundError = IOError
     with pytest.raises(FileNotFoundError):
         open("DOESNOTEXIST")
+
+
+@pytest.mark.remote_data
+def test_indexerror_631():
+    """Regression test for #631; avoid IndexError."""
+    # This previously triggered an exception:
+    result = search_lightcurvefile("KIC 8462852", sector=15)
+    assert len(result) == 1

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -99,11 +99,11 @@ def test_search_tesscut():
     search_coords = search_tesscut(c)
     # These should be identical
     assert(len(search_string.table) == len(search_coords.table))
-    # Test cutout at edge of FFI
-    search_edge = search_tesscut('30.578761, 6.210593')
-    assert(len(search_edge.table) == 1)
+    # The coordinates below are just beyond the edge of the sector 4 FFI
+    search_edge = search_tesscut('30.578761, 6.210593', sector=4)
+    assert(len(search_edge.table) == 0)
     try:
-        # This is too near the FFI edge and should fail to download
+        # This is beyond the FFI edge and should fail to download
         search_edge.download()
     except (SearchError, HTTPError):
         pass

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -99,14 +99,9 @@ def test_search_tesscut():
     search_coords = search_tesscut(c)
     # These should be identical
     assert(len(search_string.table) == len(search_coords.table))
-    # The coordinates below are just beyond the edge of the sector 4 FFI
+    # The coordinates below are beyond the edge of the sector 4 (camera 1-4) FFI
     search_edge = search_tesscut('30.578761, 6.210593', sector=4)
     assert(len(search_edge.table) == 0)
-    try:
-        # This is beyond the FFI edge and should fail to download
-        search_edge.download()
-    except (SearchError, HTTPError):
-        pass
 
 
 @pytest.mark.remote_data
@@ -250,10 +245,13 @@ def test_open():
 def test_issue_472():
     """Regression test for https://github.com/KeplerGO/lightkurve/issues/472"""
     # The line below previously threw an exception because the target was not
-    # observed in Sector 2; we're expecting an empty SearchResult instead.
+    # observed in Sector 2; we're always expecting a SearchResult object (empty
+    # or not) rather than an exception.
+    # Whether or not this SearchResult is empty has changed over the years,
+    # because the target is only ~15 pixels beyond the FFI edge and the accuracy
+    # of the FFI footprint polygons at the MAST portal have changed at times.
     search = search_tesscut("TIC41336498", sector=2)
     assert isinstance(search, SearchResult)
-    assert len(search) == 0
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
I discovered a bug in the `search` module which is triggered when someone searches for TESS data in the Kepler field.  The reason is that the following part of the code implicitly assumes that all product file names contain a dash:
https://github.com/KeplerGO/lightkurve/blob/9e9ca883ccc5cb780610f0e5925d9a4dfec535a9/lightkurve/search.py#L913-L914

However for targets in the Kepler field, the list of products returned by `astroquery.mast` includes products without dashes, namely the Kepler product tarballs.

This PR fixes the issue and adds a regression test.

Code to reproduce the bug:
```python
import lightkurve as lk
lk.log.setLevel("DEBUG")
lk.search_lightcurvefile("KIC 8462852", sector=15)
````
Output:
```python
Started querying MAST for observations within 0.0001 arcsec of objectname='KIC 8462852'.
MAST found 5 observations. Now querying MAST for the corresponding data products.
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-1-dbc917181a7c> in <module>
      1 import lightkurve as lk
      2 lk.log.setLevel("DEBUG")
----> 3 lk.search_lightcurvefile("KIC 8462852", sector=15)

~/dev/lightkurve/lightkurve/search.py in search_lightcurvefile(target, radius, cadence, mission, quarter, month, campaign, sector, limit)
    512         return _search_products(target, radius=radius, filetype="Lightcurve",
    513                                 cadence=cadence, mission=mission, quarter=quarter,
--> 514                                 month=month, campaign=campaign, sector=sector, limit=limit)
    515     except SearchError as exc:
    516         log.error(exc)

~/dev/lightkurve/lightkurve/search.py in _search_products(target, radius, filetype, cadence, mission, quarter, month, campaign, sector, limit)
    614                                          campaign=campaign, quarter=quarter,
    615                                          cadence=cadence, project=mission,
--> 616                                          month=month, sector=sector, limit=limit)
    617         log.debug("MAST found {} matching data products.".format(len(masked_result)))
    618         return SearchResult(masked_result)

~/dev/lightkurve/lightkurve/search.py in _filter_products(products, campaign, quarter, month, sector, cadence, limit, project, filetype)
    787                                   cadence=cadence, filetype=filetype)
    788     if 'tess' in project_lower and quarter is None and campaign is None:
--> 789         mask |= _mask_tess_products(products, sector=sector, filetype=filetype)
    790 
    791     products = products[mask]

~/dev/lightkurve/lightkurve/search.py in _mask_tess_products(products, sector, filetype)
    913             #sector_mask |= np.array([("-" in fn) and (fn.split('-')[1] == 's{:04d}'.format(s))
    914             sector_mask |= np.array([fn.split('-')[1] == 's{:04d}'.format(s)
--> 915                                      for fn in products['productFilename']])
    916         mask &= sector_mask
    917 

~/dev/lightkurve/lightkurve/search.py in <listcomp>(.0)
    913             #sector_mask |= np.array([("-" in fn) and (fn.split('-')[1] == 's{:04d}'.format(s))
    914             sector_mask |= np.array([fn.split('-')[1] == 's{:04d}'.format(s)
--> 915                                      for fn in products['productFilename']])
    916         mask &= sector_mask
    917 

IndexError: list index out of range
```
