### PR TITLE
Create .gitattributes to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/* linguist-documentation


### PR DESCRIPTION
This is a Python project, not a Jupyter notebook project! GitHub shouldn't be counting the docs directory as the majority of the code.