### PR TITLE
Make `fbpca` a required dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.5.3 (unreleased)
+1.6.0 (unreleased)
 ==================
 
 - Fixed a bug in ``tpf.to_lightcurve()`` which caused ``flux`` and ``flux_err``
@@ -8,6 +8,9 @@
   in Sector 14 to mark cadences affected by strong scattered light.  Compared
   to the original stray light flag (bit 12), this flag is set automatically by
   the pipeline based on background level thresholds.
+
+- Changed the requirements to make ``fbpca`` a required dependency, because
+  it allows ``DesignMatrix.pca()`` to be faster and more robust.
 
 
 

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -207,16 +207,12 @@ class DesignMatrix():
         # nterms cannot be langer than the number of columns in the matrix
         if nterms > self.shape[1]:
             nterms = self.shape[1]
-        # `fbpca.pca` is faster than `np.linalg.svd` but an optional dependency
-        try:
-            from fbpca import pca
-            # fbpca is randomized, and has n_iter=2 as default,
-            # we find this to be too few, and that n_iter=10 is still fast but
-            # produces stable results.
-            new_values, _, _ = pca(self.values, nterms, n_iter=10)
-        except ImportError:
-            new_values, _, _ = np.linalg.svd(self.values)
-            new_values = new_values[:, :nterms]
+        # We use `fbpca.pca` instead of `np.linalg.svd` because it is faster.
+        # Note that fbpca is randomized, and has n_iter=2 as default,
+        # we find this to be too few, and that n_iter=10 is still fast but
+        # produces more stable results.
+        from fbpca import pca  # local import because not used elsewhere
+        new_values, _, _ = pca(self.values, nterms, n_iter=10)
         return DesignMatrix(new_values, name=self.name)
 
     def append_constant(self, prior_mu=0, prior_sigma=np.inf):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tqdm
 pandas
 uncertainties
 patsy
+fbpca

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov', 'pytest
 # 3. What dependencies are required for optional features?
 # `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.
-# `PLDCorrector` requires pybind11, celerite, fbpca.
+# `PLDCorrector` requires pybind11, celerite.
 extras_require = {"all":  ["astropy>=3.1",
                            "bokeh>=1.0", "ipython",
-                           "pybind11", "celerite", "fbpca"],
+                           "pybind11", "celerite"],
                   "test": tests_require}
 
 setup(name='lightkurve',


### PR DESCRIPTION
This PR changes the minimum requirements to make the ``fbpca`` package a required dependency instead of an optional one, because it allows ``DesignMatrix.pca()`` to be much faster and more robust.

By adding it as a required dependency, we can make sure that ``DesignMatrix.pca()`` will behave in the same way for all users.  Right now its implementation falls back to ``scipy.linalg.svd`` if ``fbpca`` is not installed, which makes debugging user issues more complicated.

`fbpca` can easily be installed via `pip`; numpy and scipy are its only dependencies, and we already require those as well.