### PR TITLE
Introduce a consistent `get_header()` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ===================
 
 - Deprecated the ``TargetPixelFile.header`` property and ``LightCurveFile.header()``
-  a method in favor of consistent ``get_header()`` methods. [#TBD]
+  method in favor of a consistent ``get_header()`` method. [#736]
 
 - Fixed a bug in ``tpf.interact_sky()`` which caused star positions to be off
   by half a pixel. [#734]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,13 @@
-1.10.1 (unreleased)
+1.11.0 (unreleased)
 ===================
+
+- Deprecated the ``TargetPixelFile.header`` property and ``LightCurveFile.header()``
+  a method in favor of consistent ``get_header()`` methods. [#TBD]
 
 - Fixed a bug in ``tpf.interact_sky()`` which caused star positions to be off
   by half a pixel. [#734]
+
+
 
 
 1.10.0 (2015-05-14)

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -41,7 +41,35 @@ class LightCurveFile(object):
             self.hdu = pyfits.open(self.path, **kwargs)
 
     def header(self, ext=0):
-        """Header of the object at extension `ext`"""
+        """DEPRECATED. Please use ``get_header()`` instead."""
+        warnings.warn("`LightCurveFile.header` is deprecated, please use "
+                      "`LightCurveFile.get_header()` instead.",
+                      LightkurveWarning)
+        return self.hdu[ext].header
+
+    def get_header(self, ext=0):
+        """Returns the metadata embedded in the file.
+
+        Light Curve Files contain embedded metadata headers spread across three
+        different FITS extensions:
+
+        1. The "PRIMARY" extension (``ext=0``) provides a metadata header
+           providing details on the target and its CCD position.
+        2. The "LIGHTCURVE" extension (``ext=1``) provides details on the
+           data columns and the systematics removal.
+        3. The "APERTURE" extension (``ext=2``) provides details on the
+           aperture pixel mask and the expected coordinate system (WCS).
+
+        Parameters
+        ----------
+        ext : int or str
+            FITS extension name or number.
+
+        Returns
+        -------
+        header : `~astropy.io.fits.header.Header`
+            Header object containing metadata keywords.
+        """
         return self.hdu[ext].header
 
     def get_keyword(self, keyword, hdu=0, default=None):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -118,8 +118,36 @@ class TargetPixelFile(object):
 
     @property
     def header(self):
-        """Returns the header of the primary extension."""
+        """DEPRECATED. Please use ``get_header()`` instead."""
+        warnings.warn("`TargetPixelFile.header` is deprecated, please use "
+                      "`TargetPixelFile.get_header()` instead.",
+                      LightkurveWarning)
         return self.hdu[0].header
+
+    def get_header(self, ext=0):
+        """Returns the metadata embedded in the file.
+
+        Target Pixel Files contain embedded metadata headers spread across three
+        different FITS extensions:
+
+        1. The "PRIMARY" extension (``ext=0``) provides a metadata header
+           providing details on the target and its CCD position.
+        2. The "PIXELS" extension (``ext=1``) provides details on the
+           data column and their coordinate system (WCS).
+        3. The "APERTURE" extension (``ext=2``) provides details on the
+           aperture pixel mask and the expected coordinate system (WCS).
+
+        Parameters
+        ----------
+        ext : int or str
+            FITS extension name or number.
+
+        Returns
+        -------
+        header : `~astropy.io.fits.header.Header`
+            Header object containing metadata keywords.
+        """
+        return self.hdu[ext].header
 
     @property
     def ra(self):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -19,6 +19,7 @@ from ..targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
 from ..utils import LightkurveWarning
 from .test_targetpixelfile import TABBY_TPF
 
+
 # 8th Quarter of Tabby's star
 TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
             "/0084/008462852/kplr008462852-2011073133259_llc.fits")
@@ -428,7 +429,7 @@ def test_cdpp_tabby():
     lcf = KeplerLightCurveFile(TABBY_Q8)
     # Tabby's star shows dips after cadence 1000 which increase the cdpp
     lc = LightCurve(lcf.PDCSAP_FLUX.time[:1000], lcf.PDCSAP_FLUX.flux[:1000])
-    assert(np.abs(lc.estimate_cdpp() - lcf.header(ext=1)['CDPP6_0']) < 30)
+    assert(np.abs(lc.estimate_cdpp() - lcf.get_header(ext=1)['CDPP6_0']) < 30)
 
 
 # TEMPORARILY SKIP, cf. https://github.com/KeplerGO/lightkurve/issues/663
@@ -1024,3 +1025,13 @@ def test_SSOs():
     assert(len(result) == 1)
     result, mask = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(lc.flux))
+
+
+def test_get_header():
+    """Test the basic functionality of ``tpf.get_header()``"""
+    lcf = TessLightCurveFile(filename_tess_custom)
+    assert lcf.get_header()['CREATOR'] == lcf.get_keyword("CREATOR")
+    assert lcf.get_header(ext=2)['EXTNAME'] == "APERTURE"
+    # ``tpf.header`` is deprecated
+    with pytest.warns(LightkurveWarning, match='deprecated'):
+        lcf.header()

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -303,7 +303,7 @@ def test_tpf_factory():
 
     # Can we add our own keywords?
     tpf = factory.get_tpf(hdu0_keywords={'creator': 'Christina TargetPixelFileWriter'})
-    assert tpf.header['CREATOR'] == 'Christina TargetPixelFileWriter'
+    assert tpf.get_keyword('CREATOR') == 'Christina TargetPixelFileWriter'
 
 
 def _create_image_array(header=None, shape=(5, 5)):
@@ -567,3 +567,14 @@ def test_SSOs():
     assert(len(result) == 1)
     result, mask = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(tpf.flux))
+
+
+def test_get_header():
+    """Test the basic functionality of ``tpf.get_header()``"""
+    tpf = lkopen(filename_tpf_one_center)
+    assert tpf.get_header()['CHANNEL'] == tpf.get_keyword("CHANNEL")
+    assert tpf.get_header(0)['MISSION'] == tpf.get_keyword("MISSION")
+    assert tpf.get_header(ext=2)['EXTNAME'] == "APERTURE"
+    # ``tpf.header`` is deprecated
+    with pytest.warns(LightkurveWarning, match='deprecated'):
+        tpf.header


### PR DESCRIPTION
The Lightkurve API currently suffers from an annoying inconsistency:
* `TargetPixelFile.header` is a property;
* `LightCurveFile.header(ext=0)` is a method.

This PR proposes to deprecate the above and adds a consistent `get_header(ext=0)` method to both classes.