### PR TITLE
Add a warning when `SFFCorrector` is used to correct a TESS light curve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Added a ``scale='linear'`` option to ``TargetPixelFile.interact()`` to show
   pixels using a linear stretch. The default is ``scale='log'``. [#664]
 
+- Added a warning if ``SFFCorrector`` is used to correct TESS data. [#660]
+
 - Changed the behavior of sigma-clipping inside ``RegressionCorrector``. [#654]
 
 - Fixed a bug which caused ``LightCurve.show_properties()`` to raise a

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -84,7 +84,7 @@ class RegressionCorrector(Corrector):
             raise ValueError('Input light curve has NaNs in `flux_err`. '
                              'Please remove NaNs before correction '
                              '(e.g. using `lc = lc.remove_nans()`).')
-        if np.any(lc.flux_err <= 0):
+        if np.any(lc.flux_err[np.isfinite(lc.flux_err)] <= 0):
             raise ValueError('Input light curve contains flux uncertainties '
                              'smaller than or equal to zero. Please remove '
                              'these (e.g. using `lc = lc[lc.flux_err > 0]`).')

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -35,6 +35,11 @@ class SFFCorrector(RegressionCorrector):
         The light curve that needs to be corrected.
     """
     def __init__(self, lc):
+        if getattr(lc, 'mission', '') == 'TESS':
+            warnings.warn("The SFF correction method is not designed for use "
+                          "with TESS light curves.",
+                          LightkurveWarning)
+
         self.raw_lc = lc
         if hasattr(lc, 'flux_unit'):
             if lc.flux_unit is None:
@@ -47,8 +52,7 @@ class SFFCorrector(RegressionCorrector):
             lc = lc.copy().normalize()
 
         # Setting these values as None so we don't get a value error if the
-        # user calls before "correct()"
-
+        # user tries to access them before "correct()"
         self.window_points = None
         self.windows = None
         self.bins = None

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -36,8 +36,9 @@ class SFFCorrector(RegressionCorrector):
     """
     def __init__(self, lc):
         if getattr(lc, 'mission', '') == 'TESS':
-            warnings.warn("The SFF correction method is not designed for use "
-                          "with TESS light curves.",
+            warnings.warn("The SFF correction method is not suitable for use "
+                          "with TESS data, because the spacecraft motion does "
+                          "not proceed along a consistent arc.",
                           LightkurveWarning)
 
         self.raw_lc = lc

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -3,7 +3,8 @@ import pytest
 import numpy as np
 from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_array_equal
-from ... import LightCurve, KeplerLightCurveFile, KeplerLightCurve
+from ... import LightCurve, KeplerLightCurveFile, KeplerLightCurve, \
+                TessLightCurve, LightkurveWarning
 from .. import SFFCorrector
 
 
@@ -166,3 +167,10 @@ def test_sff_breakindex():
                  centroid_col=np.random.randn(20),
                  centroid_row=np.random.randn(20), windows=1)
     assert_array_equal(corr.window_points, np.asarray([5, 10]))
+
+
+def test_sff_tess_warning():
+    """SFF is not designed for TESS, so we raise a warning."""
+    lc = TessLightCurve(flux=[1, 2, 3])
+    with pytest.warns(LightkurveWarning, match='not designed for'):
+        corr = SFFCorrector(lc)

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -172,5 +172,5 @@ def test_sff_breakindex():
 def test_sff_tess_warning():
     """SFF is not designed for TESS, so we raise a warning."""
     lc = TessLightCurve(flux=[1, 2, 3])
-    with pytest.warns(LightkurveWarning, match='not designed for'):
+    with pytest.warns(LightkurveWarning, match='not suitable'):
         corr = SFFCorrector(lc)


### PR DESCRIPTION
This PR adds a warning when `SFFCorrector` is used to correct a TESS light curve.  This addresses #660.

I'd like to improve the warning message slightly.  @christinahedges can you make a suggestion?
 