### PR TITLE
Ensure aperture photometry returns NaN if all FLUX or FLUX_ERR pixel values are NaN (fixes #648)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.5.3 (unreleased)
+==================
+
+- Fixed a bug in ``tpf.to_lightcurve()`` which caused ``flux`` and ``flux_err``
+  to be ``0`` instead of ``NaN`` for cadences with all-NaN pixels. [#651]
+
+
+
 1.5.2 (2019-12-05)
 ==================
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -242,20 +242,20 @@ class LightCurve(object):
         light curve of Pi Mensae as an example, which we obtained as follows::
 
             >>> import lightkurve as lk
-            >>> lc = lk.search_lightcurvefile("Pi Mensae", mission="TESS", sector=1).download().PDCSAP_FLUX
-            >>> lc
+            >>> lc = lk.search_lightcurvefile("Pi Mensae", mission="TESS", sector=1).download().PDCSAP_FLUX  # doctest: +SKIP
+            >>> lc  # doctest: +SKIP
             TessLightCurve(TICID: 261136679)
 
         Every `LightCurve` object has a `time` attribute, which provides access
         to the original array of time values given in the native format and
         scale used by the data product from which the light curve was obtained::
 
-            >>> lc.time
+            >>> lc.time  # doctest: +SKIP
             array([1325.29698328, 1325.29837215, 1325.29976102, ..., 1353.17431099,
                    1353.17569985, 1353.17708871])
-            >>> lc.time_format
+            >>> lc.time_format  # doctest: +SKIP
             'btjd'
-            >>> lc.time_scale
+            >>> lc.time_scale  # doctest: +SKIP
             'tdb'
 
         To enable users to convert these time values to different formats or

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -31,21 +31,21 @@ class Seismology(object):
     Download the TESS light curve for HIP 116158:
 
         >>> import lightkurve as lk
-        >>> lc = lk.search_lightcurvefile("HIP 116158", sector=2).download().PDCSAP_FLUX
-        >>> lc = lc.normalize().remove_nans().remove_outliers()
+        >>> lc = lk.search_lightcurvefile("HIP 116158", sector=2).download().PDCSAP_FLUX  # doctest: +SKIP
+        >>> lc = lc.normalize().remove_nans().remove_outliers()  # doctest: +SKIP
 
     Create a Lomb-Scargle periodogram:
 
-        >>> pg = lc.to_periodogram(normalization='psd', minimum_frequency=100, maximum_frequency=800)
+        >>> pg = lc.to_periodogram(normalization='psd', minimum_frequency=100, maximum_frequency=800)  # doctest: +SKIP
 
     Create a Seismology object and use it to estimate parameters:
 
-        >>> seismology = pg.flatten().to_seismology()
-        >>> seismology.estimate_numax()
+        >>> seismology = pg.flatten().to_seismology()  # doctest: +SKIP
+        >>> seismology.estimate_numax()  # doctest: +SKIP
         numax: 415.00 uHz (method: ACF2D)
-        >>> seismology.estimate_deltanu()
+        >>> seismology.estimate_deltanu()  # doctest: +SKIP
         deltanu: 28.78 uHz (method: ACF2D)
-        >>> seismology.estimate_radius(teff=5080)
+        >>> seismology.estimate_radius(teff=5080)  # doctest: +SKIP
         radius: 2.78 solRad (method: Uncorrected Scaling Relations)
 
     Parameters

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -559,6 +559,38 @@ class TargetPixelFile(object):
         row_centr = np.asfarray(row_centr) + self.row + .5
         return col_centr, row_centr
 
+    def _aperture_photometry(self, aperture_mask='pipeline', centroid_method='moments'):
+        """Helper method for ``extract_aperture photometry``.
+
+        Returns
+        -------
+        flux, flux_err, centroid_col, centroid_row
+        """
+        # Validate the aperture mask
+        aperture_mask = self._parse_aperture_mask(aperture_mask)
+        if aperture_mask.sum() == 0:
+            log.warning('Warning: aperture mask contains zero pixels.')
+
+        # Estimate centroids
+        centroid_col, centroid_row = self.estimate_centroids(aperture_mask,
+                                                             method=centroid_method)
+
+        # Estimate flux and flux_err
+        flux = np.nansum(self.flux[:, aperture_mask], axis=1)
+        # Ignore warnings related to zero or negative errors
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            flux_err = np.nansum(self.flux_err[:, aperture_mask]**2, axis=1)**0.5
+            # We use ``np.nansum`` above to be robust against the errors in a
+            # subset of pixels being NaN. However, if *all* pixels show
+            # ``FLUX_ERR==NaN```, it is important that we propogate
+            # ``flux_err=NaN``` for that cadence:
+            is_allnan = ~np.any(np.isfinite(self.flux_err[:, aperture_mask]),
+                                axis=1)
+            flux_err[is_allnan] = np.nan
+
+        return flux, flux_err, centroid_col, centroid_row
+
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
              show_colorbar=True, mask_color='pink', title=None, style='lightkurve',
              **kwargs):
@@ -697,16 +729,16 @@ class TargetPixelFile(object):
         To select an aperture mask for V827 Tau::
 
             >>> import lightkurve as lk
-            >>> tpf = lk.search_targetpixelfile("V827 Tau", mission="K2").download()
-            >>> tpf.interact()
+            >>> tpf = lk.search_targetpixelfile("V827 Tau", mission="K2").download()  # doctest: +SKIP
+            >>> tpf.interact()  # doctest: +SKIP
 
 
         To see the full y-axis dynamic range of your lightcurve and normalize
         the lightcurve after each pixel selection::
 
-            >>> ylim_func = lambda lc: (0.0, lc.flux.max())
-            >>> transform_func = lambda lc: lc.normalize()
-            >>> tpf.interact(ylim_func=ylim_func, transform_func=transform_func)
+            >>> ylim_func = lambda lc: (0.0, lc.flux.max())  # doctest: +SKIP
+            >>> transform_func = lambda lc: lc.normalize()  # doctest: +SKIP
+            >>> tpf.interact(ylim_func=ylim_func, transform_func=transform_func)  # doctest: +SKIP
 
         """
         from .interact import show_interact_widget
@@ -1050,15 +1082,9 @@ class KeplerTargetPixelFile(TargetPixelFile):
             Array containing the summed flux within the aperture for each
             cadence.
         """
-        aperture_mask = self._parse_aperture_mask(aperture_mask)
-        if aperture_mask.sum() == 0:
-            log.warning('Warning: aperture mask contains zero pixels.')
-        centroid_col, centroid_row = self.estimate_centroids(aperture_mask, method=centroid_method)
-        # Ignore warnings related to zero or negative errors
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            flux_err = np.nansum(self.flux_err[:, aperture_mask]**2, axis=1)**0.5
-
+        flux, flux_err, centroid_col, centroid_row = \
+            self._aperture_photometry(aperture_mask=aperture_mask,
+                                      centroid_method=centroid_method)
         keys = {'centroid_col': centroid_col,
                 'centroid_row': centroid_row,
                 'quality': self.quality,
@@ -1072,7 +1098,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 'label': self.header['OBJECT'],
                 'targetid': self.targetid}
         return KeplerLightCurve(time=self.time,
-                                flux=np.nansum(self.flux[:, aperture_mask], axis=1),
+                                flux=flux,
                                 flux_err=flux_err,
                                 **keys)
 
@@ -1650,7 +1676,7 @@ class TessTargetPixelFile(TargetPixelFile):
         return btjd_to_astropy_time(btjd=self.time)
 
     def extract_aperture_photometry(self, aperture_mask='pipeline', centroid_method='moments'):
-        """Performs aperture photometry.
+        """Returns a LightCurve obtained using aperture photometry.
 
         Parameters
         ----------
@@ -1672,15 +1698,9 @@ class TessTargetPixelFile(TargetPixelFile):
         lc : TessLightCurve object
             Contains the summed flux within the aperture for each cadence.
         """
-        aperture_mask = self._parse_aperture_mask(aperture_mask)
-        if aperture_mask.sum() == 0:
-            log.warning('Warning: aperture mask contains zero pixels.')
-        centroid_col, centroid_row = self.estimate_centroids(aperture_mask, method=centroid_method)
-        # Ignore warnings related to zero or negative errors
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            flux_err = np.nansum(self.flux_err[:, aperture_mask]**2, axis=1)**0.5
-
+        flux, flux_err, centroid_col, centroid_row = \
+            self._aperture_photometry(aperture_mask=aperture_mask,
+                                      centroid_method=centroid_method)
         keys = {'centroid_col': centroid_col,
                 'centroid_row': centroid_row,
                 'quality': self.quality,
@@ -1693,7 +1713,7 @@ class TessTargetPixelFile(TargetPixelFile):
                 'label': self.get_keyword('OBJECT'),
                 'targetid': self.targetid}
         return TessLightCurve(time=self.time,
-                              flux=np.nansum(self.flux[:, aperture_mask], axis=1),
+                              flux=flux,
                               flux_err=flux_err,
                               **keys)
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -580,7 +580,7 @@ class TargetPixelFile(object):
         # being NaN, however if *all* pixels are NaN, we propagate a NaN.
         is_allnan = ~np.any(np.isfinite(self.flux[:, apmask]), axis=1)
         flux[is_allnan] = np.nan
-        
+
         # Estimate flux_err
         with warnings.catch_warnings():
             # Ignore warnings due to negative errors

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -534,3 +534,15 @@ def test_cutout():
         ntpf = tpf.cutout(size=2)
         assert np.product(ntpf.flux.shape[1:]) == 4
         assert ntpf.targetid == '{}_CUTOUT'.format(tpf.targetid)
+
+
+def test_aperture_photometry_fluxerr_nan():
+    """Regression test for #648.
+
+    When FLUX_ERR is entirely NaN in a TPF, the resulting light curve
+    should report flux_err=NaN in that cadence rather than zero."""
+    tpf = lkopen(filename_tpf_one_center)
+    tpf.hdu[1].data['FLUX_ERR'][2] = np.nan
+    lc = tpf.to_lightcurve(aperture_mask='all')
+    assert ~np.isnan(lc.flux_err[1])
+    assert np.isnan(lc.flux_err[2])


### PR DESCRIPTION
When the `FLUX` or `FLUX_ERR` column in a Target Pixel File is all NaN for a given cadence, Lightkurve's aperture photometry currently reported the `flux` or `flux_err` as being zero in that cadence.  This is because we use `np.nansum` to compute aperture photometry. This PR fixes the issues, which will also address #648. 

i.e. the following unit test used to fail and passes now:
```
    tpf.hdu[1].data['FLUX_ERR'][2] = np.nan
    lc = tpf.to_lightcurve(aperture_mask='all')
    assert np.isnan(lc.flux_err[2])
```