### PR TITLE
Added `column` argument to `LightCurve` plotting functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,6 @@
 2.0.dev (unreleased)
 =====================
 
-- Modified the Seismology `estimate_radius`, `estimate_mass` and `estimate_logg`
-  functions to use observation meta data for effective temperature, when available. [#766]
-
 - Removed support for Python 2. [#733]
 
 - Added ``SparseDesignMatrix`` and modified ``RegressionCorrector`` to enable
@@ -12,8 +9,14 @@
 - Added the ability to perform math with ``TargetPixelFile`` objects, e.g.,
   ``tpf = tpf - 100`` will subtract 100 from the ``tpf.flux`` values. [#665]
 
-- Added the ``column`` parameter to ``TargetPixelFile.plot()`` to enable all
-  columns in a pixel file to be plotted (e.g. ``column="BKG_FLUX"``). [#738]
+- Added a ``column`` parameter to ``TargetPixelFile.plot()`` to enable any
+  column in a pixel file to be plotted (e.g. ``column="BKG_FLUX"``). [#738]
+
+- Added a ``column`` parameter to ``LightCurve``'s ``plot()``, ``scatter()``,
+  and ``errorbar()`` methods to enable any column to be plotted. [#765]
+
+- Modified the ``estimate_radius``, ``estimate_mass``, and ``estimate_logg``
+  methods to default to the ``teff`` value in the meta data. [#766]
 
 
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1262,7 +1262,7 @@ class LightCurve(TimeSeries):
                 if np.any(~np.isnan(flux_err)):
                     ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
                 else:
-                    raise ValueError(f"Column `{column}` has no associated errors.")
+                    log.warning(f"Column `{column}` has no associated errors.")
             else:
                 ax.plot(self.time.value, flux.value, **kwargs)
             ax.set_xlabel(xlabel)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1219,7 +1219,7 @@ class LightCurve(TimeSeries):
                     ylabel = f"{column}"
             if normalize or self.meta.get("normalized"):
                 ylabel = "Normalized " + ylabel
-            elif (self[column].unit) and (self[column].unit.to_string() is not ''):
+            elif (self[column].unit) and (self[column].unit.to_string() != ''):
                 ylabel += f" [{self[column].unit.to_string('latex_inline')}]"
             else: 
                 pass

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1219,7 +1219,7 @@ class LightCurve(TimeSeries):
                     ylabel = f"{column}"
             if normalize or self.meta.get("normalized"):
                 ylabel = "Normalized " + ylabel
-            elif (self[column].unit) and (type(self[column].unit) is not u.CompositeUnit):
+            elif (self[column].unit) and (self[column].unit.to_string() is not ''):
                 ylabel += f" [{self[column].unit.to_string('latex_inline')}]"
             else: 
                 pass

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1234,8 +1234,6 @@ class LightCurve(TimeSeries):
         else:
             lc_plot.flux_err = np.full(len(lc_plot.flux), np.nan)
             errors = False
-            print('HELLO')
-            print(errors)
 
         # Normalize the data if requested
         if normalize:
@@ -1262,8 +1260,7 @@ class LightCurve(TimeSeries):
                 if errors:
                     ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
                 elif errors == False:
-                    print('HELLO')
-                    raise ValueError("The column {} has no associated errors".format(column)))
+                    raise ValueError("The column {} has no associated errors".format(column))
             else:
                 ax.plot(self.time.value, flux.value, **kwargs)
             ax.set_xlabel(xlabel)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1217,14 +1217,12 @@ class LightCurve(TimeSeries):
                     ylabel = "Flux"
             else:
                     ylabel = f"{column}"
-                    
             if normalize or self.meta.get("normalized"):
                 ylabel = "Normalized " + ylabel
-            elif self[column].unit:
+            elif (self[column].unit) and (type(self[column].unit) is not u.CompositeUnit):
                 ylabel += f" [{self[column].unit.to_string('latex_inline')}]"
             else: 
                 pass
-
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1185,8 +1185,8 @@ class LightCurve(TimeSeries):
             return res, np.in1d(self.astropy_time.jd, res.epoch)
         return res
 
-    def _create_plot(self, method='plot', ax=None, normalize=False,
-                     xlabel=None, ylabel=None, column='flux', title='', style='lightkurve',
+    def _create_plot(self, column='flux', method='plot', ax=None, normalize=False,
+                     xlabel=None, ylabel=None, title='', style='lightkurve',
                      show_colorbar=True, colorbar_label='',
                      **kwargs):
         """Implements `plot()`, `scatter()`, and `errorbar()` to avoid code duplication.
@@ -1213,20 +1213,18 @@ class LightCurve(TimeSeries):
                 xlabel = 'Time'
         # Default ylabel
         if ylabel is None:
-            if column in ['flux','sap_flux','sap_bkg','pdscap_flux']:
-                if normalize or (self.flux.unit == u.dimensionless_unscaled):
-                    ylabel = 'Normalized Flux'
-                elif self.flux.unit is None:
-                    ylabel = 'Flux'
-                else:
-                    ylabel = 'Flux [{}]'.format(self.flux.unit.to_string("latex_inline"))
+            if "flux" in column:
+                    ylabel = "Flux"
             else:
-                if normalize:
-                    ylabel = 'Normalized {}'.format(column)
-                elif self[column].unit is None:
-                    ylabel = '{}'.format(column)
-                else:
-                    ylabel = '{} [{}]'.format(column, self[column].unit.to_string("latex_inline"))
+                    ylabel = f"{column}"
+                    
+            if normalize or self.meta.get("normalized"):
+                ylabel = "Normalized " + ylabel
+            elif self[column].unit:
+                ylabel += f" [{self[column].unit.to_string('latex_inline')}]"
+            else: 
+                pass
+
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')
@@ -1284,6 +1282,8 @@ class LightCurve(TimeSeries):
 
         Parameters
         ----------
+        column : str
+            Name of data column to plot. Default `flux`.
         ax : `~matplotlib.axes.Axes`
             A matplotlib axes object to plot into. If no axes is provided,
             a new one will be created.
@@ -1293,8 +1293,6 @@ class LightCurve(TimeSeries):
             Plot x axis label
         ylabel : str
             Plot y axis label
-        column : str
-            Name of data column to plot. Default `flux`.
         title : str
             Plot set_title
         style : str
@@ -1316,6 +1314,8 @@ class LightCurve(TimeSeries):
 
         Parameters
         ----------
+        column : str
+            Name of data column to plot. Default `flux`.
         ax : `~matplotlib.axes.Axes`
             A matplotlib axes object to plot into. If no axes is provided,
             a new one will be generated.
@@ -1351,6 +1351,8 @@ class LightCurve(TimeSeries):
 
         Parameters
         ----------
+        column : str
+            Name of data column to plot. Default `flux`.
         ax : `~matplotlib.axes.Axes`
             A matplotlib axes object to plot into. If no axes is provided,
             a new one will be generated.

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1226,7 +1226,7 @@ class LightCurve(TimeSeries):
                 elif self[column].unit is None:
                     ylabel = '{}'.format(column)
                 else:
-                    ylabel = 'Normalized {} [{}]'.format(column, self[column].unit.to_string("latex_inline"))
+                    ylabel = '{} [{}]'.format(column, self[column].unit.to_string("latex_inline"))
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1221,7 +1221,12 @@ class LightCurve(TimeSeries):
                 else:
                     ylabel = 'Flux [{}]'.format(self.flux.unit.to_string("latex_inline"))
             else:
-                ylabel = '{} [{}]'.format(column, self['column'].unit.to_string("latex_inline"))
+                if normalize:
+                    ylabel = 'Normalized {}'.format(column)
+                elif self['column'].unit is None:
+                    ylabel = '{}'.format(column)
+                else:
+                    ylabel = 'Normalized {} [{}]'.format(column, self['column'].unit.to_string("latex_inline"))
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1223,7 +1223,7 @@ class LightCurve(TimeSeries):
             else:
                 if normalize:
                     ylabel = 'Normalized {}'.format(column)
-                elif self['column'].unit is None:
+                elif self[column].unit is None:
                     ylabel = '{}'.format(column)
                 else:
                     ylabel = 'Normalized {} [{}]'.format(column, self[column].unit.to_string("latex_inline"))

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1213,20 +1213,22 @@ class LightCurve(TimeSeries):
                 xlabel = 'Time'
         # Default ylabel
         if ylabel is None:
-            if normalize or (self.flux.unit == u.dimensionless_unscaled):
-                ylabel = 'Normalized Flux'
-            elif self.flux.unit is None:
-                ylabel = 'Flux'
+            if column in ['flux','sap_flux','sap_bkg','pdscap_flux']:
+                if normalize or (self.flux.unit == u.dimensionless_unscaled):
+                    ylabel = 'Normalized Flux'
+                elif self.flux.unit is None:
+                    ylabel = 'Flux'
+                else:
+                    ylabel = 'Flux [{}]'.format(self.flux.unit.to_string("latex_inline"))
             else:
-                ylabel = 'Flux [{}]'.format(self.flux.unit.to_string("latex_inline"))
+                ylabel = '{} [{}]'.format(column, self['column'].unit.to_string("latex_inline"))
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')
-
         # Create a copy with the appropriate flux and flux_err columns
         lc_plot = self.copy()
         lc_plot.flux = lc_plot[column]
-
+        # Check if column has associated uncertainties
         if column in ['flux','sap_flux','sap_bkg','pdscap_flux',
                         'psf_centr1','psf_centr2','mom_centr1','mom_centr2']:
             lc_plot.flux_err = lc_plot['{}_err'.format(column)]
@@ -1260,7 +1262,7 @@ class LightCurve(TimeSeries):
                 if errors:
                     ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
                 elif errors == False:
-                    raise ValueError("The column {} has no associated errors".format(column))
+                    raise ValueError("The column `{}` has no associated errors.".format(column))
             else:
                 ax.plot(self.time.value, flux.value, **kwargs)
             ax.set_xlabel(xlabel)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1230,8 +1230,12 @@ class LightCurve(TimeSeries):
         if column in ['flux','sap_flux','sap_bkg','pdscap_flux',
                         'psf_centr1','psf_centr2','mom_centr1','mom_centr2']:
             lc_plot.flux_err = lc_plot['{}_err'.format(column)]
+            errors = True
         else:
             lc_plot.flux_err = np.full(len(lc_plot.flux), np.nan)
+            errors = False
+            print('HELLO')
+            print(errors)
 
         # Normalize the data if requested
         if normalize:
@@ -1255,7 +1259,11 @@ class LightCurve(TimeSeries):
                     cbar.ax.yaxis.set_tick_params(tick1On=False, tick2On=False)
                     cbar.ax.minorticks_off()
             elif method == 'errorbar':
-                ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
+                if errors:
+                    ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
+                elif errors == False:
+                    print('HELLO')
+                    raise ValueError("The column {} has no associated errors".format(column)))
             else:
                 ax.plot(self.time.value, flux.value, **kwargs)
             ax.set_xlabel(xlabel)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1226,7 +1226,7 @@ class LightCurve(TimeSeries):
                 elif self['column'].unit is None:
                     ylabel = '{}'.format(column)
                 else:
-                    ylabel = 'Normalized {} [{}]'.format(column, self['column'].unit.to_string("latex_inline"))
+                    ylabel = 'Normalized {} [{}]'.format(column, self[column].unit.to_string("latex_inline"))
         # Default legend label
         if ('label' not in kwargs):
             kwargs['label'] = self.meta.get('label')

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -343,7 +343,12 @@ def test_lightcurve_plots():
         lc.scatter()
         lc.scatter(c='C3')
         lc.scatter(c=lc.time.value, show_colorbar=True, colorbar_label='Time')
-        lc.errorbar()
+        lc.plot(column='sap_flux')
+        lc.plot(column='sap_bkg', normalize=True)
+        lc.plot(column='cadenceno')
+        lc.errorbar(column='psf_centr1')
+        with pytest.raises(ValueError):
+            lc.errorbar(column='timecorr')      
         plt.close('all')
 
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -347,8 +347,7 @@ def test_lightcurve_plots():
         lc.plot(column='sap_bkg', normalize=True)
         lc.plot(column='cadenceno')
         lc.errorbar(column='psf_centr1')
-        with pytest.raises(ValueError):
-            lc.errorbar(column='timecorr')      
+        lc.errorbar(column='timecorr')
         plt.close('all')
 
 


### PR DESCRIPTION
Following @barentsen's recent PR #744, Lightkurve `LightCurve` objects are a subclass of Astropy Timeseries. This means that for a single `LighCurve`, we have access to a ton of time-dependent properties such as the PDCSAP flux, SAP flux, Momentum and PSF drift, you name it. 

This PR makes it a little easier to plot these different columns side-by-side without having to manipulate your `LightCurve` object. The new behaviour could be as follows:

```python3
lc = lightkurve.search_lightcurve('Kepler-8', quarter=4).download()
ax = lc.plot(normalize=True, label='PDCSAP')
lc.plot(column='sap_flux', ax=ax, normalize=True, label='SAP')
lc.plot(column='sap_bkg', ax=ax, normalize=True, label='Background')
```

In this example, the second line plots the PDCSAP flux, because by default `.plot()` plots what is in the `flux` column, which is by default is the PDCSAP flux. This produces the plot below.

![image](https://user-images.githubusercontent.com/22291663/85550939-613c4980-b619-11ea-9a52-a7979749f671.png)

In the case where the y-axis units are not flux, `.plot()` will show the name of the chosen `column` keyword along with the units (if applicable) on the y-axis. If you try to use the `.errorbar()` function to plot a property that doesn't have errors (such as `cadenceno` or `timecorr`) it will throw a ValueError.