### PR TITLE
Add unit test: can files be opened from cache on Windows?

### DIFF
--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -309,3 +309,6 @@ def test_windows_cache_bug():
     lcf1 = search.download()
     lcf2 = search.download()
     assert "cache" in lcf2.path
+    import platform
+    if platform.system() == 'Windows':
+        assert "fail" == lcf2.path

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -300,3 +300,12 @@ def test_indexerror_631():
     # This previously triggered an exception:
     result = search_lightcurvefile("KIC 8462852", sector=15)
     assert len(result) == 1
+
+
+@pytest.mark.remote_data
+def test_windows_cache_bug():
+    """Does opening a file from the cache work on Windows?"""
+    search = search_lightcurvefile('010848459', quarter=4)
+    lcf1 = search.download()
+    lcf2 = search.download()
+    assert "cache" in lcf2.path


### PR DESCRIPTION
Via e-mail, a user reported encountering a `FileNotFoundError` when downloading a file from cache in Windows.  This test test attempts to reproduce the problem.