### PR TITLE
[Bugfix] Fixing interact bug where empty pipeline aperture masks cause it to crash.

### DIFF
--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -289,6 +289,14 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     fiducial_frame: int
         The tpf slice to start with by default, it is assumed the WCS
         is exact for this frame.
+    scale: str
+        Color scale for tpf figure. Default is 'log'
+    vmin: int [optional]
+        Minimum color scale for tpf figure
+    vmax: int [optional]
+        Maximum color scale for tpf figure
+    cmap: str
+        Colormap to use for tpf plot. Default is 'Viridis256'
 
     Returns
     -------
@@ -475,6 +483,14 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         A function that returns ylimits (low, high) given a LightCurve object.
         The default is to return an expanded window around the 10-90th
         percentile of lightcurve flux values.
+    scale: str
+        Color scale for tpf figure. Default is 'log'
+    vmin: int [optional]
+        Minimum color scale for tpf figure
+    vmax: int [optional]
+        Maximum color scale for tpf figure
+    cmap: str
+        Colormap to use for tpf plot. Default is 'Viridis256'    
     """
     try:
         import bokeh

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -306,7 +306,7 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     """
     if pedestal is None:
         pedestal = -np.nanmin(tpf.flux) + 1
-    if scale is 'linear':
+    if scale == 'linear':
         pedestal = 0
 
     if tpf.mission in ['Kepler', 'K2']:
@@ -333,14 +333,14 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     if vmax is not None:
         vhi, hi = vmax, vmax
 
-    if scale is 'log':
+    if scale == 'log':
         vstep = (np.log10(vhi) - np.log10(vlo)) / 300.0  # assumes counts >> 1.0!
-    if scale is 'linear':
+    if scale == 'linear':
         vstep = (vhi - vlo) / 300.0  # assumes counts >> 1.0!
 
-    if scale is 'log':
+    if scale == 'log':
         color_mapper = LogColorMapper(palette=cmap, low=lo, high=hi)
-    elif scale is 'linear':
+    elif scale == 'linear':
         color_mapper = LinearColorMapper(palette=cmap, low=lo, high=hi)
     else:
         raise ValueError('Please specify either `linear` or `log` scale for color.')
@@ -355,9 +355,9 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     # This effect is known, some workarounds might work to fix the plot area:
     # https://github.com/bokeh/bokeh/issues/5186
 
-    if scale is 'log':
+    if scale == 'log':
         ticker = LogTicker(desired_num_ticks=8)
-    elif scale is 'linear':
+    elif scale == 'linear':
         ticker = BasicTicker(desired_num_ticks=8)
 
     color_bar = ColorBar(color_mapper=color_mapper,
@@ -376,10 +376,10 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
                 fill_alpha=0.4, line_color='white')
 
     # Configure the stretch slider and its callback function
-    if scale is 'log':
+    if scale == 'log':
         start, end = np.log10(vlo), np.log10(vhi)
         values = (np.log10(lo), np.log10(hi))
-    elif scale is 'linear':
+    elif scale == 'linear':
         start, end = vlo, vhi
         values = (lo, hi)
 
@@ -406,9 +406,9 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
         fig.select('tpfimg')[0].glyph.color_mapper.high = new[1]
         fig.select('tpfimg')[0].glyph.color_mapper.low = new[0]
 
-    if scale is 'log':
+    if scale == 'log':
         stretch_slider.on_change('value', stretch_change_callback_log)
-    if scale is 'linear':
+    if scale == 'linear':
         stretch_slider.on_change('value', stretch_change_callback_linear)
 
     return fig, stretch_slider
@@ -550,7 +550,7 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
 
         # Create the TPF figure and its stretch slider
         pedestal = -np.nanmin(tpf.flux) + 1
-        if scale is 'linear':
+        if scale == 'linear':
             pedestal = 0
         fig_tpf, stretch_slider = make_tpf_figure_elements(tpf, tpf_source,
                                                            pedestal=pedestal,

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -506,8 +506,10 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
 
     aperture_mask = tpf._parse_aperture_mask(aperture_mask)
     if ~aperture_mask.any():
+        log.error("No pixels in `aperture_mask`, finding optimum aperture using `tpf.create_threshold_mask`.")
         aperture_mask = tpf.create_threshold_mask()
     if ~aperture_mask.any():
+        log.error("No pixels in `aperture_mask`, using all pixels.")
         aperture_mask = tpf._parse_aperture_mask('all')
 
 

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -505,6 +505,11 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         return None
 
     aperture_mask = tpf._parse_aperture_mask(aperture_mask)
+    if ~aperture_mask.any():
+        aperture_mask = tpf.create_threshold_mask()
+    if ~aperture_mask.any():
+        aperture_mask = tpf._parse_aperture_mask('all')
+
 
     if exported_filename is None:
         exported_filename = make_default_export_name(tpf)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -672,7 +672,7 @@ class TargetPixelFile(object):
 
     def interact(self, notebook_url='localhost:8888', max_cadences=30000,
                  aperture_mask='pipeline', exported_filename=None,
-                 transform_func=None, ylim_func=None):
+                 transform_func=None, ylim_func=None, **kwargs):
         """Display an interactive Jupyter Notebook widget to inspect the pixel data.
 
         The widget will show both the lightcurve and pixel data.  By default,
@@ -747,7 +747,7 @@ class TargetPixelFile(object):
                                     aperture_mask=aperture_mask,
                                     exported_filename=exported_filename,
                                     transform_func=transform_func,
-                                    ylim_func=ylim_func)
+                                    ylim_func=ylim_func, **kwargs)
 
     def interact_sky(self, notebook_url='localhost:8888', magnitude_limit=18):
         """Display a Jupyter Notebook widget showing Gaia DR2 positions on top of the pixels.


### PR DESCRIPTION
In tesscut TPFs the aperture mask is set to be all False. In interact, if there is an all False aperture mask it doesn't actually work. I've added a fix that will create a threshold mask if there isn't one, or failing that use all the pixels.