### PR TITLE
Ensure the unit tests pass after #644

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,9 @@
-1.6.0 (unreleased)
+1.5.2 (2019-12-05)
 ==================
 
-
-
-1.5.2 (2019-12-04)
-==================
-
-- Fixed a bug introduced in Lightkurve v1.5 which raised an error upon import
-  for installs with astropy version <=3.1 or <=2.10, due to missing
-  calculate_bin_edges. [#644]
+- Fixed a bug introduced in v1.5.0 which caused an ``ImportError`` related to
+  ``astropy.stats.calculate_bin_edges`` to be raised when a user has an older
+  version of AstroPy installed (version <3.1 or <2.10). [#644]
 
 - Fixed a bug which caused the positions of stars in ``tpf.interact_sky()`` to
   be off by one pixel. [#638]

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -921,8 +921,6 @@ class LightCurve(object):
         - If the original lightcurve contains a quality attribute, then the
           bitwise OR of the quality flags will be returned per bin.
         """
-        # Early versions of astropy do not have calculate_bin_edges
-
         # Validate user input
         method = validate_method(method, supported_methods=['mean', 'median'])
         if (binsize is None) and (bins is None):
@@ -930,14 +928,17 @@ class LightCurve(object):
         elif (binsize is not None) and (bins is not None):
             raise ValueError('Both binsize and bins kwargs were passed to '
                              '`.bin()`.  Must assign only one of these.')
+
+        # Only recent versions of AstroPy (>Dec 2018) provide ``calculate_bin_edges``
         if bins is not None:
             try:
                 from astropy.stats import calculate_bin_edges
             except ImportError:
                 from astropy import __version__ as astropy_version
-                raise ImportError(" The `bins=` parameter requires astropy >3.1 or >2.10,"
-                      " you currently have astropy version {}."
-                      " Update astropy or use the `binsize` kwarg".format(astropy_version))
+                raise ImportError("The `bins=` parameter requires astropy >=3.1 or >=2.10, "
+                                  "you currently have astropy version {}. "
+                                  "Update astropy or use the `binsize` argument instead."
+                                  "".format(astropy_version))
 
         # Define and map the functions to be applied to each bin
         method_func = np.__dict__['nan' + method]

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -442,6 +442,14 @@ def test_bin():
 
 def test_bins_kwarg():
     """Does binning work with user-defined bin placement?"""
+    # The bins feature requires astropy >3.1 or >2.10;
+    # so we'll ignore this test if those versions are not available.
+    # We should remove this check once we upgrade the minimum requirements.
+    try:
+        from astropy.stats import calculate_bin_edges
+    except ImportError:
+        return
+
     n_times = 3800
     time_points = np.sort(np.random.uniform(low=0.0, high=80.0, size=n_times))
     lc = LightCurve(time=time_points, flux=1.0+np.random.normal(0, 0.1, n_times),


### PR DESCRIPTION
This PR adds a few small tweaks to make sure #644 does not break the unit tests when an older version of astropy is installed.