### PR TITLE
[WIP] Added support for scipy.sparse in DesignMatrix and RegressionCorrector to speed up regression on large, sparse matrices

### DIFF
--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -537,7 +537,7 @@ def create_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline',
 
 @jit(nopython=True)
 def basis(x, degree, i, knots):
-    """Create a spline basis for an input x, for the ith knot
+    """Create a spline basis vector for an input x, for the ith knot.
 
     Parameters
     ----------
@@ -549,6 +549,11 @@ def basis(x, degree, i, knots):
         The index of the knot to calculate the basis for
     knots : np.ndarray
         Array of all knots
+
+    Returns
+    -------
+    B : np.ndarray
+        A vector of same length as x containing the spline basis for the ith knot
     """
     if degree == 0:
         B = np.zeros(len(x))
@@ -597,7 +602,6 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
     # To use jit we have to use float64
     x = np.asarray(x, np.float64)
 
-
     if not isinstance(n_knots, int):
         raise ValueError('`n_knots` must be an integer.')
     if n_knots - degree <= 0:
@@ -614,6 +618,3 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
     matrices = [csr_matrix(basis(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)]
     spline_dm = vstack([m for m in matrices if (m.sum() != 0) ], format='csr').T
     return DesignMatrix(spline_dm, name=name)
-    # df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
-    #                                       for idx in range(n_knots)])
-    # return DesignMatrix(df, name=name, sparse=sparse)

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -8,7 +8,8 @@ import warnings
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.sparse import lil_matrix, hstack, vstack
+from scipy.sparse import lil_matrix, csr_matrix, hstack, vstack, issparse, find
+from copy import deepcopy
 
 from .. import MPLSTYLE
 from ..utils import LightkurveWarning, plot_image
@@ -28,11 +29,11 @@ class DesignMatrix():
 
     Parameters
     ----------
-    df : dict, array, or `pandas.DataFrame` object
+    X : dict, array, or `pandas.DataFrame` object
         Columns to include in the design matrix.  If this object is not a
         `~pandas.DataFrame` then it will be passed to the DataFrame constructor.
     columns : iterable of str (optional)
-        Column names, if not already provided via ``df``.
+        Column names, if not already provided via ``X``.
     name : str
         Name of the matrix.
     prior_mu : array
@@ -42,23 +43,39 @@ class DesignMatrix():
         Prior standard deviations of the coefficients associated with each
         column in a linear regression problem.
     """
