### PR TITLE
Require AstroPy>=4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.11
-astropy>=3.2
+astropy>=4.0
 scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
 astroquery>=0.3.10


### PR DESCRIPTION
The new TimeSeries-based `LightCurve` class requires AstroPy 4.0 or later.

This PR updates `requirements.txt` accordingly, and should also fix #762.