### PR TITLE
Added option to plot TPF background to `TargetPixelFile.plot()`

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -716,7 +716,7 @@ class TargetPixelFile(object):
             return res, np.in1d(self.astropy_time.jd, res.epoch)
         return res
 
-    def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
+    def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, add_bkg=False, aperture_mask=None,
              show_colorbar=True, mask_color='pink', title=None, style='lightkurve',
              **kwargs):
         """Plot the pixel data for a single frame (i.e. at a single time).
@@ -734,8 +734,11 @@ class TargetPixelFile(object):
         cadenceno : int, optional
             Alternatively, a cadence number can be provided.
             This argument has priority over frame number.
-        bkg : bool
+        bkg: bool
+            If True, plot the background pixel values only.
+        add_bkg : bool
             If True, background will be added to the pixel values.
+            Can not be True if 'bkg' is True.
         aperture_mask : ndarray or str
             Highlight pixels selected by aperture_mask.
         show_colorbar : bool
@@ -764,8 +767,10 @@ class TargetPixelFile(object):
                                  "must be in the range {}-{}.".format(
                                      cadenceno, self.cadenceno[0], self.cadenceno[-1]))
         try:
-            if bkg and np.any(np.isfinite(self.flux_bkg[frame])):
+            if add_bkg and np.any(np.isfinite(self.flux_bkg[frame])):
                 pflux = self.flux[frame] + self.flux_bkg[frame]
+            elif bkg and np.any(np.isfinite(self.flux_bkg[frame])):
+                pflux = self.flux_bkg[frame]
             else:
                 pflux = self.flux[frame]
         except IndexError:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -767,26 +767,25 @@ class TargetPixelFile(object):
                                  "must be in the range {}-{}.".format(
                                      cadenceno, self.cadenceno[0], self.cadenceno[-1]))      
         try:
-            if column not in ('FLUX','FLUX_ERR','FLUX_BKG','FLUX_BKG_ERR',
-                                'COSMIC_RAYS','RAW_CNTS'):
-                raise ValueError("column must be one of the following: ('FLUX','FLUX_ERR',"
-                                 "'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
             if column == 'FLUX':
                 if bkg and np.any(np.isfinite(self.flux_bkg[frame])):
-                    pflux = self.flux[frame] + self.flux_bkg[frame]
+                    data_to_plot = self.flux[frame] + self.flux_bkg[frame]
                 else:
-                    pflux = self.flux[frame]
+                    data_to_plot = self.flux[frame]
             else:
-                pflux = self.hdu[1].data[column][self.quality_mask][frame]
+                data_to_plot = self.hdu[1].data[column][self.quality_mask][frame]
+        except KeyError:
+            raise ValueError("column must be one of the following: ('FLUX','FLUX_ERR',"
+                                "'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
         except IndexError:
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.shape[0]))
 
         # Make list of preset colour labels
         clabels = {'FLUX': 'Flux ($e^{-}s^{-1}$)',
-                'FLUX_ERR': 'Flux Err ($e^{-}s^{-1}$)',
-                'FLUX_BKG': 'Background Flux Err ($e^{-}s^{-1}$)',
-                'FLUX_BKG_ERR': 'Background Flux Err ($e^{-}s^{-1}$)',
+                'FLUX_ERR': 'Flux Err. ($e^{-}s^{-1}$)',
+                'FLUX_BKG': 'Background Flux ($e^{-}s^{-1}$)',
+                'FLUX_BKG_ERR': 'Background Flux Err. ($e^{-}s^{-1}$)',
                 'COSMIC_RAYS': 'Cosmic Ray Flux ($e^{-}s^{-1}$)', 
                 'RAW_CNTS': 'Raw Counts'}
 
@@ -795,7 +794,7 @@ class TargetPixelFile(object):
                 title = 'Target ID: {}, Cadence: {}'.format(self.targetid, self.cadenceno[frame])
             img_extent = (self.column, self.column + self.shape[2],
                           self.row, self.row + self.shape[1])
-            ax = plot_image(pflux, ax=ax, title=title, extent=img_extent,
+            ax = plot_image(data_to_plot, ax=ax, title=title, extent=img_extent,
                             show_colorbar=show_colorbar, clabel = clabels[column], **kwargs)
             ax.grid(False)
         if aperture_mask is not None:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -776,11 +776,6 @@ class TargetPixelFile(object):
                     pflux = self.flux[frame] + self.flux_bkg[frame]
                 else:
                     pflux = self.flux[frame]
-            elif column == 'COSMIC_RAYS':
-                try:
-                    pflux = self.hdu[3].data[column]
-                except KeyError:
-                    raise ValueError("no COSMIC_RAYS data for this file")
             else:
                 pflux = self.hdu[1].data[column][self.quality_mask][frame]
         except IndexError:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -734,9 +734,9 @@ class TargetPixelFile(object):
         cadenceno : int, optional
             Alternatively, a cadence number can be provided.
             This argument has priority over frame number.
-        bkg: bool
-            If True, background will be added to the pixel values.
-        column :
+        bkg : bool
+            If True and `column="FLUX"`, background will be added to the pixel values.
+        column : str
             Choose the FITS data column to be plotted. May be one of ('FLUX',
             'FLUX_ERR','FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS').
         aperture_mask : ndarray or str
@@ -765,7 +765,7 @@ class TargetPixelFile(object):
             except IndexError:
                 raise ValueError("cadenceno {} is out of bounds, "
                                  "must be in the range {}-{}.".format(
-                                     cadenceno, self.cadenceno[0], self.cadenceno[-1]))      
+                                     cadenceno, self.cadenceno[0], self.cadenceno[-1]))
         try:
             if column == 'FLUX':
                 if bkg and np.any(np.isfinite(self.flux_bkg[frame])):
@@ -776,7 +776,7 @@ class TargetPixelFile(object):
                 data_to_plot = self.hdu[1].data[column][self.quality_mask][frame]
         except KeyError:
             raise ValueError("column must be one of the following: ('FLUX','FLUX_ERR',"
-                                "'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
+                             "'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
         except IndexError:
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.shape[0]))
@@ -795,7 +795,7 @@ class TargetPixelFile(object):
             img_extent = (self.column, self.column + self.shape[2],
                           self.row, self.row + self.shape[1])
             ax = plot_image(data_to_plot, ax=ax, title=title, extent=img_extent,
-                            show_colorbar=show_colorbar, clabel = clabels[column], **kwargs)
+                            show_colorbar=show_colorbar, clabel = clabels.get(column, column), **kwargs)
             ax.grid(False)
         if aperture_mask is not None:
             aperture_mask = self._parse_aperture_mask(aperture_mask)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -769,8 +769,8 @@ class TargetPixelFile(object):
         try:
             if column not in ('FLUX','FLUX_ERR','FLUX_BKG','FLUX_BKG_ERR',
                                 'COSMIC_RAYS','RAW_CNTS'):
-                raise ValueError("column must be one of the following: ('FLUX','FLUX_ERR',\
-                                    'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
+                raise ValueError("column must be one of the following: ('FLUX','FLUX_ERR',"
+                                 "'FLUX_BKG','FLUX_BKG_ERR','COSMIC_RAYS','RAW_CNTS')")
             if column == 'FLUX':
                 if bkg and np.any(np.isfinite(self.flux_bkg[frame])):
                     pflux = self.flux[frame] + self.flux_bkg[frame]

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -89,7 +89,7 @@ def test_tpf_plot():
         tpf.plot(column='FLUX_BKG') 
         tpf.plot(column='FLUX_BKG_ERR') 
         tpf.plot(column='RAW_CNTS') 
-        # tpf.plot(column='COSMIC_RAYS') 
+        tpf.plot(column='COSMIC_RAYS') 
         with pytest.raises(ValueError):
             tpf.plot(column='not a column')
 

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -84,6 +84,15 @@ def test_tpf_plot():
         tpf.plot(scale="log")
         with pytest.raises(ValueError):
             tpf.plot(scale="blabla")
+        tpf.plot(column='FLUX')
+        tpf.plot(column='FLUX_ERR') 
+        tpf.plot(column='FLUX_BKG') 
+        tpf.plot(column='FLUX_BKG_ERR') 
+        tpf.plot(column='RAW_CNTS') 
+        # tpf.plot(column='COSMIC_RAYS') 
+        with pytest.raises(ValueError):
+            tpf.plot(column='not a column')
+
         plt.close('all')
 
 


### PR DESCRIPTION
For cases where there are strong background features (e.g. near the corners of TESS CCDs) in Target Pixel File data, it might be useful to be able to plot the TPF background flux using the Lightkurve infrastructure.

This PR changes the keyword arguments of `TargetPixelFile.plot()`, so that:

- `bkg=True` plots the TPF flux background _only_
- `add_bkg=True` plots the TPF flux with the background added (this functionality was previously under the `bkg=True` argument).

If `bkg=True` and `add_bkg=True` are passed, the `bkg` keyword is ignored.

Example usage:
![image](https://user-images.githubusercontent.com/22291663/82350150-e1f0a000-99f2-11ea-84a2-c8658d3c56e9.png)
