### PR TITLE
Fix the MAST URL of the Kepler PRF files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 1.10.dev (unreleased)
-==================
+=====================
 
 - Added the ``extra_columns`` attribute to ``LightCurve`` objects. [#724]
+
+- Fixed the URL to the Point Response Function (PRF) files in ``KeplerPRF``. [#727]
 
 
 

--- a/lightkurve/prf/prfmodel.py
+++ b/lightkurve/prf/prfmodel.py
@@ -47,8 +47,7 @@ class KeplerPRF(object):
     >>> import matplotlib.pyplot as plt
     >>> from lightkurve import KeplerPRF
     >>> kepprf = KeplerPRF(channel=44, shape=(10, 10), column=5, row=5) # doctest: +SKIP
-    Downloading http://archive.stsci.edu/missions/kepler/fpc/prf
-    /extracted/kplr13.4_2011265_prf.fits [Done]
+    Downloading http://archive.stsci.edu/missions/kepler/fpc/prf/kplr13.4_2011265_prf.fits [Done]
     >>> prf = kepprf(flux=1000, center_col=10, center_row=10,
     ...              scale_row=0.7, scale_col=0.7, rotation_angle=math.pi/2) # doctest: +SKIP
     >>> plt.imshow(prf, origin='lower') # doctest: +SKIP
@@ -195,7 +194,7 @@ class KeplerPRF(object):
             prefix = 'kplr0'
         else:
             prefix = 'kplr'
-        prfs_url_path = "http://archive.stsci.edu/missions/kepler/fpc/prf/extracted/"
+        prfs_url_path = "http://archive.stsci.edu/missions/kepler/fpc/prf/"
         prffile = prfs_url_path + prefix + str(module) + '.' + str(output) + '_2011265_prf.fits'
 
         # read PRF images

--- a/lightkurve/prf/tests/test_prfmodel.py
+++ b/lightkurve/prf/tests/test_prfmodel.py
@@ -41,7 +41,7 @@ def test_simple_kepler_prf_interpolation_consistency():
     """
     sprf = SimpleKeplerPRF(channel=56, shape=[15, 15], column=0, row=0)
     cal_prf = fits.open("http://archive.stsci.edu/missions/kepler/fpc/prf/"
-                        "extracted/kplr16.4_2011265_prf.fits")
+                        "kplr16.4_2011265_prf.fits")
     cal_prf_subsampled = cal_prf[-1].data[25::50, 25::50]
     cal_prf_subsampled_normalized = cal_prf_subsampled / (cal_prf[-1].data.sum() * 0.02 ** 2)
     sprf_data = sprf(center_col=7.5, center_row=7.5, flux=1)


### PR DESCRIPTION
The Kepler PRF files appear to have moved from `http://archive.stsci.edu/missions/kepler/fpc/prf/extracted` to `http://archive.stsci.edu/missions/kepler/fpc/prf/`.

This is causing features that utilize the `KeplerPRF` class to fail.

This PR fixes the URL inside Lightkurve.