### PR TITLE
Bugfix in `interact`: pixel coordinates must refer to pixel centers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@
 1.12.0 (unreleased)
 ===================
 
+- Fixed ``tpf.plot()`` and ``tpf.interact_sky()`` to reflect that Kepler and
+  TESS pixel coordinates refer to pixel centers. [#755]
+
 - Fixed a bug in ``tpf.interact()`` which caused the pixel selection to be off
   by half a pixel. The bug was introduced in v1.11.0. [#754]
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -833,8 +833,10 @@ class TargetPixelFile(object):
         with plt.style.context(style):
             if title is None:
                 title = 'Target ID: {}, Cadence: {}'.format(self.targetid, self.cadenceno[frame])
-            img_extent = (self.column, self.column + self.shape[2],
-                          self.row, self.row + self.shape[1])
+            # We subtract -0.5 because pixel coordinates refer to the middle of
+            # a pixel, e.g. (col, row) = (10.0, 20.0) is a pixel center.
+            img_extent = (self.column - 0.5, self.column + self.shape[2] - 0.5,
+                          self.row - 0.5, self.row + self.shape[1] - 0.5)
             ax = plot_image(data_to_plot, ax=ax, title=title, extent=img_extent,
                             show_colorbar=show_colorbar, clabel = clabels.get(column, column), **kwargs)
             ax.grid(False)


### PR DESCRIPTION
Steve Bryson confirmed to me that pixel coordinates refer to the middle of a pixel.

For example:
* (column, row) = (10.0, 20.0) is a pixel **center**.
* (column, row) = (10.5, 20.5) is a pixel **corner**.

In the past, Lightkurve inadvertently assumed that pixel coordinates referred to pixel corners.  For example, we mixed this up in `tpf.interact_sky()`, causing several users to report that the overlaid Gaia positions appeared off by 0.5 pixels.  Likewise, the axis labels were off by 0.5 pixels in `tpf.plot()` and `tpf.interact()`. This PR fixes those shifts!

### `tpf.interact_sky()` before this PR:

![sky-before](https://user-images.githubusercontent.com/817669/84980478-0d94a200-b0e7-11ea-8aad-8ea99eea9f3d.png)

### `tpf.interact_sky()` after this PR:

![sky-after](https://user-images.githubusercontent.com/817669/84980547-36b53280-b0e7-11ea-9d8b-4623f1063361.png)

### `tpf.plot()` before this PR:

![plot-before](https://user-images.githubusercontent.com/817669/84980572-4765a880-b0e7-11ea-8eee-80c632787c27.png)

### `tpf.plot()` after this PR:

![plot-after](https://user-images.githubusercontent.com/817669/84980575-4b91c600-b0e7-11ea-8ce0-4557e559ca95.png)

Finally, this PR also fixes the incorrect correction of proper motion in `interact_sky` (cf. #743).