### PR TITLE
TPF objects can now be added, subtracted, multiplied and divided by numpy arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Removed support for Python 2. [#733]
 
+- Added the ability to perform math with ``TargetPixelFile`` objects, e.g.,
+  ``tpf = tpf - 100`` will subtract 100 from the ``tpf.flux`` values. [#665]
+
 
 
 1.11.0 (2015-05-20)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -90,40 +90,7 @@ class TargetPixelFile(object):
     def __len__(self):
         return len(self.time)
 
-
-    def _verify_other_(self, other):
-        # 1D
-        other = np.atleast_1d(np.copy(other))
-        if len(np.shape(other)) == 1:
-            # point
-            if np.shape(other)[0] == 1:
-                reshaped_other = other[0]
-            # vector
-            elif np.shape(other)[0] == len(self.time):
-                reshaped_other = np.atleast_3d(other).transpose([1, 0, 2]) * np.ones(self.flux.shape)
-            else:
-                raise ValueError('No way to add shape {} to self flux of shape {}'.format(other.shape, self.flux.shape))
-
-        # 2D
-        if len(np.shape(other)) == 2:
-            # point
-            if np.shape(other) == np.shape(self.flux)[1:]:
-                reshaped_other = np.atleast_3d(other).transpose([2, 0, 1]) * np.ones(self.flux.shape)
-            else:
-                raise ValueError('No way to add shape {} to tpf flux of shape {}'.format(other.shape, self.flux.shape))
-
-        # 3D
-        if len(np.shape(other)) == 3:
-            # point
-            if np.shape(other) == np.shape(self.flux):
-                reshaped_other = other
-            else:
-                raise ValueError('No way to add shape {} to tpf flux of shape {}'.format(other.shape, self.flux.shape))
-
-        return reshaped_other
-
     def __add__(self, other):
-        other = self._verify_other_(other)
         hdu = deepcopy(self.hdu)
         tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] += other
@@ -135,7 +102,6 @@ class TargetPixelFile(object):
         return tpf
 
     def __mul__(self, other):
-        other = self._verify_other_(other)
         hdu = deepcopy(self.hdu)
         tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] *= other
@@ -148,7 +114,6 @@ class TargetPixelFile(object):
         return tpf
 
     def __rtruediv__(self, other):
-        other = self._verify_other_(other)
         hdu = deepcopy(self.hdu)
         tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] /= other
@@ -161,31 +126,24 @@ class TargetPixelFile(object):
         return tpf
 
     def __radd__(self, other):
-        other = self._verify_other_(other)
         return self.__add__(other)
 
     def __sub__(self, other):
-        other = self._verify_other_(other)
         return self.__add__(-1 * other)
 
     def __rsub__(self, other):
-        other = self._verify_other_(other)
         return (-1 * self).__add__(other)
 
     def __rmul__(self, other):
-        other = self._verify_other_(other)
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        other = self._verify_other_(other)
         return self.__mul__(1. / other)
 
     def __div__(self, other):
-        other = self._verify_other_(other)
         return self.__truediv__(other)
 
     def __rdiv__(self, other):
-        other = self._verify_other_(other)
         return self.__rtruediv__(other)
 
     @property

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -22,8 +22,6 @@ import numpy as np
 from scipy.ndimage import label
 from tqdm import tqdm
 from copy import deepcopy
-import pandas as pd
-import tempfile
 
 from . import PACKAGEDIR, MPLSTYLE
 from .lightcurve import KeplerLightCurve, TessLightCurve
@@ -97,27 +95,15 @@ class TargetPixelFile(object):
 
     def __mul__(self, other):
         hdu = deepcopy(self.hdu)
-        tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] *= other
         hdu[1].data['FLUX_ERR'][self.quality_mask] *= other
-        fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
-        tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
-        tpf.path = None
-        tmp.close()
-        os.remove(tmp.name)
-        return tpf
+        return type(self)(hdu, quality_bitmask=self.quality_bitmask)
 
     def __rtruediv__(self, other):
         hdu = deepcopy(self.hdu)
-        tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] /= other
         hdu[1].data['FLUX_ERR'][self.quality_mask] /= other
-        fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
-        tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
-        tpf.path = None
-        tmp.close()
-        os.remove(tmp.name)
-        return tpf
+        return type(self)(hdu, quality_bitmask=self.quality_bitmask)
 
     def __radd__(self, other):
         return self.__add__(other)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -92,14 +92,8 @@ class TargetPixelFile(object):
 
     def __add__(self, other):
         hdu = deepcopy(self.hdu)
-        tmp = tempfile.NamedTemporaryFile(delete=False)
         hdu[1].data['FLUX'][self.quality_mask] += other
-        fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
-        tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
-        tpf.path = None
-        tmp.close()
-        os.remove(tmp.name)
-        return tpf
+        return type(self)(hdu, quality_bitmask=self.quality_bitmask)
 
     def __mul__(self, other):
         hdu = deepcopy(self.hdu)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -129,6 +129,7 @@ class TargetPixelFile(object):
         hdu[1].data['FLUX'][self.quality_mask] += other
         fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
         tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