-    def __init__(self, df, columns=None, name='unnamed_matrix', prior_mu=None,
+    def __init__(self, X, columns=None, name='unnamed_matrix', prior_mu=None,
                  prior_sigma=None, sparse=False):
-        if not isinstance(df, pd.DataFrame):
-            df = pd.DataFrame(df)
-        if columns is not None:
-            df.columns = columns
-        self.df = df
+
         self.name = name
         self._sparse = sparse
-        if self._sparse:
-            self._sparse_values = lil_matrix(self.df.values)
+
+        if issparse(X):
+            # Build a sparse DM
+            self._sparse = True
+            self.X = X
+            self.columns = columns
+        else:
+            if not isinstance(X, pd.DataFrame):
+                X = pd.DataFrame(X)
+            if columns is not None:
+                if hasattr(X, 'columns'):
+                    X.columns = columns
+                else:
+                    self.columns = columns
+            else:
+                self.columns = columns
+            if self._sparse:
+                self.X = lil_matrix(np.asarray(X))
+            else:
+                self.X = X
+
         if prior_mu is None:
-            prior_mu = np.zeros(len(df.T))
+            prior_mu = np.zeros(X.shape[1])
         if prior_sigma is None:
-            prior_sigma = np.ones(len(df.T)) * np.inf
+            prior_sigma = np.ones(X.shape[1]) * np.inf
         self.prior_mu = prior_mu
         self.prior_sigma = prior_sigma
+
 
     def plot(self, ax=None, **kwargs):
         """Visualize the design matrix values as an image.
@@ -81,15 +98,14 @@ class DesignMatrix():
         """
         with plt.style.context(MPLSTYLE):
             values = self.values
-            if self._sparse:
-                values = values.toarray()
             ax = plot_image(values, ax=ax, xlabel='Component', ylabel='X',
                             clabel='Component Value', title=self.name, **kwargs)
             ax.set_aspect(self.shape[1]/(1.6*self.shape[0]))
             if self.shape[1] <= 40:
                 ax.set_xticks(np.arange(self.shape[1]))
-                ax.set_xticklabels([r'${}$'.format(i) for i in self.columns],
-                                   rotation=90, fontsize=8)
+                if self.columns is not None:
+                    ax.set_xticklabels([r'${}$'.format(i) for i in self.columns],
+                                       rotation=90, fontsize=8)
         return ax
 
     def plot_priors(self, ax=None):
@@ -125,7 +141,7 @@ class DesignMatrix():
         """Returns a random sample from the prior distribution."""
         return np.random.normal(self.prior_mu, self.prior_sigma)
 
-    def split(self, row_indices):
+    def split(self, row_indices, inplace=False):
         """Returns a new `.DesignMatrix` with regressors split into multiple
         columns.
 
@@ -145,24 +161,38 @@ class DesignMatrix():
         `.DesignMatrix`
             A new design matrix with shape (n_rows, len(row_indices)*n_columns).
         """
-        if isinstance(row_indices, int):
-            row_indices = [row_indices]
-        if (len(row_indices) == 0) or (row_indices == [0]) or (row_indices is None):
+        if not hasattr(row_indices, '__iter__'):
+            row_indices = list(row_indices)
+        if len(row_indices) == 0:
             return self
-        # Where do the submatrices begin and end?
-        lower_idx = np.append(0, row_indices)
-        upper_idx = np.append(row_indices, len(self.df))
-        dfs = []
-        for idx, a, b in zip(range(len(lower_idx)), lower_idx, upper_idx):
-            new_columns = dict(
-                ('{}'.format(val), '{}'.format(val) + ' {}'.format(idx + 1))
-                for val in list(self.df.columns))
-            dfs.append(self.df[a:b].rename(columns=new_columns))
-        new_df = pd.concat(dfs, axis=1).fillna(0)
-        prior_mu = np.hstack([self.prior_mu for idx in range(len(dfs))])
-        prior_sigma = np.hstack([self.prior_sigma for idx in range(len(dfs))])
-        return DesignMatrix(new_df, name=self.name, prior_mu=prior_mu,
-                            prior_sigma=prior_sigma, sparse=self._sparse)
+        if (row_indices == [0]) or (row_indices == [self.shape[0]]):
+            return self
+
+        if inplace:
+            dm = self
+        else:
+            dm = self.copy()
+
+        x = np.arange(dm.shape[0])
+        dm.prior_mu = np.concatenate([list(self.prior_mu) * (len(row_indices) + 1)])
+        dm.prior_sigma = np.concatenate([list(self.prior_sigma) * (len(row_indices) + 1)])
+        if isinstance(dm.X, pd.DataFrame):
+            dm.X = pd.concat([((dm.X * np.atleast_2d(np.in1d(x, idx).astype(int)).T)).add_suffix('_{}'.format(jdx)) for jdx, idx in enumerate(np.array_split(x, row_indices))], axis=1)
+            non_zero = dm.X.sum(axis=0) != 0
+            dm.X = dm.X[dm.X.columns[non_zero]]
+        if issparse(dm.X):
+            dm.X = hstack([dm.X.multiply(lil_matrix(np.in1d(x, idx).astype(int)).T) for idx in np.array_split(x, row_indices)], format='lil')
+            non_zero = dm.X.sum(axis=0) != 0
+            non_zero = np.asarray(non_zero).ravel()
+            dm.X = dm.X[:, non_zero]
+
+        dm.prior_mu = dm.prior_mu[non_zero]
+        dm.prior_sigma = dm.prior_sigma[non_zero]
+        return dm
+
+    def copy(self):
+        """Returns a deepcopy of DesignMatrix"""
+        return deepcopy(self)
 
     def standardize(self, inplace=False):
         """Returns a new `.DesignMatrix` in which the columns have been
@@ -185,20 +215,32 @@ class DesignMatrix():
         `.DesignMatrix`
             A new design matrix with median-subtracted & sigma-divided columns.
         """
-        df_nan = self.df.replace(0, np.nan)
-        mean = df_nan.mean()
-        std = df_nan.std()
-        mean[std == 0] = 0
-        std[std == 0] = 1
-        df = ((df_nan - mean) / std).fillna(0)
-        if 'offset' in df.columns:
-            df['offset'] = 1
+
         if inplace:
-            self.df = df
-            if self._sparse:
-                self._sparse_values = lil_matrix(self.df.values)
-            return self
-        return DesignMatrix(df, name=self.name, sparse=self._sparse)
+            dm = self
+        else:
+            dm = self.copy()
+
+        if isinstance(dm.X, pd.DataFrame):
+            df_nan = dm.X.replace(0, np.nan)
+            mean = df_nan.mean()
+            std = df_nan.std()
+            mean[std == 0] = 0
+            std[std == 0] = 1
+            dm.X = ((df_nan - mean) / std).fillna(0)
+
+        if issparse(dm.X):
+            idx, jdx, v = find(dm.X)
+            weights = dm.X.copy()
+            weights[dm.X != 0] = 1
+            mean = np.bincount(jdx, weights=v)/np.bincount(jdx)
+            std = np.asarray([((np.sum((v[jdx == i] - mean[i])**2) * (1/((jdx == i).sum() - 1))))**0.5 for i in np.unique(jdx)])
+            mean[std == 0] = 0
+            std[std == 0] = 1
+            white = (dm.X - vstack([lil_matrix(mean)] * dm.shape[0])).multiply(vstack([lil_matrix(1/std)] * dm.shape[0]))
+            dm.X = white.multiply(weights)
+        return dm
+
 
     def pca(self, nterms=6):
         """Returns a new `.DesignMatrix` with a smaller number of regressors.
@@ -224,10 +266,7 @@ class DesignMatrix():
         # we find this to be too few, and that n_iter=10 is still fast but
         # produces more stable results.
         from fbpca import pca  # local import because not used elsewhere
-        if self._sparse:
-            new_values, _, _ = pca(self.values.toarray(), nterms, n_iter=10)
-        else:
-            new_values, _, _ = pca(self.values, nterms, n_iter=10)
+        new_values, _, _ = pca(self.values, nterms, n_iter=10)
         return DesignMatrix(new_values, name=self.name, sparse=self._sparse)
 
     def append_constant(self, prior_mu=0, prior_sigma=np.inf, inplace=False):
@@ -243,11 +282,12 @@ class DesignMatrix():
             dm = self
         else:
             dm = self.copy()
-        dm.df.insert(self.df.shape[1], 'offset', 1, allow_duplicates=False)
-        dm.prior_mu = np.append(self.prior_mu, prior_mu)
-        dm.prior_sigma = np.append(self.prior_sigma, prior_sigma)
-        if self._sparse:
-            self._sparse_values = hstack([self.values, lil_matrix(np.ones(self.values.shape[0])).T], format='lil')
+        if isinstance(dm.X, pd.DataFrame):
+            dm.X.insert(dm.shape[1], 'offset', 1, allow_duplicates=False)
+        else:
+            dm.X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format='lil')
+        dm.prior_mu = np.append(dm.prior_mu, prior_mu)
+        dm.prior_sigma = np.append(dm.prior_sigma, prior_sigma)
         return dm
 
     def _validate(self):
@@ -265,29 +305,22 @@ class DesignMatrix():
     @property
     def rank(self):
         """Matrix rank computed using `numpy.linalg.matrix_rank`."""
-        if self._sparse:
-                return np.linalg.matrix_rank(self.values.toarray())
         return np.linalg.matrix_rank(self.values)
-
-    @property
-    def columns(self):
-        """List of column names."""
-        return list(self.df.columns)
 
     @property
     def shape(self):
         """Tuple specifying the shape of the matrix as (n_rows, n_columns)."""
-        return self.df.shape
+        return self.X.shape
 
     @property
     def values(self):
         """2D numpy array containing the matrix values."""
-        if self._sparse:
-            return self._sparse_values
-        return self.df.values
+        if issparse(self.X):
+            return self.X.toarray()
+        return self.X.values
 
-    def __getitem__(self, key):
-        return self.df[key]
+    # def __getitem__(self, key):
+    #     return self.df[key]
 
     def __repr__(self):
         if self._sparse:
@@ -300,18 +333,22 @@ class DesignMatrixCollection():
     def __init__(self, matrices):
         if np.all([m._sparse for m in matrices]):
             self._sparse = True
-            self._sparse_values = hstack([m.values for m in matrices], format='lil')
+#            self._sparse_values = hstack([m.values for m in matrices], format='lil')
         else:
             self._sparse = False
-
         self.matrices = matrices
 
     @property
     def values(self):
         """2D numpy array containing the matrix values."""
-        if self._sparse:
-            return self._sparse_values
+#       if self._sparse:
+#            return self._sparse_values
         return np.hstack(tuple(m.values if isinstance(m.values, np.ndarray) else m.values.toarray() for m in self.matrices))
+
+
+    def X(self):
+        """Stack of X as either np.array or sparse array"""
+        return None
 
     @property
     def prior_mu(self):

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -346,19 +346,15 @@ class DesignMatrixCollection():
         else:
             self._sparse = False
         self.matrices = matrices
+        if self._sparse:
+             self.X = hstack([m.X for m in matrices], format='csr')
+        else:
+             self.X = np.hstack([m.X for m in matrices])
 
     @property
     def values(self):
         """2D numpy array containing the matrix values."""
         return np.hstack(tuple(m.values for m in self.matrices))
-
-    @property
-    def X(self):
-        """Stack of X as either np.array or sparse array"""
-        if self._sparse:
-             return hstack([m.X for m in self.matrices], format='csr')
-        else:
-             return np.hstack([m.X for m in self.matrices])
 
     @property
     def df(self):
@@ -577,7 +573,8 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
             B = alpha1 * basis(x, (degree-1), i, knots) + alpha2 * basis(x, (degree-1), (i+1), knots)
         return B
 
-    spline_dm = vstack([lil_matrix(basis(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)], format='lil').T
+    matrices = [lil_matrix(basis(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)]
+    spline_dm = vstack([m for m in matrices], format='lil').T
     return DesignMatrix(spline_dm, name=name)
     # df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
     #                                       for idx in range(n_knots)])

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -590,10 +590,10 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
     if (knots is None)  and (n_knots is not None):
         knots = np.asarray([s[-1] for s in np.array_split(np.argsort(x), n_knots - degree)[:-1]])
         knots = [np.mean([x[k], x[k + 1]]) for k in knots]
-        knots = np.append(np.append(x.min(), knots), x.max())
-#        knots = np.linspace(x.min(), x.max(), n_knots - 2)
     elif (knots is None)  and (n_knots is None):
         raise ValueError('Pass either `n_knots` or `knots`.')
+    knots = np.append(np.append(x.min(), knots), x.max())
+    knots = np.unique(knots)
     knots_wbounds = np.append(np.append([x.min()] * (degree - 1), knots), [x.max()] * (degree))
 
     matrices = [csr_matrix(basis(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)]

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -585,11 +585,12 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
 
     if not isinstance(n_knots, int):
         raise ValueError('`n_knots` must be an integer.')
-
+    if n_knots - degree <= 0:
+        raise ValueError('n_knots must be greater than degree.')
     if (knots is None)  and (n_knots is not None):
-        knots = np.asarray([s[-1] for s in np.array_split(np.argsort(x), n_knots)[1:-1]])
+        knots = np.asarray([s[-1] for s in np.array_split(np.argsort(x), n_knots - degree)[:-1]])
         knots = [np.mean([x[k], x[k + 1]]) for k in knots]
-
+        knots = np.append(np.append(x.min(), knots), x.max())
 #        knots = np.linspace(x.min(), x.max(), n_knots - 2)
     elif (knots is None)  and (n_knots is None):
         raise ValueError('Pass either `n_knots` or `knots`.')

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -295,11 +295,13 @@ class DesignMatrix():
             dm = self
         else:
             dm = self.copy()
-        if isinstance(dm.X, pd.DataFrame):
+        if issparse(dm.X):
+            dm.X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format='lil')
+        elif isinstance(dm.df, pd.DataFrame):
             dm.df.insert(dm.shape[1], 'offset', 1, allow_duplicates=False)
             dm.X = dm.df.values
         else:
-            dm.X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format='lil')
+            raise NotImplementedError("Need to implement for numpy only")
         dm.prior_mu = np.append(dm.prior_mu, prior_mu)
         dm.prior_sigma = np.append(dm.prior_sigma, prior_sigma)
         return dm

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -236,10 +236,7 @@ class RegressionCorrector(Corrector):
                                        prior_sigma=self.design_matrix_collection.prior_sigma,
                                        propagate_errors=propagate_errors)
 
-            if self.design_matrix_collection._sparse:
-                model_flux = self.X.dot(coefficients)
-            else:
-                model_flux = (self.X.values).dot(coefficients)
+            model_flux = self.X.dot(coefficients)
             model = np.ma.masked_array(data=np.copy(model_flux),
                                        mask=~(cadence_mask & clean_cadences))
             residuals = self.lc.flux - model
@@ -255,14 +252,9 @@ class RegressionCorrector(Corrector):
             with warnings.catch_warnings():
                 # ignore "RuntimeWarning: covariance is not symmetric positive-semidefinite."
                 warnings.simplefilter("ignore", RuntimeWarning)
-                if self.design_matrix_collection._sparse:
-                    samples = np.asarray(
-                        [self.X.dot(np.random.multivariate_normal(coefficients, coefficients_err))
-                         for idx in range(100)]).T
-                else:
-                    samples = np.asarray(
-                        [self.X.values.dot(np.random.multivariate_normal(coefficients, coefficients_err))
-                         for idx in range(100)]).T
+                samples = np.asarray(
+                    [self.X.dot(np.random.multivariate_normal(coefficients, coefficients_err))
+                     for idx in range(100)]).T
             model_err = np.abs(np.percentile(samples, [16, 84], axis=1) - np.median(samples, axis=1)[:, None].T).mean(axis=0)
         else:
             model_err = np.zeros(len(model_flux))
@@ -290,7 +282,7 @@ class RegressionCorrector(Corrector):
             # submatrix_coefficients_err = self.coefficients_err[firstcol_idx:firstcol_idx+submatrix.shape[1], firstcol_idx:firstcol_idx+submatrix.shape[1]]
             # samples = np.asarray([np.dot(submatrix.values, np.random.multivariate_normal(submatrix_coefficients, submatrix_coefficients_err)) for idx in range(100)]).T
             # model_err = np.abs(np.percentile(samples, [16, 84], axis=1) - np.median(samples, axis=1)[:, None].T).mean(axis=0)
-            model_flux = submatrix.values.dot(submatrix_coefficients)
+            model_flux = submatrix.X.dot(submatrix_coefficients)
             lcs[submatrix.name] = LightCurve(self.lc.time, model_flux, np.zeros(len(model_flux)), label=submatrix.name)
         return lcs
 

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -13,7 +13,7 @@ from astropy.modeling import models, fitting
 
 from . import DesignMatrix, DesignMatrixCollection
 from .regressioncorrector import RegressionCorrector
-from .designmatrix import create_spline_matrix
+from .designmatrix import create_spline_matrix, create_sparse_spline_matrix
 
 from .. import MPLSTYLE
 from ..utils import LightkurveWarning
@@ -170,12 +170,13 @@ class SFFCorrector(RegressionCorrector):
 
         # long term
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
-        s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, include_intercept=True, sparse=sparse)
 
         if sparse:
-            means = [np.average(self.lc.flux, weights=s_dm.values[:, idx].toarray()[:, 0]) for idx in range(s_dm.shape[1])]
+            s_dm = create_sparse_spline_matrix(self.lc.time, n_knots=n_knots)
         else:
-            means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
+            s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots)
+
+        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
         s_dm.prior_mu = np.asarray(means)
 
         # I'm putting WEAK priors on the spline that it must be around 1

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -176,7 +176,7 @@ class SFFCorrector(RegressionCorrector):
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
 
         if sparse:
-            s_dm = create_sparse_spline_matrix(self.lc.time, n_knots=n_knots, name='sff').append_constant()
+            s_dm = create_sparse_spline_matrix(self.lc.time, n_knots=n_knots, name='sff')
         else:
             s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, name='sff')
 
@@ -197,8 +197,6 @@ class SFFCorrector(RegressionCorrector):
         else:
             dm = DesignMatrixCollection([s_dm, sff_dm])
 
-        print(dm)
-        dm.plot()
         # correct
         clc = super(SFFCorrector, self).correct(dm, **kwargs)
 

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -150,8 +150,8 @@ class SFFCorrector(RegressionCorrector):
 
         dms = []
         for idx, a, b in zip(range(len(lower_idx)), lower_idx, upper_idx):
-            knots = list(np.percentile(self.arclength[a:b], np.linspace(0, 100, bins+1)[1:-1]))
             ar = np.copy(self.arclength)
+            knots = list(np.percentile(ar[a:b], np.linspace(0, 100, bins+1)[1:-1]))
             ar[~np.in1d(ar, ar[a:b])] = 0
             #import pdb; pdb.set_trace()
             if sparse:
@@ -170,7 +170,7 @@ class SFFCorrector(RegressionCorrector):
             dm.prior_sigmas = ps
             dms.append(dm)
 
-        sff_dm = DesignMatrixCollection(dms).flatten().standardize()
+        sff_dm = DesignMatrixCollection(dms).flatten()#.standardize()
 
         # long term
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
@@ -180,8 +180,8 @@ class SFFCorrector(RegressionCorrector):
         else:
             s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, name='sff')
 
-        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
-        s_dm.prior_mu = np.asarray(means)
+#        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
+#        s_dm.prior_mu = np.asarray(means)
 
         # I'm putting WEAK priors on the spline that it must be around 1
         s_dm.prior_sigma = np.ones(len(s_dm.prior_mu)) * 1000 * self.lc.flux.std() + 1e-6
@@ -197,6 +197,8 @@ class SFFCorrector(RegressionCorrector):
         else:
             dm = DesignMatrixCollection([s_dm, sff_dm])
 
+        print(dm)
+        dm.plot()
         # correct
         clc = super(SFFCorrector, self).correct(dm, **kwargs)
 

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -167,25 +167,24 @@ class SFFCorrector(RegressionCorrector):
             # I'm putting VERY weak priors on the SFF motion vectors
             # (1e-6 is being added to prevent sigma from being zero)
             ps = np.ones(dm.shape[1]) * 10000 * self.lc[a:b].flux.std() + 1e-6
-            dm.prior_sigmas = ps
+            dm.prior_sigma = ps
             dms.append(dm)
 
-        sff_dm = DesignMatrixCollection(dms).flatten()#.standardize()
+        sff_dm = DesignMatrixCollection(dms).flatten(name='sff')#.standardize()
 
         # long term
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
 
         if sparse:
-            s_dm = create_sparse_spline_matrix(self.lc.time, n_knots=n_knots, name='sff')
+            s_dm = create_sparse_spline_matrix(self.lc.time, n_knots=n_knots, name='spline')
         else:
-            s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, name='sff')
+            s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, name='spline')
 
-#        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
-#        s_dm.prior_mu = np.asarray(means)
+        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
+        s_dm.prior_mu = np.asarray(means)
 
         # I'm putting WEAK priors on the spline that it must be around 1
         s_dm.prior_sigma = np.ones(len(s_dm.prior_mu)) * 1000 * self.lc.flux.std() + 1e-6
-
         # additional
         if additional_design_matrix is not None:
             if not isinstance(additional_design_matrix, DesignMatrix):

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -144,10 +144,6 @@ class SFFCorrector(RegressionCorrector):
         lower_idx = np.asarray(np.append(0, self.window_points), int)
         upper_idx = np.asarray(np.append(self.window_points, len(self.lc.time)), int)
 
-        #stack = []
-        #columns = []
-        #prior_sigmas = []
-
         dms = []
         for idx, a, b in zip(range(len(lower_idx)), lower_idx, upper_idx):
             ar = np.copy(self.arclength)
@@ -158,9 +154,6 @@ class SFFCorrector(RegressionCorrector):
                 dm = create_sparse_spline_matrix(ar, knots=knots, degree=degree).copy()
             else:
                 dm = create_spline_matrix(ar, knots=knots, degree=degree).copy()
-#            dm = np.asarray(dmatrix("bs(x, knots={}, degree={}, include_intercept={}) - 1"
-#                                    "".format(knots, degree, True), {"x": ar}))
-#            stack.append(dm)
             dm.columns = ['window{}_bin{}'.format(idx+1, jdx+1)
                                         for jdx in range(dm.shape[1])]
 

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from .. import DesignMatrix, DesignMatrixCollection
 from ... import LightkurveWarning
-
+from ..designmatrix import create_sparse_spline_matrix, create_spline_matrix
 
 def test_designmatrix_basics():
     """Can we create a design matrix from a dataframe?"""
@@ -155,3 +155,12 @@ def test_designmatrix_rank():
     assert dm.rank == 2
     with pytest.warns(LightkurveWarning, match='rank'):
         dm._validate()
+
+
+def test_splines():
+    """Do splines work as expected?"""
+    # Dense and sparse splines should produce the same answer.
+    x = np.linspace(0, 1, 100)
+    spline_dense = create_sparse_spline_matrix(x, knots=[0.1, 0.3, 0.6, 0.9], degree=2)
+    spline_sparse =create_spline_matrix(x, knots=[0.1, 0.3, 0.6, 0.9], degree=2)
+    assert np.allclose(spline_dense.values, spline_sparse.values)

--- a/lightkurve/correctors/tests/test_regressioncorrector.py
+++ b/lightkurve/correctors/tests/test_regressioncorrector.py
@@ -81,6 +81,42 @@ def test_sinusoid_noise():
     assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
 
+
+def test_sinusoid_noise_sparse():
+    """Can we remove simple sinusoid noise added to a flat light curve when using sparse?"""
+    size = 100
+    time = np.linspace(1, 100, size)
+    true_flux = np.ones(size)
+    noise = np.sin(time/5)
+    # True light curve is flat, i.e. flux=1 at all time steps
+    true_lc = LightCurve(time, true_flux, flux_err=0.1*np.ones(size))
+    # Noisy light curve has a sinusoid single added
+    noisy_lc = LightCurve(time, true_flux+noise, flux_err=true_lc.flux_err)
+    dm = DesignMatrix({'noise': noise,
+                       'offset': np.ones(len(time))},
+                      name='noise_model', sparse=True)
+
+    # Can we recover the true light curve?
+    rc = RegressionCorrector(noisy_lc)
+    corrected_lc = rc.correct(dm)
+    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+
+    # Can we produce the diagnostic plot?
+    rc.diagnose()
+
+    # Does it work when we set priors?
+    dm.prior_mu = [0.1, 0.1]
+    dm.prior_sigma = [1e6, 1e6]
+    corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
+    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+
+    # Does it work when `flux_err` isn't available?
+    noisy_lc = LightCurve(time=time, flux=true_flux+noise)
+    corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
+    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+
+
+
 def test_nan_input():
     # The following light curves should all raise ValueErrors because of NaNs
     with warnings.catch_warnings():

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -23,6 +23,10 @@ def test_remote_data(path):
     sff = SFFCorrector(lcf.PDCSAP_FLUX.remove_nans())
     sff.correct(windows=10, bins=5, timescale=0.5)
 
+    lcf = KeplerLightCurveFile(path, quality_bitmask=None)
+    sff = SFFCorrector(lcf.PDCSAP_FLUX.remove_nans())
+    sff.correct(windows=10, bins=5, timescale=0.5, sparse=True)
+
 
 def test_sff_knots():
     """Is SFF robust against gaps in time and irregular time sampling?

--- a/lightkurve/correctors/tests/test_tesspldcorrector.py
+++ b/lightkurve/correctors/tests/test_tesspldcorrector.py
@@ -16,3 +16,4 @@ def test_basics():
     corrector = TessPLDCorrector(tpf)
     corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1)
     corrector.diagnose()
