### PR TITLE
fix bug in diff'ing astropy table

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -761,7 +761,7 @@ class LombScarglePeriodogram(Periodogram):
         time = lc.time.copy()
 
         # Approximate Nyquist Frequency and frequency bin width in terms of days
-        nyquist = 0.5 * (1./(np.median(np.diff(time))))
+        nyquist = 0.5 * (1./(np.median(np.diff(time.value)))) * (1/cds.d)
         fs = (1./(time[-1] - time[0])) / oversample_factor
 
         # Convert these values to requested frequency unit


### PR DESCRIPTION
Hi all, I'm enjoying the new timeseries functionality lightkurve has! However, I've run into some problems with it appearing to break the Periodogram functionality. The Python kernel appears to gets stuck when performing a np.diff on lc.time? This is a small patch to address the problem, which assumes that the input time is always days. I will likely rewrite a large portion of the periodogram module in the near future to make it more compatible with these updates.