### PR TITLE
Bugfix: import `MastClass` from `astroquery.mast` instead of `astroquery.mast.core`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Fixed the URL to the Point Response Function (PRF) files in ``KeplerPRF``. [#727]
 
+- Fixed a bug which caused searches to fail with Astroquery v0.4.1 and later. [#728]
+
 
 
 1.9.1 (2020-03-25)

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -1054,7 +1054,7 @@ def _open_downloaded_file(path, **kwargs):
 
 def _resolve_object(target):
     """Ask MAST to resolve an object string to a set of coordinates."""
-    from astroquery.mast.core import MastClass
+    from astroquery.mast import MastClass
     # `_resolve_object` was renamed `resolve_object` in astroquery 0.3.10 (2019)
     try:
         return MastClass().resolve_object(target)


### PR DESCRIPTION
The `lightkurve.search` module included the following import:
```python
from astroquery.mast.core import MastClass
```

This will no longer work as of Astroquery v0.4.1, due to a recent refactor of `astroquery.mast` (https://github.com/astropy/astroquery/pull/1645). Users will encounter the following error:
```
Error: cannot import name 'MastClass' from 'astroquery.mast.core'
```

This PR fixes the issue.  The correct import to use is:
```python
from astroquery.mast import MastClass
```