### PR TITLE
Speed up TESS data product searches by a factor 10x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.9.1 (unreleased)
 ==================
 
+- Increased the speed of ``search_lightcurvefile()`` and
+  ``search_targetpixelfile()`` by a factor ~10. [#715]
+
 - Fixed a bug in `LightCurve.bin()` which caused the method to fail if the
   ``quality`` array has a floating point data type. [#705]
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -610,7 +610,7 @@ def search_tesscut(target, sector=None):
 
 def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
                      mission=('Kepler', 'K2', 'TESS'), quarter=None, month=None,
-                     campaign=None, sector=None, limit=None):
+                     campaign=None, sector=None, limit=None, **extra_query_criteria):
     """Helper function which returns a SearchResult object containing MAST
     products that match several criteria.
 
@@ -652,7 +652,11 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
                         "Please add the prefix 'EPIC' or 'TIC' to disambiguate."
                         "".format(target))
 
-    observations = _query_mast(target, project=mission, radius=radius)
+    # Speed up by restricting the MAST query
+    extra_query_criteria = {}
+    if filetype == 'Lightcurve':
+        extra_query_criteria['dataproduct_type'] = 'timeseries'
+    observations = _query_mast(target, project=mission, radius=radius, **extra_query_criteria)
     log.debug("MAST found {} observations. "
               "Now querying MAST for the corresponding data products."
               "".format(len(observations)))
@@ -702,7 +706,7 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
         return SearchResult(masked_result)
 
 
-def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS')):
+def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS'), **extra_query_criteria):
     """Helper function which wraps `astroquery.mast.Observations.query_criteria()`
     to returns a table of all Kepler or K2 observations of a given target.
 
@@ -755,7 +759,8 @@ def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS')):
             target_obs = Observations.query_criteria(target_name=target_name,
                                                      radius=str(radius.to(u.deg)),
                                                      project=project,
-                                                     obs_collection=project)
+                                                     obs_collection=project,
+                                                     **extra_query_criteria)
 
         if len(target_obs) == 0:
             raise ValueError("No observations found for '{}'.".format(target_name))
@@ -779,7 +784,8 @@ def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS')):
                 obs = Observations.query_criteria(coordinates='{} {}'.format(ra, dec),
                                                   radius=str(radius.to(u.deg)),
                                                   project=project,
-                                                  obs_collection=project)
+                                                  obs_collection=project,
+                                                  **extra_query_criteria)
             obs.sort('distance')
         return obs
     except ValueError:
@@ -799,7 +805,8 @@ def _query_mast(target, radius=None, project=('Kepler', 'K2', 'TESS')):
             obs = Observations.query_criteria(objectname=target,
                                               radius=str(radius.to(u.deg)),
                                               project=project,
-                                              obs_collection=project)
+                                              obs_collection=project,
+                                              **extra_query_criteria)
         obs.sort('distance')
         return obs
     except ResolverError as exc:

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -652,10 +652,12 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
                         "Please add the prefix 'EPIC' or 'TIC' to disambiguate."
                         "".format(target))
 
-    # Speed up by restricting the MAST query
+    # Speed up by restricting the MAST query if we don't want FFI image data
     extra_query_criteria = {}
-    if filetype == 'Lightcurve':
-        extra_query_criteria['dataproduct_type'] = 'timeseries'
+    if filetype in ['Lightcurve', 'Target Pixel']:
+        # At MAST, non-FFI Kepler pipeline products are known as "cube" products,
+        # and non-FFI TESS pipeline products are listed as "timeseries".
+        extra_query_criteria['dataproduct_type'] = ['cube', 'timeseries']
     observations = _query_mast(target, project=mission, radius=radius, **extra_query_criteria)
     log.debug("MAST found {} observations. "
               "Now querying MAST for the corresponding data products."


### PR DESCRIPTION
**Issue**: one of our beloved users (@dfm) pointed out to me that searches for TESS light curve and target pixel files have become incredibly slow.

**Cause**: a huge number of TESS FFIs records now exist in the MAST Portal database. Whenever someone calls `search_lightcurvefile` or `search_targetpixelfile`, Lightkurve unnecessarily downloads all the FFI records for the requested target before filtering them out locally.

**Solution**: we need to make sure we specify `dataproduct_type=['cube', 'timeseries']` as a parameter in our calls to `astroquery.mast.Observations.query_criteria()`. This prevents FFI records from being returned (they have `dataproduct_type='image'`).

This PR makes this change.  The speed up is pretty incredible.  For example, `search_lightcurvefile("Pi Men")` now takes 2 seconds instead of 2 minutes.

### Before:

![Screenshot from 2020-03-24 14-32-34](https://user-images.githubusercontent.com/817669/77480473-03605180-6ddf-11ea-84f3-2ecc0c9f75d4.png)

### After:

![Screenshot from 2020-03-24 14-36-20](https://user-images.githubusercontent.com/817669/77480467-ff343400-6dde-11ea-8d61-6ee4e481c27f.png)