+    corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1, sparse=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 uncertainties
 patsy>=0.5.1
 fbpca>=1.0
+numba>=0.39.0


### PR DESCRIPTION
`scipy.sparse` provides a great tool for doing matrix maths on very sparse matrices, which for very large/sparse matrices can speed up the following lines from `RegressionCorrector`:

```python
sigma_w_inv = X.T.dot(X/flux_err[:, None]**2)
B = X.T.dot(flux/flux_err**2)
```

(For a full Kepler light curve `X` can easily be 80000 x 2000.)

The implementation doesn't slow down `RegressionCorrector` for small values of X:
![image](https://user-images.githubusercontent.com/14965634/78414107-6ae08300-75cf-11ea-953a-ebced160de6d.png)

But for large values of X (i.e. with an entire Kepler dataset) we can increase the speed by a factor 2x:

![image](https://user-images.githubusercontent.com/14965634/78414119-8055ad00-75cf-11ea-9a37-d86260a73387.png)

This is a fairly minor tweak to `RegressionCorrector` and `DesignMatrix` to allow for sparse matrix maths. `DesignMatrix` still relies on users supplying a (non-sparse) matrix, pandas dataframe or dictionary. What this means in practice is that we're not getting any of the memory savings from using sparse, because we still store the large matrix in memory. We are only saving time during the `RegressionCorrector` call to `_fit_coefficients`. This is still worth it, but in future it would be great to improve the `DesignMatrix` API specifically for sparse matrices.

To do this in practice, I would need to remove the `patsy` dependence in `create_spline_dm`, because that function is relied on heavily in most detrending and does not currently support scipy sparse.
