### PR TITLE
Prevent `interact()` from crashing when a TPF contains NaN fluxes (fixes #679)

### DIFF
--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -14,14 +14,17 @@ visualization widget showing the pixel data and a lightcurve::
 Note that this will only work inside a Jupyter notebook at this time.
 """
 from __future__ import division, print_function
+import os
 import logging
 import warnings
+
 import numpy as np
-from astropy.stats import sigma_clip
-from .utils import KeplerQualityFlags, LightkurveWarning
-import os
-from astropy.coordinates import SkyCoord, Angle
 import astropy.units as u
+from astropy.coordinates import SkyCoord, Angle
+from astropy.stats import sigma_clip
+from astropy.utils.exceptions import AstropyUserWarning
+
+from .utils import KeplerQualityFlags, LightkurveWarning
 
 log = logging.getLogger(__name__)
 
@@ -121,7 +124,9 @@ def get_lightcurve_y_limits(lc_source):
     ymin, ymax : float, float
         Flux min and max limits.
     """
-    flux = sigma_clip(lc_source.data['flux'], sigma=5)
+    with warnings.catch_warnings():  # Ignore warnings due to NaNs
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        flux = sigma_clip(lc_source.data['flux'], sigma=5, masked=False)
     low, high = np.nanpercentile(flux, (1, 99))
     margin = 0.10 * (high - low)
     return low - margin, high + margin

--- a/lightkurve/tests/test_interact.py
+++ b/lightkurve/tests/test_interact.py
@@ -1,11 +1,16 @@
 """Tests the features of the lightkurve.interact module."""
-from astropy.utils.data import get_pkg_data_filename
-import pytest
 import warnings
+
+from astropy.utils.data import get_pkg_data_filename
+from bokeh.plotting import ColumnDataSource
+import numpy as np
+import pytest
 
 from .. import LightkurveWarning
 from ..targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
 from .test_targetpixelfile import TABBY_TPF
+from ..interact import get_lightcurve_y_limits
+
 
 bad_optional_imports = False
 try:
@@ -148,3 +153,12 @@ def test_interact_sky_functions():
     fig1, slider1 = make_tpf_figure_elements(tpf, tpf_source)
     add_gaia_figure_elements(tpf, fig1)
     add_gaia_figure_elements(tpf, fig1, magnitude_limit=22)
+
+
+def test_ylim_with_nans():
+    """Regression test for #679: y limits should not be NaN."""
+    lc_source = ColumnDataSource({'flux': [-1, np.nan, 1]})
+    ymin, ymax = get_lightcurve_y_limits(lc_source)
+    # ymin/ymax used to return nan, make sure this is no longer the case
+    assert ymin == -1.176
+    assert ymax == 1.176

--- a/lightkurve/tests/test_interact.py
+++ b/lightkurve/tests/test_interact.py
@@ -2,7 +2,6 @@
 import warnings
 
 from astropy.utils.data import get_pkg_data_filename
-from bokeh.plotting import ColumnDataSource
 import numpy as np
 import pytest
 
@@ -15,6 +14,7 @@ from ..interact import get_lightcurve_y_limits
 bad_optional_imports = False
 try:
     import bokeh
+    from bokeh.plotting import ColumnDataSource
 except ImportError:
     bad_optional_imports = True
 
@@ -155,6 +155,7 @@ def test_interact_sky_functions():
     add_gaia_figure_elements(tpf, fig1, magnitude_limit=22)
 
 
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_ylim_with_nans():
     """Regression test for #679: y limits should not be NaN."""
     lc_source = ColumnDataSource({'flux': [-1, np.nan, 1]})


### PR DESCRIPTION
This PR should fix #679.