### PR TITLE
ignore astropy_time attribute exception in show_properties

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -308,7 +308,7 @@ class LightCurve(object):
             if not attr.startswith('_'):
                 try:
                     res = getattr(self, attr)
-                except Exception: 
+                except Exception:
                     continue
                 if callable(res):
                     continue

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -306,7 +306,10 @@ class LightCurve(object):
         attrs = {}
         for attr in dir(self):
             if not attr.startswith('_'):
-                res = getattr(self, attr)
+                try:
+                    res = getattr(self, attr)
+                except Exception: 
+                    continue
                 if callable(res):
                     continue
                 if attr == 'hdu':


### PR DESCRIPTION
Fixes #655, so that available properties are successfully printed by call to `show_properties` when time is not `astropy_time` formatted.