### PR TITLE
Make the `SearchResult` repr easier to read

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -51,10 +51,11 @@ class SearchResult(object):
                 self._add_columns()
 
     def _add_columns(self):
-        """Adds user-friendly ``idx`` and ``collection`` columns.
+        """Adds user-friendly ``idx`` and ``observation`` columns.
 
         These columns are not part of the MAST Portal API, but they make the
-        display of search results much nicer in Lightkurve."""
+        display of search results much nicer in Lightkurve.
+        """
         self.table['observation'] = None
         self.table['#'] = None
         try:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -66,8 +66,8 @@ class SearchResult(object):
                 if mission == 'Kepler' and self.table['sequence_number'].mask[3]:
                     seqno = re.findall(r".*Q(\d+)", self.table['description'][idx])[0]
                 self.table['collection'][idx] = "{} {} {}".format(mission,
-                                                                prefix[mission],
-                                                                seqno)
+                                                                  prefix[mission],
+                                                                  seqno)
         except Exception as e:
             # be robust against MAST API changes
             # which may cause the above to fail

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -55,7 +55,7 @@ class SearchResult(object):
 
         These columns are not part of the MAST Portal API, but they make the
         display of search results much nicer in Lightkurve."""
-        self.table['collection'] = None
+        self.table['observation'] = None
         self.table['#'] = None
         try:
             prefix = {'Kepler': 'Quarter', 'K2': 'Campaign', 'TESS': 'Sector'}

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -52,7 +52,7 @@ class SearchResult(object):
 
     def _add_columns(self):
         """Adds user-friendly ``idx`` and ``collection`` columns.
-        
+
         These columns are not part of the MAST Portal API, but they make the
         display of search results much nicer in Lightkurve."""
         self.table['collection'] = None
@@ -65,19 +65,20 @@ class SearchResult(object):
                 seqno = self.table['sequence_number'][idx]
                 if mission == 'Kepler' and self.table['sequence_number'].mask[3]:
                     seqno = re.findall(r".*Q(\d+)", self.table['description'][idx])[0]
-                self.table['collection'][idx] = "{} {} {}".format(mission,
-                                                                  prefix[mission],
-                                                                  seqno)
-        except Exception as e:
-            # be robust against MAST API changes
-            # which may cause the above to fail
-            pass
+                self.table['observation'][idx] = "{} {} {}".format(mission,
+                                                                   prefix[mission],
+                                                                   seqno)
+        except Exception:
+            # be tolerant of any MAST API changes
+            # which may cause the code above to fail
+            log.warning("Unexpected data encountered in the ``SearchResult`` "
+                        "constructor; the MAST API may have changed.")
 
     def __repr__(self, html=False):
         out = 'SearchResult containing {} data products.'.format(len(self.table))
         if len(self.table) == 0:
             return out
-        columns = ['#', 'collection', 'target_name', 'productFilename', 'distance']
+        columns = ['#', 'observation', 'target_name', 'productFilename', 'distance']
         return out + '\n\n' + '\n'.join(self.table[columns].pformat(max_width=300, html=html))
 
     def _repr_html_(self):

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -163,7 +163,8 @@ def test_searchresult():
     assert len(sr) == len(sr.table)  # Tests SearchResult.__len__
     assert len(sr[2:7]) == 5  # Tests SearchResult.__get__
     assert len(sr[2]) == 1
-    assert "kplr" in str(sr)  # Tests SearchResult.__repr__
+    assert "kplr" in sr.__repr__()
+    assert "kplr" in sr._repr_html_()
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This PR proposes to make the screen representation of a `SearchResult` object easier to read and interpret.

See before/after screenshots below.  Thoughts anyone?

## Old behavior:
![Screenshot from 2019-11-17 21-14-20](https://user-images.githubusercontent.com/817669/69026317-52086580-097f-11ea-97a0-c7849fb580cc.png)


## New behavior proposed by this PR:
![Screenshot from 2019-11-17 21-13-42](https://user-images.githubusercontent.com/817669/69026314-4e74de80-097f-11ea-815a-2b0ba0c3cfa5.png)
