### PR TITLE
Avoid forcing Agg as the matplotlib backend on OSX

### DIFF
--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -10,7 +10,7 @@ MPLSTYLE = '{}/data/lightkurve.mplstyle'.format(PACKAGEDIR)
 # which may require an X11 connection (i.e. a display).  When no display is
 # available, errors may occur.  In this case, we default to the robust Agg backend.
 import platform
-if platform.system() == "Linux" and "DISPLAY" not in os.environ:
+if platform.system() == "Linux" and os.environ.get('DISPLAY', '') == '':
     import matplotlib
     matplotlib.use('Agg')
 

--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -9,6 +9,7 @@ MPLSTYLE = '{}/data/lightkurve.mplstyle'.format(PACKAGEDIR)
 # By default Matplotlib is configured to work with a graphical user interface
 # which may require an X11 connection (i.e. a display).  When no display is
 # available, errors may occur.  In this case, we default to the robust Agg backend.
+import platform
 if platform.system() == "Linux" and "DISPLAY" not in os.environ:
     import matplotlib
     matplotlib.use('Agg')

--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -9,7 +9,7 @@ MPLSTYLE = '{}/data/lightkurve.mplstyle'.format(PACKAGEDIR)
 # By default Matplotlib is configured to work with a graphical user interface
 # which may require an X11 connection (i.e. a display).  When no display is
 # available, errors may occur.  In this case, we default to the robust Agg backend.
-if os.name == 'posix' and "DISPLAY" not in os.environ:
+if platform.system() == "Linux" and "DISPLAY" not in os.environ:
     import matplotlib
     matplotlib.use('Agg')
 


### PR DESCRIPTION
Over in https://github.com/KeplerGO/lightkurve/commit/7fa8d647c697ed0c2b592a0115e77f3f85ed2ca9 I accidentally forced all OSX users to use matplotlib's Agg backend when importing Lightkurve, whereas my intention was to only force it upon the environments running the GitHub Actions unit tests.

This PR reverts the mistake.