### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -1,13 +1,12 @@
 # GitHub Actions workflow for Lightkurve's continuous integration.
 #
-# This file configures seven different jobs:
-# 1) pytest on Linux, Python 2.7.
-# 2) pytest on Linux, Python 3.7.
-# 3) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
-# 4) pytest on Linux, Python 3.8, without installing optional dependencies.
-# 5) pytest on Windows, Python 3.8, with --remote-data enabled.
-# 6) pytest on OSX, Python 3.8.
-# 7) flake8 syntax check.
+# This file configures six different jobs:
+# 1) pytest on Linux, Python 3.7.
+# 2) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
+# 3) pytest on Linux, Python 3.8, without installing optional dependencies.
+# 4) pytest on Windows, Python 3.8, with --remote-data enabled.
+# 5) pytest on OSX, Python 3.8.
+# 6) flake8 syntax check.
 
 name: Lightkurve-tests
 
@@ -20,12 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [2.7, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies]
+        name: [3.7, 3.8-remote-data, 3.8-no-optional-dependencies]
         include:
-          - name: 2.7
-            python-version: 2.7
-            pip-command: pip install -e .[test]
-            pytest-command: pytest
           - name: 3.7
             python-version: 3.7
             pip-command: pip install -e .[all,test]
@@ -58,8 +53,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        name: [3.7-remote-data]
-        python-version: [3.7]
+        name: [3.8-remote-data]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -79,7 +74,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -99,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,15 @@
+2.0.dev (unreleased)
+=====================
+
+- Removed support for Python 2.
+
+
+
 1.11.0 (2015-05-20)
