### PR TITLE
Added support for scipy.sparse in DesignMatrix and RegressionCorrector to speed up regression on large, sparse matrices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Removed support for Python 2. [#733]
 
+- Added ``SparseDesignMatrix`` and modified ``RegressionCorrector`` to enable
+  systematics removal methods to benefit from ``scipy.sparse`` speed-ups. [#732]
+
 - Added the ability to perform math with ``TargetPixelFile`` objects, e.g.,
   ``tpf = tpf - 100`` will subtract 100 from the ``tpf.flux`` values. [#665]
 

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -329,7 +329,7 @@ class DesignMatrix():
                                   prior_mu=self.prior_mu,
                                   prior_sigma=self.prior_sigma)
 
-    def join(self, matrix):
+    def collect(self, matrix):
         """ Join two designmatrices, return a design matrix collection """
         return DesignMatrixCollection([self, matrix])
 
@@ -680,7 +680,7 @@ class SparseDesignMatrix(DesignMatrix):
     def __repr__(self):
         return '{} SparseDesignMatrix {}'.format(self.name, self.shape)
 
-    def join(self, matrix):
+    def collect(self, matrix):
         """ Join two designmatrices, return a design matrix collection """
         return SparseDesignMatrixCollection([self, matrix])
 

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -1,8 +1,4 @@
-"""Defines `DesignMatrix` and `DesignMatrixCollection`.
-
-These classes are intended to make linear regression problems with a large
-design matrix more easy.
-"""
+"""Defines `DesignMatrix`, `DesignMatrixCollection`, `SparseDesignMatrix` and `SparseDesignMatrixCollection`"""
 
 import warnings
 import numpy as np

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -354,7 +354,8 @@ class DesignMatrixCollection():
     >>> import lightkurve as lk
     >>> dm1 = lk.designmatrix.create_spline_matrix(np.arange(100), n_knots=5, name='spline')
     >>> dm2 = lk.DesignMatrix(np.arange(100), name='slope')
-    >>> lk.DesignMatrixCollection([dm1, dm2])
+    >>> dmc = lk.DesignMatrixCollection([dm1, dm2])
+    >>> dmc
     DesignMatrixCollection:
     	spline DesignMatrix (100, 5)
     	slope DesignMatrix (100, 1)

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -354,7 +354,7 @@ class DesignMatrixCollection():
     >>> import lightkurve as lk
     >>> dm1 = lk.designmatrix.create_spline_matrix(np.arange(100), n_knots=5, name='spline')
     >>> dm2 = lk.DesignMatrix(np.arange(100), name='slope')
-    >>> dmc = lk.DesignMatrixCollection([dm1, dm2])
+    >>> lk.DesignMatrixCollection([dm1, dm2])
     DesignMatrixCollection:
     	spline DesignMatrix (100, 5)
     	slope DesignMatrix (100, 1)

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -3,17 +3,20 @@
 These classes are intended to make linear regression problems with a large
 design matrix more easy.
 """
-import warnings
 
+import warnings
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from copy import deepcopy
 
 from .. import MPLSTYLE
 from ..utils import LightkurveWarning, plot_image
 
+from numba import jit
+from scipy.sparse import lil_matrix, csr_matrix, hstack, vstack, issparse, find, csc_matrix
 
-__all__ = ['DesignMatrix', 'DesignMatrixCollection']
+__all__ = ['DesignMatrix', 'DesignMatrixCollection', 'SparseDesignMatrix', 'SparseDesignMatrixCollection']
 
 
 class DesignMatrix():
@@ -45,9 +48,11 @@ class DesignMatrix():
                  prior_sigma=None):
         if not isinstance(df, pd.DataFrame):
             df = pd.DataFrame(df)
+        self.df = df
+        self.X = self.df.values
         if columns is not None:
             df.columns = columns
-        self.df = df
+        self.columns = list(df.columns)
         self.name = name
         if prior_mu is None:
             prior_mu = np.zeros(len(df.T))
@@ -55,6 +60,12 @@ class DesignMatrix():
             prior_sigma = np.ones(len(df.T)) * np.inf
         self.prior_mu = prior_mu
         self.prior_sigma = prior_sigma
+        self._validate()
+
+    def copy(self):
+        """Returns a deepcopy of DesignMatrix"""
+        return deepcopy(self)
+
 
     def plot(self, ax=None, **kwargs):
         """Visualize the design matrix values as an image.
@@ -242,16 +253,23 @@ class DesignMatrix():
                           "Consider reducing the dimensionality by calling the "
                           "`pca()` method.".format(self.rank, self.shape[1]),
                           LightkurveWarning)
+        if self.prior_mu is not None:
+            if len(self.prior_mu) != self.shape[1]:
+                raise ValueError('`prior_mu` must have shape {}'
+                                 ''.format(self.shape[1]))
+        if self.prior_sigma is not None:
+            if len(self.prior_sigma) != self.shape[1]:
+                raise ValueError('`prior_sigma` must have shape {}'
+                                 ''.format(self.shape[1]))
+            if np.any(np.asarray(self.prior_sigma) <= 0):
+                raise ValueError('`prior_sigma` values cannot be smaller than '
+                                 'or equal to zero')
+
 
     @property
     def rank(self):
         """Matrix rank computed using `numpy.linalg.matrix_rank`."""
         return np.linalg.matrix_rank(self.values)
-
-    @property
-    def columns(self):
-        """List of column names."""
-        return list(self.df.columns)
 
     @property
     def shape(self):
@@ -264,16 +282,42 @@ class DesignMatrix():
         return self.df.values
 
     def __getitem__(self, key):
-        return self.df[key]
+        return self.df[key].values
 
     def __repr__(self):
         return '{} DesignMatrix {}'.format(self.name, self.shape)
+
+    def to_sparse(self):
+        return SparseDesignMatrix(csr_matrix(self.values), name=self.name,
+                            columns=self.columns, prior_mu=self.prior_mu,
+                             prior_sigma=self.prior_sigma)
+
+    def join(self, matrix):
+        """ Join two designmatrices, return a design matrix collection """
+        return self.__class__([self, matrix])
+
+    def multichoose(self):
+        """ Create products of each vector in the design matrix """
+        raise NotImplementedError
 
 
 class DesignMatrixCollection():
     """A set of design matrices."""
     def __init__(self, matrices):
-        self.matrices = matrices
+        if np.any([issparse(m.X) for m in matrices]):
+            warnings.warn(('Some matrices are `SparseDesignMatrix` objects. '
+                            'Sparse matrices will be converted to dense matrices.'), LightkurveWarning)
+            dense_matrices = []
+            for m in matrices:
+                if isinstance(m, SparseDesignMatrix):
+                    dense_matrices.append(m.copy().to_dense())
+                else:
+                    dense_matrices.append(m)
+            self.matrices = dense_matrices
+        else:
+            self.matrices = matrices
+        self.X = np.hstack(tuple(m.X for m in self.matrices))
+        self._validate()
 
     @property
     def values(self):
@@ -353,7 +397,7 @@ class DesignMatrixCollection():
         `.DesignMatrixCollection`
             A new design matrix collection.
         """
-        return DesignMatrixCollection([d.split(row_indices) for d in self])
+        return self.__class__([d.split(row_indices) for d in self])
 
     def standardize(self):
         """Returns a new `.DesignMatrixCollection` in which all the
@@ -365,7 +409,7 @@ class DesignMatrixCollection():
         `.DesignMatrixCollection`
             The new design matrix collection.
         """
-        return DesignMatrixCollection([d.standardize() for d in self])
+        return self.__class__([d.standardize() for d in self])
 
     @property
     def columns(self):
@@ -387,14 +431,345 @@ class DesignMatrixCollection():
                     ''.join(['\t{}\n'.format(i.__repr__()) for i in self])
 
 
+class SparseDesignMatrix(DesignMatrix):
+    """A matrix of column vectors for use in linear regression.
+
+    This class is similar to the `lk.SparseDesignMatrix` class, but uses the
+    `scipy.sparse` library to improve speed in the case of sparse matrices.
+
+    The purpose of this class is to provide a convenient method to interact
+    with a set of one or more regressors which are known to correlate with
+    trends or systematic noise signals which we want to remove from a light
+    curve. Specifically, this class is designed to provide the design matrix
+    for use by Lightkurve's `.RegressionCorrector` class.
+
+    Parameters
+    ----------
+    X : `scipy.sparse` matrix
+        The values to build the design matrix with
+    columns : iterable of str (optional)
+        Column names
+    name : str
+        Name of the matrix.
+    prior_mu : array
+        Prior means of the coefficients associated with each column in a linear
+        regression problem.
+    prior_sigma : array
+        Prior standard deviations of the coefficients associated with each
+        column in a linear regression problem.
+    """
+    def __init__(self, X, columns=None, name='unnamed_matrix', prior_mu=None,
+                 prior_sigma=None):
+
+        if not issparse(X):
+            raise ValueError('Must pass a `scipy.sparse` matrix (e.g. `scipy.sparse.csr_matrix`)')
+        if columns is None:
+            columns = np.arange(X.shape[1])
+        self.columns = columns
+        self.name = name
+        if prior_mu is None:
+            prior_mu = np.zeros(X.shape[1])
+        if prior_sigma is None:
+            prior_sigma = np.ones(X.shape[1]) * np.inf
+        self.X = X
+        self.prior_mu = prior_mu
+        self.prior_sigma = prior_sigma
+        self._validate()
+
+    @property
+    def values(self):
+        """2D numpy array containing the matrix values."""
+        return self.X.toarray()
+
+    def split(self, row_indices, inplace=False):
+        """Returns a new `.SparseDesignMatrix` with regressors split into multiple
+        columns.
+
+        This method will return a new design matrix containing
+        n_columns * len(row_indices) regressors.  This is useful in situations
+        where the linear regression can be improved by fitting separate
+        coefficients for different contiguous parts of the regressors.
+
+        Parameters
+        ----------
+        row_indices : iterable of integers
+            Every regressor (i.e. column) in the design matrix will be split
+            up over multiple columns separated at the indices provided.
+
+        Returns
+        -------
+        `.SparseDesignMatrix`
+            A new design matrix with shape (n_rows, len(row_indices)*n_columns).
+        """
+
+        if not hasattr(row_indices, '__iter__'):
+            row_indices = [row_indices]
+
+        # You can't split on the first or last index
+        row_indices = list(np.asarray(row_indices)[~np.in1d(row_indices, [0, self.shape[0]])])
+        if len(row_indices) == 0:
+            return self
+        if inplace:
+            dm = self
+        else:
+            dm = self.copy()
+        x = np.arange(dm.shape[0])
+        dm.prior_mu = np.concatenate([list(self.prior_mu) * (len(row_indices) + 1)])
+        dm.prior_sigma = np.concatenate([list(self.prior_sigma) * (len(row_indices) + 1)])
+        dm.X = hstack([dm.X.multiply(lil_matrix(np.in1d(x, idx).astype(int)).T) for idx in np.array_split(x, row_indices)], format='lil')
+        non_zero = dm.X.sum(axis=0) != 0
+        non_zero = np.asarray(non_zero).ravel()
+        dm.X = dm.X[:, non_zero]
+        if dm.columns is not None:
+            dm.columns = list(np.asarray([['{}_{}'.format(c, idx) for c in dm.columns] for idx in range(len(row_indices) + 1)]).ravel())
+        dm.prior_mu = dm.prior_mu[non_zero]
+        dm.prior_sigma = dm.prior_sigma[non_zero]
+        return dm
+
+
+    def standardize(self, inplace=False):
+        """Returns a new `.SparseDesignMatrix` in which the columns have been
+        mean-subtracted and sigma-divided.
+
+        For each column in the matrix, this method will subtract the mean of
+        the column and divide by the column's standard deviation, i.e. it
+        will compute the column's so-called "standard scores" or "z-values".
+
+        This operation is useful because it will make the matrix easier to
+        visualize and makes fitted coefficients easier to interpret.
+
+        Notes:
+        * Standardizing a spline design matrix will break the splines.
+        * Columns with constant values (i.e. zero standard deviation) will be
+        left unchanged.
+
+        Returns
+        -------
+        `.SparseDesignMatrix`
+            A new design matrix with mean-subtracted & sigma-divided columns.
+        """
+        if inplace:
+            dm = self
+        else:
+            dm = self.copy()
+
+        idx, jdx, v = find(dm.X)
+        weights = dm.X.copy()
+        weights[dm.X != 0] = 1
+        mean = np.bincount(jdx, weights=v)/np.bincount(jdx)
+        std = np.asarray([((np.sum((v[jdx == i] - mean[i])**2) * (1/((jdx == i).sum() - 1))))**0.5 for i in np.unique(jdx)])
+        mean[std == 0] = 0
+        std[std == 0] = 1
+        white = (dm.X - vstack([lil_matrix(mean)] * dm.shape[0])).multiply(vstack([lil_matrix(1/std)] * dm.shape[0]))
+        dm.X = white.multiply(weights)
+        return dm
+
+    def pca(self, nterms=6, **kwargs):
+        """Returns a new `.SparseDesignMatrix` with a smaller number of regressors.
+
+        This method will use Principal Components Analysis (PCA) to reduce
+        the number of columns in the matrix.
+
+        Parameters
+        ----------
+        nterms : int
+            Number of columns in the new matrix.
+
+        Returns
+        -------
+        `.SparseDesignMatrix`
+            A new design matrix with PCA applied.
+        """
+        # nterms cannot be langer than the number of columns in the matrix
+        if nterms > self.shape[1]:
+            nterms = self.shape[1]
+        # We use `fbpca.pca` instead of `np.linalg.svd` because it is faster.
+        # Note that fbpca is randomized, and has n_iter=2 as default,
+        # we find this to be too few, and that n_iter=10 is still fast but
+        # produces more stable results.
+        from fbpca import pca  # local import because not used elsewhere
+        new_values, _, _ = pca(self.values, nterms, n_iter=10)
+        return SparseDesignMatrix(type(self.X)(new_values), name=self.name, **kwargs)
+
+    def append_constant(self, prior_mu=0, prior_sigma=np.inf, inplace=False):
+        """Returns a new `.SparseDesignMatrix` with a column of ones appended.
+
+        Returns
+        -------
+        `.SparseDesignMatrix`
+            New design matrix with a column of ones appended. This column is
+            named "offset".
+        """
+        if inplace:
+            dm = self
+        else:
+            dm = self.copy()
+        dm.X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format='lil')
+        dm.prior_mu = np.append(dm.prior_mu, prior_mu)
+        dm.prior_sigma = np.append(dm.prior_sigma, prior_sigma)
+        return dm
+
+    def __getitem__(self, key):
+        loc = np.where(np.asarray(self.columns) == key)[0]
+        if len(loc) == 0:
+            raise ValueError('No such column as `{}`.'.format(key))
+        return self.X[:, loc].toarray()
+
+    @property
+    def shape(self):
+        """Tuple specifying the shape of the matrix as (n_rows, n_columns)."""
+        return self.X.shape
+
+    def __repr__(self):
+        return '{} SparseDesignMatrix {}'.format(self.name, self.shape)
+
+    def join(self, matrix):
+        """ Join two designmatrices, return a design matrix collection """
+        return SparseDesignMatrixCollection([self, matrix])
+
+    def to_dense(self):
+        return DesignMatrix(self.values, name=self.name,
+                            columns=self.columns, prior_mu=self.prior_mu,
+                             prior_sigma=self.prior_sigma)
+
+
+class SparseDesignMatrixCollection(DesignMatrixCollection):
+    """A set of design matrices."""
+    def __init__(self, matrices):
+        if not np.all([issparse(m.X) for m in matrices]):
+            warnings.warn(('Not all matrices are `SparseDesignMatrix` objects. '
+                            'Dense matrices will be converted to sparse matrices.'), LightkurveWarning)
+            sparse_matrices = []
+            for m in matrices:
+                if isinstance(m, DesignMatrix):
+                    sparse_matrices.append(m.copy().to_sparse())
+                else:
+                    sparse_matrices.append(m)
+            self.matrices = sparse_matrices
+        else:
+            self.matrices = matrices
+        self.X = hstack([m.X for m in self.matrices], format='csr')
+        self._child_class = SparseDesignMatrix
+        self._validate()
+
+    def plot(self, ax=None, **kwargs):
+        """Visualize the design matrix values as an image.
+
+        Uses Matplotlib's `~lightkurve.utils.plot_image` to visualize the
+        matrix values.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`
+            A matplotlib axes object to plot into. If no axes is provided,
+            a new one will be created.
+        **kwargs : dict
+            Extra parameters to be passed to `.plot_image`.
+
+        Returns
+        -------
+        `~matplotlib.axes.Axes`
+            The matplotlib axes object.
+        """
+        temp_dm = SparseDesignMatrix(hstack([d.X for d in self]))
+        ax = temp_dm.plot(**kwargs)
+        ax.set_title("Design Matrix Collection")
+        return ax
+
+    def __repr__(self):
+        return 'SparseDesignMatrixCollection:\n' + \
+                    ''.join(['\t{}\n'.format(i.__repr__()) for i in self])
+
+
+
 ####################################################
 # Functions to create commonly-used design matrices.
 ####################################################
 
-def create_spline_matrix(x, n_knots=20, degree=3, name='spline',
-                         include_intercept=False):
-    """Returns a `.DesignMatrix` which models splines using `patsy.dmatrix`.
 
+@jit(nopython=True)
+def basis(x, degree, i, knots):
+    """Create a spline basis vector for an input x, for the ith knot.
+    Parameters
+    ----------
+    x : np.ndarray
+        Input x
+    degree : int
+        Degree of spline to calculate basis for
+    i : int
+        The index of the knot to calculate the basis for
+    knots : np.ndarray
+        Array of all knots
+    Returns
+    -------
+    B : np.ndarray
+        A vector of same length as x containing the spline basis for the ith knot
+    """
+    if degree == 0:
+        B = np.zeros(len(x))
+        B[(x >= knots[i]) & (x <= knots[i+1])] = 1
+        #B = (B)
+    else:
+#        alpha1, alpha2 = 0, 0
+        da = (knots[degree + i] - knots[i])
+        db = (knots[i + degree + 1] - knots[i + 1])
+        if ((knots[degree + i] - knots[i]) != 0):
+            alpha1 = ((x - knots[i])/da)
+        else:
+            alpha1 = np.zeros(len(x))
+        if ((knots[i+degree+1] - knots[i+1]) != 0):
+            alpha2 = ((knots[i + degree + 1] - x)/db)
+        else:
+            alpha2 = np.zeros(len(x))
+        B = (basis(x, (degree-1), i, knots)) * (alpha1) + (basis(x, (degree-1), (i+1), knots)) * (alpha2)
+    return B
+
+def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline'):
+    """Returns a `.SparseDesignMatrix` which models which are
+    Parameters
+    ----------
+    x : np.ndarray
+        vector to spline
+    n_knots: int
+        Number of knots (default: 20).
+    knots : np.ndarray [optional]
+        Optional array containing knots
+    degree: int
+        Polynomial degree.
+    name: string
+        Name to pass to `.SparseDesignMatrix` (default: 'spline').
+    include_intercept: bool
+        Whether to include row of ones to find intercept. Default False.
+    Returns
+    -------
+    dm: `.SparseDesignMatrix`
+        Design matrix object with shape (len(x), n_knots*degree).
+    """
+
+    # To use jit we have to use float64
+    x = np.asarray(x, np.float64)
+
+    if not isinstance(n_knots, int):
+        raise ValueError('`n_knots` must be an integer.')
+    if n_knots - degree <= 0:
+        raise ValueError('n_knots must be greater than degree.')
+    if (knots is None)  and (n_knots is not None):
+        knots = np.asarray([s[-1] for s in np.array_split(np.argsort(x), n_knots - degree)[:-1]])
+        knots = [np.mean([x[k], x[k + 1]]) for k in knots]
+    elif (knots is None)  and (n_knots is None):
+        raise ValueError('Pass either `n_knots` or `knots`.')
+    knots = np.append(np.append(x.min(), knots), x.max())
+    knots = np.unique(knots)
+    knots_wbounds = np.append(np.append([x.min()] * (degree - 1), knots), [x.max()] * (degree))
+
+    matrices = [csr_matrix(basis(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)]
+    spline_dm = vstack([m for m in matrices if (m.sum() != 0) ], format='csr').T
+    return SparseDesignMatrix(spline_dm, name=name)
+
+
+def create_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline',
+                         include_intercept=True):
+    """Returns a `.DesignMatrix` which models splines using `patsy.dmatrix`.
     Parameters
     ----------
     x : np.ndarray
@@ -407,16 +782,22 @@ def create_spline_matrix(x, n_knots=20, degree=3, name='spline',
         Name to pass to `.DesignMatrix` (default: 'spline').
     include_intercept: bool
         Whether to include row of ones to find intercept. Default False.
-
     Returns
     -------
     dm: `.DesignMatrix`
         Design matrix object with shape (len(x), n_knots*degree).
     """
     from patsy import dmatrix  # local import because it's rarely-used
-    dm_formula = "bs(x, df={}, degree={}, include_intercept={}) - 1" \
+    if knots is not None:
+        dm_formula = "bs(x, knots={}, degree={}, include_intercept={}) - 1" \
+                     "".format(knots, degree, include_intercept)
+        spline_dm = np.asarray(dmatrix(dm_formula, {"x": x}))
+        df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
+                                              for idx in range(spline_dm.shape[1])])
+    else:
+        dm_formula = "bs(x, df={}, degree={}, include_intercept={}) - 1" \
                  "".format(n_knots, degree, include_intercept)
-    spline_dm = np.asarray(dmatrix(dm_formula, {"x": x}))
-    df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
-                                          for idx in range(n_knots)])
+        spline_dm = np.asarray(dmatrix(dm_formula, {"x": x}))
+        df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
+                                              for idx in range(n_knots)])
     return DesignMatrix(df, name=name)

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -293,7 +293,14 @@ class DesignMatrix():
                                  'or equal to zero')
 
     def validate(self, rank=True):
-        """Raises a `LightkurveWarning` if the matrix has a low rank, or priors that are the wrong shape."""
+        """Raises a `LightkurveWarning` if the matrix has a low rank, or priors that are the wrong shape.
+
+        Note that for SparseDesignMatrix objects, calculating the rank will force the design matrix
+        to be evaluated and stored in memory, reducing the speed and memory savings of SparseDesignMatrix.
+
+        For SparseDesignMatrix, rank checks will be turned off by default.
+        """
+
         self._validate()
 
     @property

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -753,7 +753,10 @@ class SparseDesignMatrixCollection(DesignMatrixCollection):
 
 @jit(nopython=True)
 def _spline_basis_vector(x, degree, i, knots):
-    """Create a spline basis vector for an input x, for the ith knot.
+    """Recursive function to create a single spline basis vector for an input x, for the ith knot.
+
+    See https://en.wikipedia.org/wiki/B-spline for definition of B-spline basis vectors
+
     Parameters
     ----------
     x : np.ndarray
@@ -789,7 +792,13 @@ def _spline_basis_vector(x, degree, i, knots):
     return B
 
 def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline'):
-    """Returns a `.SparseDesignMatrix` which models which are
+    """Creates a piecewise polynomial function, creating a continuous, smooth function in x
+
+    See https://en.wikipedia.org/wiki/B-spline for the definitions of Basis Splines
+
+    B-spline vectors of degree higher than 0 are created using recursion, using the
+    `_spline_basis_vector` function to evaluate the basis vectors for x, for each knot.
+
     Parameters
     ----------
     x : np.ndarray

--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -42,6 +42,7 @@ class DesignMatrix():
 
     Examples
     --------
+    >>> import lightkurve as lk
     >>> lk.DesignMatrix(np.arange(100), name='slope')
     slope DesignMatrix (100, 1)
     >>> lk.designmatrix.create_spline_matrix(np.arange(100), n_knots=5, name='spline')

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -1,20 +1,22 @@
-"""Defines RegressionCorrector."""
-from __future__ import division  # necessary for math in `_fit_coefficients`
-
+"""Defines `RegressionCorrector` to solve large linear regression problems
+with user-defined Gaussian priors in a fast, analytical way.
+"""
 import logging
 import warnings
 
+from astropy.stats import sigma_clip
 import matplotlib.pyplot as plt
 import numpy as np
-from astropy.stats import sigma_clip
-
-from .corrector import Corrector
-from .designmatrix import DesignMatrix, DesignMatrixCollection, SparseDesignMatrix, SparseDesignMatrixCollection
-from ..lightcurve import LightCurve, MPLSTYLE
-
 from scipy.sparse import issparse, csr_matrix
 
+from .corrector import Corrector
+from .designmatrix import DesignMatrix, DesignMatrixCollection, \
+                          SparseDesignMatrix, SparseDesignMatrixCollection
+from ..lightcurve import LightCurve, MPLSTYLE
+
+
 __all__ = ['RegressionCorrector']
+
 
 log = logging.getLogger(__name__)
 
@@ -156,7 +158,6 @@ class RegressionCorrector(Corrector):
             # Compute `X^T cov^-1 y + prior_mu/prior_sigma^2`
             B = X.T.dot((self.lc.flux[cadence_mask]/flux_err**2))
             sigma_w_inv = sigma_w_inv.toarray()
-
 
         if prior_sigma is not None:
             sigma_w_inv += np.diag(1. / prior_sigma**2)

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -170,8 +170,8 @@ class SFFCorrector(RegressionCorrector):
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
 
         s_dm = spline(self.lc.time, n_knots=n_knots, name='spline')
-
-        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
+        means = [np.average(chunk) for chunk in np.array_split(self.lc.flux, n_knots)]
+#        means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
         s_dm.prior_mu = np.asarray(means)
 
         # I'm putting WEAK priors on the spline that it must be around 1

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -11,9 +11,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 from astropy.modeling import models, fitting
 
-from . import DesignMatrix, DesignMatrixCollection
+from . import DesignMatrix, DesignMatrixCollection, SparseDesignMatrixCollection
 from .regressioncorrector import RegressionCorrector
-from .designmatrix import create_spline_matrix
+from .designmatrix import create_spline_matrix, create_sparse_spline_matrix
 
 from .. import MPLSTYLE
 from ..utils import LightkurveWarning
@@ -69,7 +69,7 @@ class SFFCorrector(RegressionCorrector):
 
     def correct(self, centroid_col=None, centroid_row=None, windows=20, bins=5,
                 timescale=1.5, breakindex=None, degree=3, restore_trend=False,
-                additional_design_matrix=None, polyorder=None, **kwargs):
+                additional_design_matrix=None, polyorder=None, sparse=False, **kwargs):
         """Find the best fit correction for the light curve.
 
         Parameters
@@ -118,9 +118,11 @@ class SFFCorrector(RegressionCorrector):
         corrected_lc : `~lightkurve.lightcurve.LightCurve`
             Corrected light curve, with noise removed.
         """
-        from patsy import dmatrix  # local import because it's rarely-used
+        DMC, spline = DesignMatrixCollection, create_spline_matrix
+        if sparse:
+            DMC, spline = SparseDesignMatrixCollection, create_sparse_spline_matrix
 
-        if polyorder is not None: 
+        if polyorder is not None:
             warnings.warn("`polyorder` is deprecated and no longer used, "
                           "please use the `degree` keyword instead.",
                           LightkurveWarning)
@@ -144,33 +146,30 @@ class SFFCorrector(RegressionCorrector):
         lower_idx = np.asarray(np.append(0, self.window_points), int)
         upper_idx = np.asarray(np.append(self.window_points, len(self.lc.time)), int)
 
-        stack = []
-        columns = []
-        prior_sigmas = []
+        dms = []
         for idx, a, b in zip(range(len(lower_idx)), lower_idx, upper_idx):
-            knots = list(np.percentile(self.arclength[a:b], np.linspace(0, 100, bins+1)[1:-1]))
             ar = np.copy(self.arclength)
+            knots = list(np.percentile(ar[a:b], np.linspace(0, 100, bins+1)[1:-1]))
             ar[~np.in1d(ar, ar[a:b])] = 0
-            dm = np.asarray(dmatrix("bs(x, knots={}, degree={}, include_intercept={}) - 1"
-                                    "".format(knots, degree, True), {"x": ar}))
-            stack.append(dm)
-            columns.append(['window{}_bin{}'.format(idx+1, jdx+1)
-                            for jdx in range(len(dm.T))])
+            #import pdb; pdb.set_trace()
+            dm = spline(ar, knots=knots, degree=degree).copy()
+            dm.columns = ['window{}_bin{}'.format(idx+1, jdx+1)
+                                        for jdx in range(dm.shape[1])]
 
             # I'm putting VERY weak priors on the SFF motion vectors
             # (1e-6 is being added to prevent sigma from being zero)
-            ps = np.ones(len(dm.T)) * 10000 * self.lc[a:b].flux.std() + 1e-6
-            prior_sigmas.append(ps)
+            ps = np.ones(dm.shape[1]) * 10000 * self.lc[a:b].flux.std() + 1e-6
+            dm.prior_sigma = ps
+            dms.append(dm)
 
-        sff_dm = DesignMatrix(pd.DataFrame(np.hstack(stack)),
-                              columns=np.hstack(columns),
-                              name='sff',
-                              prior_sigma=np.hstack(prior_sigmas))
+        sff_dm = DMC(dms).flatten(name='sff')#.standardize()
+
 
 
         # long term
         n_knots = int((self.lc.time[-1] - self.lc.time[0])/timescale)
-        s_dm = create_spline_matrix(self.lc.time, n_knots=n_knots, include_intercept=True)
+
+        s_dm = spline(self.lc.time, n_knots=n_knots, name='spline')
 
         means = [np.average(self.lc.flux, weights=s_dm.values[:, idx]) for idx in range(s_dm.shape[1])]
         s_dm.prior_mu = np.asarray(means)
@@ -183,11 +182,11 @@ class SFFCorrector(RegressionCorrector):
             if not isinstance(additional_design_matrix, DesignMatrix):
                 raise ValueError('`additional_design_matrix` must be a DesignMatrix object.')
             self.additional_design_matrix = additional_design_matrix
-            dm = DesignMatrixCollection([s_dm,
+            dm = DMC([s_dm,
                                          sff_dm,
                                          additional_design_matrix])
         else:
-            dm = DesignMatrixCollection([s_dm, sff_dm])
+            dm = DMC([s_dm, sff_dm])
 
         # correct
         clc = super(SFFCorrector, self).correct(dm, **kwargs)

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -162,7 +162,7 @@ class SFFCorrector(RegressionCorrector):
             dm.prior_sigma = ps
             dms.append(dm)
 
-        sff_dm = DMC(dms).flatten(name='sff')#.standardize()
+        sff_dm = DMC(dms).to_designmatrix(name='sff')#.standardize()
 
 
 

--- a/lightkurve/correctors/tesspldcorrector.py
+++ b/lightkurve/correctors/tesspldcorrector.py
@@ -17,6 +17,7 @@ from .regressioncorrector import RegressionCorrector
 from .designmatrix import create_spline_matrix, create_sparse_spline_matrix
 from .. import MPLSTYLE
 
+import warnings
 
 __all__ = ['TessPLDCorrector']
 
@@ -77,7 +78,9 @@ class TessPLDCorrector(RegressionCorrector):
         dm_bkg = DesignMatrix(simple_bkg, name='background_model')
         dm_spline = spline(self.lc.time, n_knots=spline_n_knots,
                              degree=spline_degree).append_constant()
-        dm = DMC([dm_pixels, dm_bkg, dm_spline], warn=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            dm = DMC([dm_pixels, dm_bkg, dm_spline])
         return dm
 
     def correct(self, pixel_components=3, spline_n_knots=100, spline_degree=3,

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -103,11 +103,11 @@ def test_designmatrix_rank():
     # Good rank
     dm = DesignMatrix({'a': [1, 2, 3]})
     assert dm.rank == 1
-    dm._validate()  # Should not raise a warning
+    dm.validate(rank=True)  # Should not raise a warning
 
     # Bad rank
     dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
                        'd': [1, 1, 1], 'e': [3, 4, 5]})
     assert dm.rank == 2
     with pytest.warns(LightkurveWarning, match='rank'):
-        dm._validate()
+        dm.validate(rank=True)

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -66,11 +66,11 @@ def test_standardize():
     """Verifies DesignMatrix.standardize()"""
     # A column with zero standard deviation remains unchanged
     dm = DesignMatrix({'const': np.ones(10)})
-    assert (dm.standardize()['const'].values == dm['const'].values).all()
+    assert (dm.standardize()['const'] == dm['const']).all()
     # Normally-distributed columns will become Normal(0, 1)
     dm = DesignMatrix({'normal': np.random.normal(loc=5, scale=3, size=100)})
-    assert np.round(dm.standardize()['normal'].median(), 3) == 0
-    assert np.round(dm.standardize()['normal'].std(), 1) == 1
+    assert np.round(np.median(dm.standardize()['normal']), 3) == 0
+    assert np.round(np.std(dm.standardize()['normal']), 1) == 1
 
 
 def test_pca():

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -27,6 +27,14 @@ def test_designmatrix_basics():
     assert dm.split([10]).shape == (size, 6)        # expect double columns
     dm.__repr__()
 
+    dm = DesignMatrix(df, name=name)
+    dm.append_constant(inplace=True)
+    assert dm.shape == (size, 4)  # expect one column more
+
+    dm = DesignMatrix(df, name=name)
+    dm.split([10], inplace=True)
+    assert dm.shape == (size, 6)        # expect double columns
+
 
 def test_designmatrix_from_numpy():
     """Can we create a design matrix from an ndarray?"""
@@ -71,7 +79,7 @@ def test_standardize():
     dm = DesignMatrix({'normal': np.random.normal(loc=5, scale=3, size=100)})
     assert np.round(np.median(dm.standardize()['normal']), 3) == 0
     assert np.round(np.std(dm.standardize()['normal']), 1) == 1
-
+    dm.standardize(inplace=True)
 
 def test_pca():
     """Verifies DesignMatrix.pca()"""
@@ -88,12 +96,20 @@ def test_collection_basics():
     size = 5
     dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1')
     dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2')
+
     dmc = DesignMatrixCollection([dm1, dm2])
     assert_array_equal(dmc['matrix1'].values, dm1.values)
     assert_array_equal(dmc['matrix2'].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
     dmc.plot()
     dmc.__repr__()
+
+    dmc = dm1.join(dm2)
+    assert_array_equal(dmc['matrix1'].values, dm1.values)
+    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
+
+    assert isinstance(dmc.to_designmatrix(), DesignMatrix)
 
 
 def test_designmatrix_rank():

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -104,7 +104,7 @@ def test_collection_basics():
     dmc.plot()
     dmc.__repr__()
 
-    dmc = dm1.join(dm2)
+    dmc = dm1.collect(dm2)
     assert_array_equal(dmc['matrix1'].values, dm1.values)
     assert_array_equal(dmc['matrix2'].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))

--- a/lightkurve/correctors/tests/test_regressioncorrector.py
+++ b/lightkurve/correctors/tests/test_regressioncorrector.py
@@ -28,7 +28,7 @@ def test_regressioncorrector_priors():
             # No prior
             rc.correct(dm)
             assert_almost_equal(rc.coefficients, [0, 5])
-            
+
             # Strict prior centered on correct solution
             dm.prior_mu = [0, 5]
             dm.prior_sigma = [1e-6, 1e-6]
@@ -58,8 +58,8 @@ def test_sinusoid_noise():
     # Noisy light curve has a sinusoid single added
     noisy_lc = LightCurve(time, true_flux+noise, flux_err=true_lc.flux_err)
     design_matrix = DesignMatrix({'noise': noise,
-                       'offset': np.ones(len(time))},
-                      name='noise_model')
+                                  'offset': np.ones(len(time))},
+                                  name='noise_model')
 
     for dm in [design_matrix, design_matrix.to_sparse()]:
         # Can we recover the true light curve?

--- a/lightkurve/correctors/tests/test_regressioncorrector.py
+++ b/lightkurve/correctors/tests/test_regressioncorrector.py
@@ -20,32 +20,32 @@ def test_regressioncorrector_priors():
     """
     lc1 = LightCurve(flux=[5, 10])
     lc2 = LightCurve(flux=[5, 10], flux_err=[1, 1])
-    dm = DesignMatrix(pd.DataFrame({'a':[1, 1], 'b':[1, 2]}))
-    for lc in [lc1, lc2]:
-        rc = RegressionCorrector(lc)
+    design_matrix = DesignMatrix(pd.DataFrame({'a':[1, 1], 'b':[1, 2]}))
+    for dm in [design_matrix, design_matrix.to_sparse()]:
+        for lc in [lc1, lc2]:
+            rc = RegressionCorrector(lc)
 
-        # No prior
-        rc.correct(dm)
-        assert_almost_equal(rc.coefficients, [0, 5])
+            # No prior
+            rc.correct(dm)
+            assert_almost_equal(rc.coefficients, [0, 5])
+            
+            # Strict prior centered on correct solution
+            dm.prior_mu = [0, 5]
+            dm.prior_sigma = [1e-6, 1e-6]
+            rc.correct(dm)
+            assert_almost_equal(rc.coefficients, [0, 5])
 
-        # Strict prior centered on correct solution
-        dm.prior_mu = [0, 5]
-        dm.prior_sigma = [1e-6, 1e-6]
-        rc.correct(dm)
-        assert_almost_equal(rc.coefficients, [0, 5])
+            # Strict prior centered on incorrect solution
+            dm.prior_mu = [99, 99]
+            dm.prior_sigma = [1e-6, 1e-6]
+            rc.correct(dm)
+            assert_almost_equal(rc.coefficients, [99, 99])
 
-        # Strict prior centered on incorrect solution
-        dm.prior_mu = [99, 99]
-        dm.prior_sigma = [1e-6, 1e-6]
-        rc.correct(dm)
-        assert_almost_equal(rc.coefficients, [99, 99])
-
-        # Wide prior centered on incorrect solution
-        dm.prior_mu = [9, 9]
-        dm.prior_sigma = [1e6, 1e6]
-        rc.correct(dm)
-        assert_almost_equal(rc.coefficients, [0, 5])
-
+            # Wide prior centered on incorrect solution
+            dm.prior_mu = [9, 9]
+            dm.prior_sigma = [1e6, 1e6]
+            rc.correct(dm)
+            assert_almost_equal(rc.coefficients, [0, 5])
 
 def test_sinusoid_noise():
     """Can we remove simple sinusoid noise added to a flat light curve?"""
@@ -57,28 +57,29 @@ def test_sinusoid_noise():
     true_lc = LightCurve(time, true_flux, flux_err=0.1*np.ones(size))
     # Noisy light curve has a sinusoid single added
     noisy_lc = LightCurve(time, true_flux+noise, flux_err=true_lc.flux_err)
-    dm = DesignMatrix({'noise': noise,
+    design_matrix = DesignMatrix({'noise': noise,
                        'offset': np.ones(len(time))},
                       name='noise_model')
 
-    # Can we recover the true light curve?
-    rc = RegressionCorrector(noisy_lc)
-    corrected_lc = rc.correct(dm)
-    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+    for dm in [design_matrix, design_matrix.to_sparse()]:
+        # Can we recover the true light curve?
+        rc = RegressionCorrector(noisy_lc)
+        corrected_lc = rc.correct(dm)
+        assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
-    # Can we produce the diagnostic plot?
-    rc.diagnose()
+        # Can we produce the diagnostic plot?
+        rc.diagnose()
 
-    # Does it work when we set priors?
-    dm.prior_mu = [0.1, 0.1]
-    dm.prior_sigma = [1e6, 1e6]
-    corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
-    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+        # Does it work when we set priors?
+        dm.prior_mu = [0.1, 0.1]
+        dm.prior_sigma = [1e6, 1e6]
+        corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
+        assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
-    # Does it work when `flux_err` isn't available?
-    noisy_lc = LightCurve(time=time, flux=true_flux+noise)
-    corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
-    assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
+        # Does it work when `flux_err` isn't available?
+        noisy_lc = LightCurve(time=time, flux=true_flux+noise)
+        corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
+        assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
 
 def test_nan_input():

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -22,6 +22,7 @@ def test_remote_data(path):
     lcf = KeplerLightCurveFile(path, quality_bitmask=None)
     sff = SFFCorrector(lcf.PDCSAP_FLUX.remove_nans())
     sff.correct(windows=10, bins=5, timescale=0.5)
+    sff.correct(windows=10, bins=5, timescale=0.5, sparse=True)
 
 
 def test_sff_knots():

--- a/lightkurve/correctors/tests/test_sparsedesignmatrix.py
+++ b/lightkurve/correctors/tests/test_sparsedesignmatrix.py
@@ -1,0 +1,133 @@
+import pytest
+import warnings
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pandas as pd
+
+from .. import SparseDesignMatrix, SparseDesignMatrixCollection, DesignMatrix, DesignMatrixCollection
+from ... import LightkurveWarning
+from ..designmatrix import create_sparse_spline_matrix, create_spline_matrix
+
+
+from scipy import sparse
+
+
+def test_designmatrix_basics():
+    """Can we create a design matrix from a dataframe?"""
+    size, name = 10, 'testmatrix'
+    df = pd.DataFrame({'vector1': np.ones(size),
+                       'vector2': np.arange(size),
+                       'vector3': np.arange(size)**2})
+    X = sparse.csr_matrix(np.asarray(df))
+    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
+    assert dm.columns == ['vector1', 'vector2', 'vector3']
+    assert dm.name == name
+    assert dm.shape == (size, 3)
+    dm.plot()
+    dm.plot_priors()
+    assert dm.append_constant().shape == (size, 4)  # expect one column more
+    assert dm.pca(nterms=2).shape == (size, 2)      # expect one column less
+    assert dm.split([5]).shape == (size, 6)        # expect double columns
+    dm.__repr__()
+
+
+def test_split():
+    """Can we split a design matrix correctly?"""
+    X = sparse.csr_matrix(np.vstack([np.linspace(0, 9, 10), np.linspace(100, 109, 10)]).T)
+    dm = SparseDesignMatrix(X, columns=['a', 'b'])
+    # Do we retrieve the correct shape?
+    assert dm.shape == (10, 2)
+    assert dm.split(2).shape == (10, 4)
+    assert dm.split([2,8]).shape == (10, 6)
+    # Are the new areas padded with zeros?
+    assert (dm.split([2,8]).values[2:, 0:2] == 0).all()
+    assert (dm.split([2,8]).values[:8, 4:] == 0).all()
+    # Are all the column names unique?
+    assert len(set(dm.split(4).columns)) == 4
+
+
+def test_standardize():
+    """Verifies DesignMatrix.standardize()"""
+    # A column with zero standard deviation remains unchanged
+    X = sparse.csr_matrix(np.vstack([np.ones(10)]).T)
+    dm = SparseDesignMatrix(X, columns=['const'])
+    assert (dm.standardize()['const'] == dm['const']).all()
+    # Normally-distributed columns will become Normal(0, 1)
+    X = sparse.csr_matrix(np.vstack([ np.random.normal(loc=5, scale=3, size=100)]).T)
+    dm = SparseDesignMatrix(X, columns=['normal'])
+
+    assert np.round(np.mean(dm.standardize()['normal']), 3) == 0
+    assert np.round(np.std(dm.standardize()['normal']), 1) == 1
+
+
+def test_pca():
+    """Verifies DesignMatrix.pca()"""
+    size = 10
+    dm = DesignMatrix({'a':np.random.normal(10, 20, size),
+                       'b':np.random.normal(40, 10, size),
+                       'c':np.random.normal(60, 5, size)}).to_sparse()
+    for nterms in [1, 2, 3]:
+        assert dm.pca(nterms=nterms).shape == (size, nterms)
+
+
+def test_collection_basics():
+    """Can we create a design matrix collection?"""
+    size = 5
+    dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1').to_sparse()
+    dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2').to_sparse()
+    dmc = SparseDesignMatrixCollection([dm1, dm2])
+    assert_array_equal(dmc['matrix1'].values, dm1.values)
+    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
+    dmc.plot()
+    dmc.__repr__()
+
+    """Can we create a design matrix collection when one is sparse?"""
+    size = 5
+    dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1')
+    dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2').to_sparse()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        with pytest.warns(LightkurveWarning, match='Sparse matrices will be converted to dense matrices.'):
+            dmc = DesignMatrixCollection([dm1, dm2])
+            assert not np.any([sparse.issparse(d.X) for d in dmc])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        with pytest.warns(LightkurveWarning, match='Dense matrices will be converted to sparse matrices.'):
+            dmc = SparseDesignMatrixCollection([dm1, dm2])
+            assert np.all([sparse.issparse(d.X) for d in dmc])
+
+    dmc.plot()
+    dmc.__repr__()
+
+
+
+def test_designmatrix_rank():
+    """Does DesignMatrix issue a low-rank warning when justified?"""
+    warnings.simplefilter("always")
+
+    # Good rank
+    dm = DesignMatrix({'a': [1, 2, 3]})
+    assert dm.rank == 1
+    dm._validate()  # Should not raise a warning
+
+    # Bad rank
+    dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
+                       'd': [1, 1, 1], 'e': [3, 4, 5]})
+    assert dm.rank == 2
+    with pytest.warns(LightkurveWarning, match='rank'):
+        dm._validate()
+
+
+def test_splines():
+    """Do splines work as expected?"""
+    # Dense and sparse splines should produce the same answer.
+    x = np.linspace(0, 1, 100)
+    spline_dense = create_spline_matrix(x, knots=[0.1, 0.3, 0.6, 0.9], degree=2)
+    spline_sparse =create_sparse_spline_matrix(x, knots=[0.1, 0.3, 0.6, 0.9], degree=2)
+    assert np.allclose(spline_dense.values, spline_sparse.values)
+    assert isinstance(spline_dense, DesignMatrix)
+    assert isinstance(spline_sparse, SparseDesignMatrix)

--- a/lightkurve/correctors/tests/test_sparsedesignmatrix.py
+++ b/lightkurve/correctors/tests/test_sparsedesignmatrix.py
@@ -112,14 +112,14 @@ def test_designmatrix_rank():
     # Good rank
     dm = DesignMatrix({'a': [1, 2, 3]})
     assert dm.rank == 1
-    dm._validate()  # Should not raise a warning
+    dm.validate(rank=True)  # Should not raise a warning
 
     # Bad rank
     dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
                        'd': [1, 1, 1], 'e': [3, 4, 5]})
     assert dm.rank == 2
     with pytest.warns(LightkurveWarning, match='rank'):
-        dm._validate()
+        dm.validate(rank=True)
 
 
 def test_splines():

--- a/lightkurve/correctors/tests/test_sparsedesignmatrix.py
+++ b/lightkurve/correctors/tests/test_sparsedesignmatrix.py
@@ -92,7 +92,7 @@ def test_collection_basics():
     dmc.plot()
     dmc.__repr__()
 
-    dmc = dm1.join(dm2)
+    dmc = dm1.collect(dm2)
     assert_array_equal(dmc['matrix1'].values, dm1.values)
     assert_array_equal(dmc['matrix2'].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))

--- a/lightkurve/correctors/tests/test_sparsedesignmatrix.py
+++ b/lightkurve/correctors/tests/test_sparsedesignmatrix.py
@@ -31,6 +31,14 @@ def test_designmatrix_basics():
     assert dm.split([5]).shape == (size, 6)        # expect double columns
     dm.__repr__()
 
+    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
+    dm.append_constant(inplace=True)
+    assert dm.shape == (size, 4)  # expect one column more
+
+    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
+    dm.split([5], inplace=True)
+    assert dm.shape == (size, 6)        # expect double columns
+
 
 def test_split():
     """Can we split a design matrix correctly?"""
@@ -59,7 +67,7 @@ def test_standardize():
 
     assert np.round(np.mean(dm.standardize()['normal']), 3) == 0
     assert np.round(np.std(dm.standardize()['normal']), 1) == 1
-
+    dm.standardize(inplace=True)
 
 def test_pca():
     """Verifies DesignMatrix.pca()"""
@@ -76,12 +84,18 @@ def test_collection_basics():
     size = 5
     dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1').to_sparse()
     dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2').to_sparse()
+
     dmc = SparseDesignMatrixCollection([dm1, dm2])
     assert_array_equal(dmc['matrix1'].values, dm1.values)
     assert_array_equal(dmc['matrix2'].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
     dmc.plot()
     dmc.__repr__()
+
+    dmc = dm1.join(dm2)
+    assert_array_equal(dmc['matrix1'].values, dm1.values)
+    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
 
     """Can we create a design matrix collection when one is sparse?"""
     size = 5
@@ -102,6 +116,8 @@ def test_collection_basics():
 
     dmc.plot()
     dmc.__repr__()
+
+    assert isinstance(dmc.to_designmatrix(), SparseDesignMatrix)
 
 
 

--- a/lightkurve/correctors/tests/test_tesspldcorrector.py
+++ b/lightkurve/correctors/tests/test_tesspldcorrector.py
@@ -16,3 +16,4 @@ def test_basics():
     corrector = TessPLDCorrector(tpf)
     corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1)
     corrector.diagnose()
+    corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1, sparse=True)

--- a/lightkurve/correctors/tests/test_tesspldcorrector.py
+++ b/lightkurve/correctors/tests/test_tesspldcorrector.py
@@ -1,19 +1,22 @@
 import pytest
 
 from astropy.utils.data import get_pkg_data_filename
+import numpy as np
 
 from ... import open as lkopen
 from .. import TessPLDCorrector
 
 
-TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000"
-            "/004/176/tess2019128220341-0000000417699452-0016-s_tp.fits")
+TESS_DATA = ("https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:"
+            "TESS/product/tess2018319095959-s0005-0000000238201762-0125-s_tp.fits")
 
 
 @pytest.mark.remote_data
 def test_basics():
-    tpf = lkopen(TESS_SIM)
+    tpf = lkopen(TESS_DATA)
+    tpf = tpf[np.nansum(tpf.flux[:, tpf.pipeline_mask], axis=(1)) != 0]
+    tpf = tpf[np.nansum(tpf.flux_err[:, tpf.pipeline_mask], axis=(1)) != 0]
     corrector = TessPLDCorrector(tpf)
-    corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1)
+    corrector.correct(spline_n_knots=10, spline_degree=3, pixel_components=1)
     corrector.diagnose()
-    corrector.correct(spline_n_knots=3, spline_degree=2, pixel_components=1, sparse=True)
+    corrector.correct(spline_n_knots=10, spline_degree=3, pixel_components=1, sparse=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 uncertainties
 patsy>=0.5.1
 fbpca>=1.0
+numba>=0.39.0


### PR DESCRIPTION
This is a refactor of #722, which adds the new `SparseDesignMatrix` and `SparseDesignMatrixCollection` classes. These subclass `DesignMatrix` and `DesignMatrixCollection`, but use the `scipy.sparse` to speed up the calculations in `RegressionCorrector` and reduce memory. 

@barentsen has pointed out that it might be best to use `SparseDesignMatrix` only, and remove `DesignMatrix`, however
1) `SparseDesignMatrix` is slower if the matrix is actually dense
2) `DesignMatrix` is slightly more user friendly, in that it works with numpy arrays, pandas dataframes and dictionaries.

