### PR TITLE
`lc.bin()` fails if `lc.quality` is not an integer array (fixes #705)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.9.1 (unreleased)
+==================
+
+- Fixed a bug in `LightCurve.bin()` which caused the method to fail if the
+  ``quality`` array has a floating point data type. [#705]
+
+
+
 1.9.0 (2020-02-25)
 ==================
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -779,7 +779,7 @@ class LightCurve(object):
         nlc.flux_err = fe
 
         if hasattr(lc, 'quality'):
-            quality = np.zeros(len(ntime))
+            quality = np.zeros(len(ntime), dtype=lc.quality.dtype)
             quality[in_original] = np.copy(lc.quality)
             quality[~in_original] += 65536
             nlc.quality = quality
@@ -951,7 +951,8 @@ class LightCurve(object):
         # Define and map the functions to be applied to each bin
         method_func = np.__dict__['nan' + method]
         quality_func = lambda x: np.bitwise_or.reduce(x) \
-                                 if np.all(np.isfinite(x)) else np.nan
+                                 if np.issubdtype(x.dtype, np.integer) and np.all(np.isfinite(x)) \
+                                 else np.nan
         centroid_func = lambda x: method_func(x) \
                                   if np.any(np.isfinite(x)) else np.nan
         # Assume the errors combine as the root-mean-square

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -986,3 +986,9 @@ def test_river():
     with pytest.warns(LightkurveWarning, match='`bin_points` is too high to plot'):
         folded_lc.plot_river(method='median', bin_points=6)
         plt.close()
+
+
+def test_bin_issue705():
+    """Regression test for #705: binning failed."""
+    lc = TessLightCurve(time=np.arange(50), flux=np.ones(50), quality=np.zeros(50))
+    lc.bin(binsize=15)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 astropy>=1.3
-scipy>=0.19.0
+scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
 astroquery>=0.3.9
 oktopus


### PR DESCRIPTION
This PR fixes the bug described over in #705.