### PR TITLE
Raise a `ValueError` if `RegressionCorrector` receives a light curve with flux_err <= 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
 - Fixed a bug which caused ``TargetPixelFile.interact()`` to crash if the
   pipeline aperture mask did not contain pixels. [#667]
 
+- Fixed a bug which caused ``RegressionCorrector.correct()`` to crash if the
+  input light curve contained flux uncertainties <= 0. [#668]
+
 
 
 1.6.0 (2019-12-16)

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -84,6 +84,10 @@ class RegressionCorrector(Corrector):
             raise ValueError('Input light curve has NaNs in `flux_err`. '
                              'Please remove NaNs before correction '
                              '(e.g. using `lc = lc.remove_nans()`).')
+        if np.any(lc.flux_err <= 0):
+            raise ValueError('Input light curve contains flux uncertainties '
+                             'smaller than or equal to zero. Please remove '
+                             'these (e.g. using `lc = lc[lc.flux_err > 0]`).')
         self.lc = lc
 
         # The following properties will be set when correct() is called.

--- a/lightkurve/correctors/tests/test_regressioncorrector.py
+++ b/lightkurve/correctors/tests/test_regressioncorrector.py
@@ -99,3 +99,17 @@ def test_nan_input():
     # because it is common for errors to be missing.
     lc = LightCurve(flux=[5, 10], flux_err=[np.nan, np.nan])
     RegressionCorrector(lc)
+
+
+def test_zero_fluxerr():
+    """Regression test for #668.
+
+    Flux uncertainties smaller than or equal to zero (`lc.flux_err <= 0`) will
+    trigger an invalid or non-finite matrix.  We expect `RegressionCorrector`
+    to detect this and yield a graceful `ValueError`."""
+    lc = LightCurve(flux=[5, 10], flux_err=[1, 0])
+    with pytest.raises(ValueError):
+        RegressionCorrector(lc)
+    lc = LightCurve(flux=[5, 10], flux_err=[1, -10])
+    with pytest.raises(ValueError):
+        RegressionCorrector(lc)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -475,6 +475,12 @@ class LightCurve(object):
             trend_signal = np.zeros(len(self.time[mask]))
             print("low {}".format(low))
             print("high {}".format(high))
+            print("cut {}".format(cut))
+            print("lentimemask {}".format(len(self.time[mask])))
+            print("dt {}".format(dt))
+            print("time {}".format(self.time))
+            print("mask {}".format(mask))
+
             for l, h in zip(low, high):
                 # Reduce `window_length` and `polyorder` for short segments;
                 # this prevents `savgol_filter` from raising an exception

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -503,7 +503,7 @@ class LightCurve(object):
                                                                  **kwargs)
             # No outliers
             mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
-                    (np.nanstd(self.flux[mask] - trend_signal) * sigma + 1e-15)
+                    (np.nanstd(self.flux[mask] - trend_signal) * sigma + 1e-14)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
             print("fm-ts {}".format(self.flux[mask] - trend_signal))
             print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -477,8 +477,14 @@ class LightCurve(object):
                 # Reduce `window_length` and `polyorder` for short segments;
                 # this prevents `savgol_filter` from raising an exception
                 # If the segment is too short, just take the median
+                print("l {}".format(l))
+                print("h {}".format(h))
+                print("window_length {}".format(window_length))
+                print("break_tolerance {}".format(break_tolerance))
+
                 if np.any([window_length > (h - l), (h - l) < break_tolerance]):
                     trend_signal[l:h] = np.nanmedian(self.flux[mask][l:h])
+                    print("USING MEDIAN")
                 else:
                     # Scipy outputs a warning here that is not useful, will be fixed in version 1.2
                     with warnings.catch_warnings():

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -505,13 +505,12 @@ class LightCurve(object):
             mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
                     (np.nanstd(self.flux[mask] - trend_signal) * sigma)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
-            trend_signal = f(self.time)
             print("fm-ts {}".format(self.flux[mask] - trend_signal))
             print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))
             print("sigma {}".format(sigma))
             print("nanstd {}".format(np.nanstd(self.flux[mask] - trend_signal)))
             print("================")
-
+            trend_signal = f(self.time)
             mask[mask] &= mask1
 
         flatten_lc = self.copy()

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -507,6 +507,11 @@ class LightCurve(object):
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
             trend_signal = f(self.time)
             mask[mask] &= mask1
+            print("fm-ts {}".format(self.flux[mask] - trend_signal))
+            print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))
+            print("sigma {}".format(sigma))
+            print("nanstd {}".format(np.nanstd(self.flux[mask] - trend_signal)))
+            print("================")
 
         flatten_lc = self.copy()
         with warnings.catch_warnings():

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -473,7 +473,6 @@ class LightCurve(object):
             high = np.append(cut, len(self.time[mask]))
             # Then, apply the savgol_filter to each segment separately
             trend_signal = np.zeros(len(self.time[mask]))
-
             for l, h in zip(low, high):
                 # Reduce `window_length` and `polyorder` for short segments;
                 # this prevents `savgol_filter` from raising an exception

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -473,26 +473,13 @@ class LightCurve(object):
             high = np.append(cut, len(self.time[mask]))
             # Then, apply the savgol_filter to each segment separately
             trend_signal = np.zeros(len(self.time[mask]))
-            print("low {}".format(low))
-            print("high {}".format(high))
-            print("cut {}".format(cut))
-            print("lentimemask {}".format(len(self.time[mask])))
-            print("dt {}".format(dt))
-            print("time {}".format(self.time))
-            print("mask {}".format(mask))
 
             for l, h in zip(low, high):
                 # Reduce `window_length` and `polyorder` for short segments;
                 # this prevents `savgol_filter` from raising an exception
                 # If the segment is too short, just take the median
