### PR TITLE
Add a `tpf.to_gif()` method to create animated gifs of pixel data

### DIFF
--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -555,3 +555,16 @@ def test_aperture_photometry_nan():
     assert ~np.isnan(lc.flux_err[1])
     assert np.isnan(lc.flux[2])
     assert np.isnan(lc.flux_err[2])
+
+
+def test_to_gif():
+    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
+                TessTargetPixelFile(filename_tess)]:
+        # `delete=False` is necessary to enable writing to the file on Windows
+        # but it means we have to clean up the tmp file ourselves
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".gif")
+        try:
+            tpf.to_gif(tmp.name, frames=[1, 2, 3], vmin=20)
+        finally:
+            tmp.close()
+            os.remove(tmp.name)

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -389,7 +389,7 @@ def btjd_to_astropy_time(btjd, bjdref=2457000.):
 def plot_image(image, ax=None, scale='linear', origin='lower',
                xlabel='Pixel Column Number', ylabel='Pixel Row Number',
                clabel='Flux ($e^{-}s^{-1}$)', title=None, show_colorbar=True,
-               **kwargs):
+               vmin=None, vmax=None, **kwargs):
     """Utility function to plot a 2D image
 
     Parameters
@@ -414,6 +414,10 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
         Title for the plot.
     show_colorbar : bool
         Whether or not to show the colorbar
+    vmin : float
+        Minimum pixel stretch. Defaults to a 95%-percentile stretch.
+    vmax : float
+        Maximum pixel stretch. Defaults to a 95%-percentile stretch.
     kwargs : dict
         Keyword arguments to be passed to `matplotlib.pyplot.imshow`.
 
@@ -424,13 +428,20 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
     """
     if ax is None:
         _, ax = plt.subplots()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)  # ignore image NaN values
-        mask = np.nan_to_num(image) > 0
-        if mask.any() > 0:
-            vmin, vmax = PercentileInterval(95.).get_limits(image[mask])
-        else:
-            vmin, vmax = 0, 0
+
+    # Set vmin/vmax defaults
+    if vmin is None or vmax is None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)  # ignore image NaN values
+            mask = np.nan_to_num(image) > 0
+            if mask.any() > 0:
+                vmin_tmp, vmax_tmp = PercentileInterval(95.).get_limits(image[mask])
+            else:
+                vmin_tmp, vmax_tmp = 0, 0
+            if vmin is None:
+                vmin = vmin_tmp
+            if vmax is None:
+                vmax = vmax_tmp
 
     norm = None
     if scale is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 uncertainties
 patsy>=0.5.1
 fbpca>=1.0
+gif>=1.0.2


### PR DESCRIPTION
I drafted `tpf.to_gif()` method while at the TESS Ninja 3 meeting, because making movies of TPF data seems to be a common use case.

### Example
```python
import lightkurve as lk
tpf = lk.search_tesscut("Horsehead Nebula").download(cutout_size=(41, 41))
tpf[100:150:10].to_gif("horsehead.gif")
```

### Output
![horsehead](https://user-images.githubusercontent.com/817669/74294986-c93d7200-4d93-11ea-8df4-1b830e5db282.gif)


Any comments/concerns?  Unfortunately I haven't been able to figure out how to display the gif in a notebook right away :-(