### PR TITLE
Ensure TessLightCurve(File) objects carry common properties

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -299,10 +299,7 @@ class KeplerLightCurveFile(LightCurveFile):
         self.quality_mask = KeplerQualityFlags.create_quality_mask(
                                 quality_array=self.hdu[1].data['SAP_QUALITY'],
                                 bitmask=quality_bitmask)
-        try:
-            self.targetid = self.header()['KEPLERID']
-        except KeyError:
-            self.targetid = None
+        self.targetid = self.get_keyword('KEPLERID')
 
     def __repr__(self):
         return('KeplerLightCurveFile(ID: {})'.format(self.targetid))
@@ -348,7 +345,7 @@ class KeplerLightCurveFile(LightCurveFile):
                 mission=self.mission,
                 cadenceno=self.cadenceno,
                 targetid=self.targetid,
-                label=self.hdu[0].header['OBJECT'],
+                label=self.get_keyword('OBJECT'),
                 ra=self.ra,
                 dec=self.dec)
         else:
@@ -358,12 +355,12 @@ class KeplerLightCurveFile(LightCurveFile):
     @property
     def channel(self):
         """Kepler CCD channel number. ('CHANNEL' header keyword)"""
-        return self.header(ext=0)['CHANNEL']
+        return self.get_keyword('CHANNEL')
 
     @property
     def obsmode(self):
         """'short cadence' or 'long cadence'. ('OBSMODE' header keyword)"""
-        return self.header()['OBSMODE']
+        return self.get_keyword('OBSMODE')
 
     @property
     def pos_corr1(self):
@@ -378,26 +375,17 @@ class KeplerLightCurveFile(LightCurveFile):
     @property
     def quarter(self):
         """Kepler quarter number. ('QUARTER' header keyword)"""
-        try:
-            return self.header(ext=0)['QUARTER']
-        except KeyError:
-            return None
+        return self.get_keyword('QUARTER')
 
     @property
     def campaign(self):
         """K2 Campaign number. ('CAMPAIGN' header keyword)"""
-        try:
-            return self.header(ext=0)['CAMPAIGN']
-        except KeyError:
-            return None
+        return self.get_keyword('CAMPAIGN')
 
     @property
     def mission(self):
         """'Kepler' or 'K2'. ('MISSION' header keyword)"""
-        try:
-            return self.header(ext=0)['MISSION']
-        except KeyError:
-            return None
+        return self.get_keyword('MISSION')
 
     def compute_cotrended_lightcurve(self, cbvs=(1, 2), **kwargs):
         """Returns a LightCurve object after cotrending the SAP_FLUX
@@ -474,11 +462,7 @@ class TessLightCurveFile(LightCurveFile):
         # which were not flagged by a QUALITY flag yet; the line below prevents
         # these cadences from being used. They would break most methods!
         self.quality_mask &= np.isfinite(self.hdu[1].data['TIME'])
-
-        try:
-            self.targetid = self.header()['TICID']
-        except KeyError:
-            self.targetid = None
+        self.targetid = self.get_keyword('TICID')
 
     def __repr__(self):
         return('TessLightCurveFile(TICID: {})'.format(self.targetid))
@@ -525,7 +509,7 @@ class TessLightCurveFile(LightCurveFile):
                 quality_bitmask=self.quality_bitmask,
                 cadenceno=self.cadenceno,
                 targetid=self.targetid,
-                label=self.hdu[0].header['OBJECT'],
+                label=self.get_keyword('OBJECT'),
                 sector=self.sector,
                 camera=self.camera,
                 ccd=self.ccd,

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -150,6 +150,11 @@ def test_TessLightCurveFile(quality_bitmask):
     assert lc.time_format == 'btjd'
     assert lc.time_scale == 'tdb'
     assert lc.flux_unit == u.electron / u.second
+    assert lc.sector == hdu[0].header['SECTOR']
+    assert lc.camera == hdu[0].header['CAMERA']
+    assert lc.ccd == hdu[0].header['CCD']
+    assert lc.ra == hdu[0].header['RA_OBJ']
+    assert lc.dec == hdu[0].header['DEC_OBJ']
 
     assert_array_equal(lc.time[0:10], hdu[1].data['TIME'][0:10])
     assert_array_equal(lc.flux[0:10], hdu[1].data['SAP_FLUX'][0:10])


### PR DESCRIPTION
`TessLightCurveFile.get_lightcurve()` did not pass several common properties (mission, sector, camera, ccd, ra, dec) to the `TessLightCurve` objects it returned.  As a result, the collection `__repr__` did not work correctly, as shown below.  This PR fixes the issue.

## Before this PR
![Screenshot from 2019-11-18 16-54-44](https://user-images.githubusercontent.com/817669/69106745-2be8d100-0a24-11ea-8d4d-6fc2a38e3ebb.png)

## After this PR
![Screenshot from 2019-11-18 16-54-17](https://user-images.githubusercontent.com/817669/69106753-2f7c5800-0a24-11ea-88e2-4db728eb9092.png)
