### PR TITLE
Bugfix: Tesscut caching mechanism can return the wrong sector

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -364,7 +364,7 @@ class SearchResult(object):
         # build path string name and check if it exists
         # this is necessary to ensure cutouts are not downloaded multiple times
         sec = TesscutClass().get_sectors(coords)
-        sector_name = sec[sec['sector'] == 1]['sectorName'][0]
+        sector_name = sec[sec['sector'] == sector]['sectorName'][0]
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + 'x' + str(int(cutout_size))
         elif isinstance(cutout_size, tuple) or isinstance(cutout_size, list):

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -111,13 +111,13 @@ def test_search_tesscut_download(caplog):
         ra, dec = 30.578761, -83.210593
         search_string = search_tesscut('{}, {}'.format(ra, dec), sector=[1, 12])
         # Make sure they can be downloaded with default size
-        tpf = search_string[0].download()
-        # Ensure the correct object has been read in
+        tpf = search_string[1].download()
+        # Ensure the correct object has been returned
         assert(isinstance(tpf, TessTargetPixelFile))
         # Ensure default size is 5x5
         assert(tpf.flux[0].shape == (5, 5))
-        # Ensure the tpf has a targetid (#473 regression test)
-        assert(len(tpf.targetid) > 0)
+        assert(len(tpf.targetid) > 0)  # Regression test #473
+        assert(tpf.sector == 12)  # Regression test #696
         # Ensure the WCS is valid (#434 regression test)
         center_ra, center_dec = tpf.wcs.all_pix2world([[2.5, 2.5]], 1)[0]
         assert_almost_equal(ra, center_ra, decimal=1)
@@ -126,6 +126,8 @@ def test_search_tesscut_download(caplog):
         tpfc = search_string.download_all(cutout_size=4, quality_bitmask='hard')
         assert(isinstance(tpfc, TargetPixelFileCollection))
         assert(tpfc[0].quality_bitmask == 'hard')  # Regression test for #494
+        assert(tpfc[0].sector == 1)  # Regression test #696
+        assert(tpfc[1].sector == 12) # Regression test #696
         # Ensure correct dimensions
         assert(tpfc[0].flux[0].shape == (4, 4))
         # Download with rectangular dimennsions?


### PR DESCRIPTION
The TessCut caching mechanism introduced via #481 contained a bug.  If a sector 1 cut-out was available in the cache, it would always return the sector 1 cut-out rather than the desired sector. 

This is because the following line:

https://github.com/KeplerGO/lightkurve/blob/cdf6acea8be68413d91df5a1064fc40771b1aeed/lightkurve/search.py#L367

should have said `sec['sector'] == sector` instead of `sec['sector'] == 1`.

This bug only affected master.  This feature was not part of the most recent release yet (v1.8.0), so no harm done!  This PR fixes the bug and adds a regression test.