-                print("l {}".format(l))
-                print("h {}".format(h))
-                print("window_length {}".format(window_length))
-                print("break_tolerance {}".format(break_tolerance))
-
                 if np.any([window_length > (h - l), (h - l) < break_tolerance]):
                     trend_signal[l:h] = np.nanmedian(self.flux[mask][l:h])
-                    print("USING MEDIAN")
                 else:
                     # Scipy outputs a warning here that is not useful, will be fixed in version 1.2
                     with warnings.catch_warnings():
@@ -505,11 +492,6 @@ class LightCurve(object):
             mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
                     (np.nanstd(self.flux[mask] - trend_signal) * sigma + 1e-14)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
-            print("fm-ts {}".format(self.flux[mask] - trend_signal))
-            print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))
-            print("sigma {}".format(sigma))
-            print("nanstd {}".format(np.nanstd(self.flux[mask] - trend_signal)))
-            print("================")
             trend_signal = f(self.time)
             mask[mask] &= mask1
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -488,7 +488,8 @@ class LightCurve(object):
                                                                  window_length=window_length,
                                                                  polyorder=polyorder,
                                                                  **kwargs)
-            # No outliers
+            # Ignore outliers; note we add `1e-14` below to avoid detecting
+            # outliers which are merely caused by numerical noise.
             mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
                     (np.nanstd(self.flux[mask] - trend_signal) * sigma + 1e-14)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -503,7 +503,7 @@ class LightCurve(object):
                                                                  **kwargs)
             # No outliers
             mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
-                    (np.nanstd(self.flux[mask] - trend_signal) * sigma)
+                    (np.nanstd(self.flux[mask] - trend_signal) * sigma + 1e-15)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
             print("fm-ts {}".format(self.flux[mask] - trend_signal))
             print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -506,12 +506,13 @@ class LightCurve(object):
                     (np.nanstd(self.flux[mask] - trend_signal) * sigma)
             f = interp1d(self.time[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
             trend_signal = f(self.time)
-            mask[mask] &= mask1
             print("fm-ts {}".format(self.flux[mask] - trend_signal))
             print("nantonum {}".format(np.nan_to_num(np.abs(self.flux[mask] - trend_signal))))
             print("sigma {}".format(sigma))
             print("nanstd {}".format(np.nanstd(self.flux[mask] - trend_signal)))
             print("================")
+
+            mask[mask] &= mask1
 
         flatten_lc = self.copy()
         with warnings.catch_warnings():

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -473,6 +473,8 @@ class LightCurve(object):
             high = np.append(cut, len(self.time[mask]))
             # Then, apply the savgol_filter to each segment separately
             trend_signal = np.zeros(len(self.time[mask]))
+            print("low {}".format(low))
+            print("high {}".format(high))
             for l, h in zip(low, high):
                 # Reduce `window_length` and `polyorder` for short segments;
                 # this prevents `savgol_filter` from raising an exception

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -791,9 +791,6 @@ def test_flatten_robustness():
     lc = LightCurve([1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60])
     expected_result = np.array([1.,  1.,  1.,  1.,  1., 1.])
     flat_lc = lc.flatten(window_length=3, polyorder=1)
-    a, b = lc.flatten(window_length=3, polyorder=1, return_trend=True)
-    print(a.flux)
-    print(b.flux)
     assert_allclose(flat_lc.flux, expected_result)
     # flatten should work even if `window_length > len(flux)`
     flat_lc = lc.flatten(window_length=7, polyorder=1)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -791,6 +791,9 @@ def test_flatten_robustness():
     lc = LightCurve([1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60])
     expected_result = np.array([1.,  1.,  1.,  1.,  1., 1.])
     flat_lc = lc.flatten(window_length=3, polyorder=1)
+    a, b = lc.flatten(window_length=3, polyorder=1, return_trend=True)
+    print(a.flux)
+    print(b.flux)
     assert_allclose(flat_lc.flux, expected_result)
     # flatten should work even if `window_length > len(flux)`
     flat_lc = lc.flatten(window_length=7, polyorder=1)

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -41,6 +41,7 @@ def test_running_mean():
     assert_almost_equal(running_mean([1, 2, 3], window_size=1), [1, 2, 3])
     assert_almost_equal(running_mean([1, 2, 3], window_size=2), [1.5, 2.5])
     assert_almost_equal(running_mean([2, 2, 2], window_size=3), [2])
+    assert_almost_equal(running_mean([2, 2, 2], window_size=20), [2])
 
 
 def test_quality_flag_decoding_kepler():

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_running_mean():
     assert_almost_equal(running_mean([1, 2, 3], window_size=1), [1, 2, 3])
     assert_almost_equal(running_mean([1, 2, 3], window_size=2), [1.5, 2.5])
     assert_almost_equal(running_mean([2, 2, 2], window_size=3), [2])
-    assert_almost_equal(running_mean([2, 2, 2], window_size=20), [2])
+    assert_almost_equal(running_mean([3, 4, 5], window_size=20), [4])
 
 
 def test_quality_flag_decoding_kepler():

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -316,6 +316,8 @@ def running_mean(data, window_size):
     window_size : int
         Window length used to compute the running mean.
     """
+    if window_size > len(data):
+        window_size = len(data)
     cumsum = np.cumsum(np.insert(data, 0, 0))
     return (cumsum[window_size:] - cumsum[:-window_size]) / float(window_size)
 


### PR DESCRIPTION
This PR attempts to address #668 by raising a helpful `ValueError` if `RegressionCorrector` received an input light curve with `lc.flux_err <= 0`.