+        tpf.path = None
         tmp.close()
         os.remove(tmp.name)
         return tpf
@@ -141,6 +142,7 @@ class TargetPixelFile(object):
         hdu[1].data['FLUX_ERR'][self.quality_mask] *= other
         fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
         tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
+        tpf.path = None
         tmp.close()
         os.remove(tmp.name)
         return tpf
@@ -153,6 +155,7 @@ class TargetPixelFile(object):
         hdu[1].data['FLUX_ERR'][self.quality_mask] /= other
         fits.HDUList(hdus=list(hdu)).writeto(tmp.name, overwrite=True)
         tpf = type(self)(tmp.name, quality_bitmask=self.quality_bitmask)
+        tpf.path = None
         tmp.close()
         os.remove(tmp.name)
         return tpf

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -70,7 +70,7 @@ def test_tpf_math():
                 TessTargetPixelFile(filename_tpf_all_zeros)]
     # These should work
     for tpf in tpfs:
-        for other in [1, [1], np.arange(len(tpf.time)), np.ones(tpf.flux.shape[1:]), np.ones(tpf.shape)]:
+        for other in [1, np.ones(tpf.flux.shape[1:]), np.ones(tpf.shape)]:
             tpf + other
             tpf - other
             tpf * other
@@ -84,7 +84,7 @@ def test_tpf_math():
 
     # These should fail with a value error because their shape is wrong.
     for tpf in tpfs:
-        for other in [[1, 2], np.arange(len(tpf.time) - 1), np.ones([100, 1]), np.ones([1, 2, 3])]:
+        for other in [np.asarray([1, 2]), np.arange(len(tpf.time) - 1), np.ones([100, 1]), np.ones([1, 2, 3])]:
             with pytest.raises(ValueError):
                 tpf + other
 

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -61,6 +61,41 @@ def test_tpf_shapes():
         assert tpf.quality_mask.shape == tpf.hdu[1].data['TIME'].shape
         assert tpf.flux.shape == tpf.flux_err.shape
 
+def test_tpf_math():
+    """Can you add, subtract, multiply and divide?"""
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpfs = [KeplerTargetPixelFile(filename_tpf_all_zeros),
+                TessTargetPixelFile(filename_tpf_all_zeros)]
+    # These should work
+    for tpf in tpfs:
+        for other in [1, [1], np.arange(len(tpf.time)), np.ones(tpf.flux.shape[1:]), np.ones(tpf.shape)]:
+            tpf + other
+            tpf - other
+            tpf * other
+            tpf / other
+
+
+            tpf += other
+            tpf -= other
+            tpf *= other
+            tpf /= other
+
+    # These should fail with a value error because their shape is wrong.
+    for tpf in tpfs:
+        for other in [[1, 2], np.arange(len(tpf.time) - 1), np.ones([100, 1]), np.ones([1, 2, 3])]:
+            with pytest.raises(ValueError):
+                tpf + other
+
+    # Check the values are correct
+    assert np.all(((tpf.flux + 2) == (tpf + 2).flux)[np.isfinite(tpf.flux)])
+    assert np.all(((tpf.flux - 2) == (tpf - 2).flux)[np.isfinite(tpf.flux)])
+    assert np.all(((tpf.flux * 2) == (tpf * 2).flux)[np.isfinite(tpf.flux)])
+    assert np.all(((tpf.flux / 2) == (tpf / 2).flux)[np.isfinite(tpf.flux)])
+    assert np.all(((tpf.flux_err * 2) == (tpf * 2).flux_err)[np.isfinite(tpf.flux)])
+    assert np.all(((tpf.flux_err / 2) == (tpf / 2).flux_err)[np.isfinite(tpf.flux)])
+
 
 def test_tpf_plot():
     """Sanity check to verify that tpf plotting works"""


### PR DESCRIPTION
It's useful to be able to do simple maths with TPF objects in order to e.g. remove background. I've added the capability to do that.

There are special rules depending on the shape of the object you try to add/subtract/divide/multiply. 

- If it's a point, it's add/subtract/divide/multiply-ed from all values.
- If it's a vector with **length time** , it's add/subtract/divide/multiply-ed from each frame.
- If it's a vector **NOT of length time**  it raises a value error
- If it's a 2D array with **shape npixels x mpixels** , it's add/subtract/divide/multiply-ed from each pixel.
- If it's a 2D array with **shape NOT npixels x mpixels** , it raises a value error
- If it's a 3D array with **shape time x npixels x mpixels** , it's add/subtract/divide/multiply-ed from each value.
- If it's a 3D array with **shape NOT time x npixels x mpixels** , it raises a value error


![image](https://user-images.githubusercontent.com/14965634/72569243-cb80df00-386e-11ea-8bab-f7f9898f81b3.png)

There are lovely accompanying tests.