### PR TITLE
Bugfix: Pixel selection in tpf.interact() is off by half a pixel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@
 ===================
 
 - Fixed a bug in ``tpf.interact()`` which caused the pixel selection to be off
-  by half a pixel. The bug was introduced in v1.11.0. [#751]
+  by half a pixel. The bug was introduced in v1.11.0. [#754]
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,13 @@
 
 
 
+1.12.0 (unreleased)
+===================
+
+- Fixed a bug in ``tpf.interact()`` which caused the pixel selection to be off
+  by half a pixel. The bug was introduced in v1.11.0. [#751]
+
+
 
 1.11.0 (2015-05-20)
 ===================

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -320,8 +320,8 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
         title = "Pixel data"
 
     fig = figure(plot_width=plot_width, plot_height=plot_height,
-                 x_range=(tpf.column-0.5, tpf.column-0.5+tpf.shape[2]),
-                 y_range=(tpf.row-0.5, tpf.row-0.5+tpf.shape[1]),
+                 x_range=(tpf.column, tpf.column+tpf.shape[2]),
+                 y_range=(tpf.row, tpf.row+tpf.shape[1]),
                  title=title, tools=tools,
                  toolbar_location="below",
                  border_fill_color="whitesmoke")
@@ -348,7 +348,8 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     else:
         raise ValueError('Please specify either `linear` or `log` scale for color.')
 
-    fig.image([tpf.flux[fiducial_frame, :, :] + pedestal], x=tpf.column-0.5, y=tpf.row-0.5,
+    fig.image([tpf.flux[fiducial_frame, :, :] + pedestal],
+              x=tpf.column, y=tpf.row,
               dw=tpf.shape[2], dh=tpf.shape[1], dilate=True,
               color_mapper=color_mapper, name="tpfimg")
 


### PR DESCRIPTION
We accidentally broke the pixel selection in `interact` with the release of Lightkurve v1.11.0 (culprit: https://github.com/KeplerGO/lightkurve/commit/f1cdedaf65638d0efeb42475d610b6f02d7097c4).

This PR restores the correct working of `interact`.

## Before this PR:

![interact-before](https://user-images.githubusercontent.com/817669/84971546-da93e380-b0d1-11ea-9e56-5e1c127c64da.png)

## After this PR:

![interact-after](https://user-images.githubusercontent.com/817669/84971599-ef707700-b0d1-11ea-9416-2cf7157b6f14.png)