+===================
+
+- Deprecated the ``TargetPixelFile.header`` property and ``LightCurveFile.header()``
+  method in favor of a consistent ``get_header()`` method. [#736]
 
 - Fixed a bug in ``tpf.interact_sky()`` which caused star positions to be off
   by half a pixel. [#734]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,4 @@
 1.11.0 (2015-05-20)
-===================
 
 - Fixed a bug in ``tpf.interact_sky()`` which caused star positions to be off
   by half a pixel. [#734]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,6 @@
 1.11.0 (2015-05-20)
 ===================
 
-- Deprecated the ``TargetPixelFile.header`` property and ``LightCurveFile.header()``
-  method in favor of a consistent ``get_header()`` method. [#736]
-
 - Fixed a bug in ``tpf.interact_sky()`` which caused star positions to be off
   by half a pixel. [#734]
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -1055,8 +1055,5 @@ def _open_downloaded_file(path, **kwargs):
 def _resolve_object(target):
     """Ask MAST to resolve an object string to a set of coordinates."""
     from astroquery.mast import MastClass
-    # `_resolve_object` was renamed `resolve_object` in astroquery 0.3.10 (2019)
-    try:
-        return MastClass().resolve_object(target)
-    except AttributeError:
-        return MastClass()._resolve_object(target)
+    # Note: `_resolve_object` was renamed `resolve_object` in astroquery 0.3.10 (2019)
+    return MastClass().resolve_object(target)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -79,7 +79,9 @@ class TargetPixelFile(object):
         with warnings.catch_warnings():
             # Ignore warnings about empty fields
             warnings.simplefilter('ignore', UserWarning)
-            copy = self.hdu.copy()
+            # AstroPy added `HDUList.copy()` in v3.1, but we don't want to make
+            # v3.1 a minimum requirement yet, so we copy in a funny way.
+            copy = fits.HDUList([myhdu.copy() for myhdu in self.hdu])
             copy[1].data = copy[1].data[selected_idx]
         return self.__class__(copy, quality_bitmask=self.quality_bitmask, targetid=self.targetid)
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -79,9 +79,7 @@ class TargetPixelFile(object):
         with warnings.catch_warnings():
             # Ignore warnings about empty fields
             warnings.simplefilter('ignore', UserWarning)
-            # AstroPy added `HDUList.copy()` in v3.1, but we don't want to make
-            # v3.1 a minimum requirement yet, so we copy in a funny way.
-            copy = fits.HDUList([myhdu.copy() for myhdu in self.hdu])
+            copy = self.hdu.copy()
             copy[1].data = copy[1].data[selected_idx]
         return self.__class__(copy, quality_bitmask=self.quality_bitmask, targetid=self.targetid)
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -955,11 +955,7 @@ class TargetPixelFile(object):
         if center is None:
             x, y = imshape[0]//2, imshape[1]//2
         elif isinstance(center, SkyCoord):
-            try:
-                x, y = self.wcs.world_to_pixel(center)
-            except AttributeError:
-                # Python 2 compatibility (i.e. syntax of older AstroPy versions)
-                x, y = self.wcs.all_world2pix([[center.ra.value, center.dec.value]], 1)[0]
+            x, y = self.wcs.world_to_pixel(center)
         elif isinstance(center, (tuple, list, np.ndarray)):
             x, y = center
         col = int(x)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -286,12 +286,6 @@ def test_corrupt_download_handling():
 
 def test_filenotfound():
     """Regression test for #540; ensure lk.open() yields `FileNotFoundError`."""
-    # Python 2 uses IOError instead of FileNotFoundError;
-    # the block below can be removed when we drop Python 2 support.
-    try:
-        FileNotFoundError
-    except NameError:
-        FileNotFoundError = IOError
     with pytest.raises(FileNotFoundError):
         open("DOESNOTEXIST")
 

--- a/lightkurve/tests/test_synthetic_data.py
+++ b/lightkurve/tests/test_synthetic_data.py
@@ -3,6 +3,8 @@
 from __future__ import division, print_function
 
 from astropy.utils.data import get_pkg_data_filename
+from astropy.stats.bls import BoxLeastSquares
+
 import numpy as np
 import pytest
 from scipy import stats
@@ -14,14 +16,6 @@ from ..correctors import SFFCorrector, PLDCorrector
 filename_synthetic_sine = get_pkg_data_filename("data/synthetic/synthetic-k2-sinusoid.targ.fits.gz")
 filename_synthetic_transit = get_pkg_data_filename("data/synthetic/synthetic-k2-planet.targ.fits.gz")
 filename_synthetic_flat = get_pkg_data_filename("data/synthetic/synthetic-k2-flat.targ.fits.gz")
-
-# BLS is only available in Python 3 versions of AstroPy;
-# so we will need to skip BLS-based tests below when in Python 2.
-lacks_bls = False
-try:
-    from astropy.stats.bls import BoxLeastSquares
-except ImportError:
-    lacks_bls = True
 
 
 def test_sine_sff():
@@ -59,7 +53,6 @@ def test_sine_sff():
             (fractional_amplitude < true_amplitude*1.1) )
 
 
-@pytest.mark.skipif(lacks_bls, reason="Astropy BLS requires Python 3")
 def test_transit_sff():
     """Can we recover a synthetic exoplanet signal using SFF and BLS?"""
     # Retrieve the custom, known signal properties
@@ -88,7 +81,6 @@ def test_transit_sff():
             (pg.depth_at_max_power < max_depth))
 
 
-@pytest.mark.skipif(lacks_bls, reason="Astropy BLS requires Python 3")
 def test_transit_pld():
     """Can we recover a synthetic exoplanet signal using PLD and BLS?"""
     # Retrieve the custom, known signal properties

--- a/lightkurve/version.py
+++ b/lightkurve/version.py
@@ -1,3 +1,3 @@
 # It is important to store the version number in a separate file
 # so that we can read it from setup.py without importing the package
-__version__ = "1.11.0"
+__version__ = "2.0.dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.11
-astropy>=1.3
+astropy>=3.0
 scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
 astroquery>=0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.11
-astropy>=3.0
+astropy>=3.1
 scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
-astroquery>=0.3.9
+astroquery>=0.3.10
 oktopus
 bs4
 requests

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov', 'pytest
 # `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.
 # `PLDCorrector` requires pybind11, celerite.
-extras_require = {"all":  ["astropy>=3.1",
-                           "bokeh>=1.0", "ipython",
+extras_require = {"all":  ["bokeh>=1.0", "ipython",
                            "pybind11", "celerite"],
                   "test": tests_require}
 


### PR DESCRIPTION
It has becoming increasingly difficult to support Python 2. For example, it is currently the cause of the unit test failures over in #732, and it is preventing #665 from getting merged.

This PR proposes to drop support for Python 2.

Consequences include:
* We will bump the Lightkurve version number to v2.0.
* We can now require `astropy>=3.1` and `astroquery>=0.3.10`.
