### PR TITLE
New function for TPF pixel analysis: inspect_pixels()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@
 - Modified the ``estimate_radius``, ``estimate_mass``, and ``estimate_logg``
   methods to default to the ``teff`` value in the meta data. [#766]
 
+- Added the ``TargetPixelFile.plot_pixels()`` method to plot light curves
+  and periodograms for each individual pixel in a TPF. [#771] 
+
 
 
 1.11.1 (2020-06-18)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1230,7 +1230,7 @@ class TargetPixelFile(object):
                         else:
                             pixel_list.append(lc)
 
-mask = self._parse_aperture_mask(aperture_mask)
+        mask = self._parse_aperture_mask(aperture_mask)
 
         with plt.style.context(style):
             if title is None:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1310,9 +1310,9 @@ class TargetPixelFile(object):
                             gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     else:
                         if periodogram:
-                            gax.plot(x_vals, y_vals, 'w-', lw=0.5)
+                            gax.plot(x_vals, y_vals, 'k-', lw=0.5)
                         elif not periodogram:
-                            gax.plot(x_vals, y_vals, 'w.', ms=0.5)
+                            gax.plot(x_vals, y_vals, 'k.', ms=0.5)
                     
                     gax.set_xlim(x_axis_min, x_axis_max)
                     gax.set_ylim(y_axis_min, y_axis_max)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1169,7 +1169,7 @@ class TargetPixelFile(object):
         return self.__class__(newfits)
 
 
-    def inspect_pixels(self, ax=None, normalize=False, periodogram=False, aperture_mask=None, show_flux=False, style='lightkurve', title=None, **kwargs):
+    def plot_pixels(self, ax=None, normalize=False, periodogram=False, aperture_mask=None, show_flux=False, style='lightkurve', title=None, **kwargs):
         """ Plot the light curves or associated periodograms for each pixel in one quarter
         Note that all values are autoscaled and axis labels are not provided.
         This utility is designed for by-eye inspection of signal morphology.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1169,7 +1169,7 @@ class TargetPixelFile(object):
         return self.__class__(newfits)
 
 
-    def inspect_pixels(self, ax=None, normalized=False, periodogram=False, aperture_mask=None, style='lightkurve', title=None, **kwargs):
+    def inspect_pixels(self, ax=None, normalize=False, periodogram=False, aperture_mask=None, style='lightkurve', title=None, **kwargs):
         """ Plot the light curves or associated periodograms for each pixel in one quarter
         Note that all values are autoscaled and axis labels are not provided.
         This utility is designed for by-eye inspection of signal morphology.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1219,12 +1219,12 @@ class TargetPixelFile(object):
                     except IndexError:
                         pixel_list.append(None)
                 else:
-                    if normalized == True:
+                    if normalize == True:
                         if len(lc_norm.remove_nans().flux) == 0:
                             pixel_list.append(None)
                         else:
                             pixel_list.append(lc_norm)
-                    elif normalized == False:
+                    elif normalize == False:
                         if len(lc.remove_nans().flux) == 0:
                             pixel_list.append(None)
                         else:
@@ -1245,7 +1245,7 @@ class TargetPixelFile(object):
                 if periodogram == True:
                     ax.set(title=title, xlabel='Frequency', ylabel='Power')
                 else:
-                    if normalized == True:
+                    if normalize == True:
                         ax.set(title=title, xlabel='Time', ylabel='Normalized Flux')
                     else:
                         ax.set(title=title, xlabel='Time', ylabel='Flux')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1306,7 +1306,7 @@ class TargetPixelFile(object):
                         gax.set_facecolor(tpf_plot.cmap(tpf_plot.norm(self.flux[0,x,y])))
                         if periodogram:
                             gax.plot(x_vals, y_vals, 'w-', lw=0.5)
-                        elif not periodogram:
+                        else:
                             gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     else:
                         if periodogram:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1224,9 +1224,6 @@ class TargetPixelFile(object):
                 if normalize or corrector_func is None: # overrides corrector function
                     corrector_func = lambda x:x.normalize().remove_outliers()
                     lc_corr = corrector_func(lc)
-                elif corrector_func == None:
-                    corrector_func = lambda x:x.normalize().remove_outliers()
-                    lc_corr = corrector_func(lc)
                 else:
                     lc_corr = corrector_func(lc)
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1281,7 +1281,7 @@ class TargetPixelFile(object):
                         x_axis_min = 0
                         x_axis_max = np.nanmax(x_vals)
                         y_axis_min = 0
-                        y_axis_max = np.nanmax(y_vals)
+                        y_axis_max = max(np.nanmax(y_vals),1e-99)
                     elif periodogram == False:
                         x_vals = pixel_list[k].time.value
                         y_vals = pixel_list[k].flux.value

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1282,7 +1282,7 @@ class TargetPixelFile(object):
                         x_axis_max = np.nanmax(x_vals)
                         y_axis_min = 0
                         y_axis_max = max(np.nanmax(y_vals),1e-99)
-                    elif not periodogram:
+                    else:
                         x_vals = pixel_list[k].time.value
                         y_vals = pixel_list[k].flux.value
                         y_val_range = np.nanmax(y_vals) - np.nanmin(y_vals)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1208,7 +1208,7 @@ class TargetPixelFile(object):
             style = MPLSTYLE 
         
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.simplefilter("ignore", category=(RuntimeWarning, LightkurveWarning))
 
             # get an aperture mask for each pixel
             masks = np.zeros((self.shape[1]*self.shape[2], self.shape[1], self.shape[2]), dtype='bool')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1218,7 +1218,7 @@ class TargetPixelFile(object):
                 lc_norm = lc.normalize().remove_outliers()  
                 if periodogram == True:
                     try:
-                        pixel_list.append(lc_norm.to_periodogram())
+                        pixel_list.append(lc_norm.to_periodogram(**kwargs))
                     except IndexError:
                         pixel_list.append(None)
                 else:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1221,7 +1221,7 @@ class TargetPixelFile(object):
 
                 lc = self.to_lightcurve(aperture_mask=masks[j])
 
-                if normalize: # overrides corrector function
+                if normalize or corrector_func is None: # overrides corrector function
                     corrector_func = lambda x:x.normalize().remove_outliers()
                     lc_corr = corrector_func(lc)
                 elif corrector_func == None:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1221,7 +1221,7 @@ class TargetPixelFile(object):
 
                 lc = self.to_lightcurve(aperture_mask=masks[j])
 
-                if normalize or corrector_func is None: # overrides corrector function
+                if normalize or corrector_func is None: # normalize overrides corrector function
                     corrector_func = lambda x:x.normalize().remove_outliers()
                     lc_corr = corrector_func(lc)
                 else:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1234,6 +1234,8 @@ class TargetPixelFile(object):
                             pixel_list.append(lc)
 
         mask = self._parse_aperture_mask(aperture_mask)
+        tpf_plot = plt.imshow(self.flux[0])
+        plt.close()
 
         with plt.style.context(style):
             if title is None:
@@ -1254,7 +1256,6 @@ class TargetPixelFile(object):
                         ax.set(title=title, xlabel='Time', ylabel='Flux')
 
             gs = gridspec.GridSpec(self.shape[1], self.shape[2], wspace=0.01, hspace=0.01)
-            tpf_plot = plt.imshow(self.flux[0]) # only used if show_flux = True
 
             for k in range(self.shape[1]*self.shape[2]):
                 if pixel_list[k]:
@@ -1279,7 +1280,7 @@ class TargetPixelFile(object):
                     no_mask = False
                     if aperture_mask == 'all' or aperture_mask == None:
                         no_mask = True
-                        
+
                     if mask[x,y] == True and no_mask == False:
                         with plt.rc_context(rc={"axes.linewidth":2, "axes.edgecolor":'red'}):
                             gax = fig.add_subplot(gs[self.shape[1] - x - 1,y])
@@ -1299,6 +1300,8 @@ class TargetPixelFile(object):
                     gax.set_yticklabels('')
                     gax.set_xticks([])
                     gax.set_yticks([])
+
+            fig.set_size_inches((y*1.5,x*1.5))
 
         return ax
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1288,8 +1288,8 @@ class TargetPixelFile(object):
                         y_val_range = np.nanmax(y_vals) - np.nanmin(y_vals)
                         x_axis_min = np.nanmin(x_vals)
                         x_axis_max = np.nanmax(x_vals)
-                        y_axis_min = np.nanmin(y_vals) - 0.05*y_val_range
-                        y_axis_max = np.nanmax(y_vals) + 0.05*y_val_range
+                        y_axis_min = np.nanmin(y_vals) - 0.05*max(y_val_range, 0.1)
+                        y_axis_max = np.nanmax(y_vals) + 0.05*max(y_val_range, 0.1)
 
                     no_mask = False
                     if aperture_mask == 'all' or aperture_mask == None:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1290,9 +1290,15 @@ class TargetPixelFile(object):
 
                     if show_flux == True:
                         gax.set_facecolor(tpf_plot.cmap(tpf_plot.norm(self.flux[0,x,y])))
-                        gax.plot(x_vals, y_vals, 'w.', ms=0.5)
+                        if periodogram == True:
+                            gax.plot(x_vals, y_vals, 'w-', lw=0.5)
+                        elif periodogram == False:
+                            gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     else:
-                        gax.plot(x_vals, y_vals, 'k.', ms=0.5)
+                        if periodogram == True:
+                            gax.plot(x_vals, y_vals, 'w-', lw=0.5)
+                        elif periodogram == False:
+                            gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     
                     gax.set_xlim(x_axis_min, x_axis_max)
                     gax.set_ylim(y_axis_min, y_axis_max)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1256,13 +1256,6 @@ class TargetPixelFile(object):
                 if pixel_list[k]:
                     x, y = np.unravel_index(k, (self.shape[1], self.shape[2]))
 
-                    if periodogram:
-                        x_vals = pixel_list[k].frequency.value
-                        y_vals = pixel_list[k].power.value
-                    else:
-                        x_vals = pixel_list[k].time.value
-                        y_vals = pixel_list[k].flux.value
-
                     # Highlight aperture mask in red
                     if aperture_mask is not None and mask[x,y]:
                         rc = {"axes.linewidth": 2, "axes.edgecolor": 'red'}
@@ -1271,18 +1264,23 @@ class TargetPixelFile(object):
                     with plt.rc_context(rc=rc):
                         gax = fig.add_subplot(gs[self.shape[1] - x - 1, y])
 
+                    # Determine background and foreground color
                     if show_flux:
                         gax.set_facecolor(cmap(norm(self.flux.value[0,x,y])))
-                        if periodogram:
-                            gax.plot(x_vals, y_vals, 'w-', lw=0.5)
-                        else:
-                            gax.plot(x_vals, y_vals, 'w.', ms=0.5)
+                        markercolor = "white"
                     else:
-                        if periodogram:
-                            gax.plot(x_vals, y_vals, 'k-', lw=0.5)
-                        else:
-                            gax.plot(x_vals, y_vals, 'k.', ms=0.5)
-                    
+                        markercolor = "black"
+
+                    # Plot flux or periodogram
+                    if periodogram:
+                        gax.plot(pixel_list[k].frequency.value,
+                                 pixel_list[k].power.value,
+                                 marker='None', color=markercolor, lw=0.5)
+                    else:
+                        gax.plot(pixel_list[k].time.value,
+                                 pixel_list[k].flux.value,
+                                 marker='.', color=markercolor, ms=0.5, lw=0)
+
                     gax.margins(y=.1, x=0)
                     gax.set_xticklabels('')
                     gax.set_yticklabels('')

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1234,7 +1234,7 @@ mask = self._parse_aperture_mask(aperture_mask)
 
         with plt.style.context(style):
             if title is None:
-                title = 'Target ID: {}, Quarter: {}'.format(self.targetid, self.quarter)
+                title = f'Target ID: {self.targetid}'
 
             fig = plt.figure()
             if ax == None:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1276,7 +1276,11 @@ class TargetPixelFile(object):
                         y_axis_min = np.nanmin(y_vals) - 0.05*y_val_range
                         y_axis_max = np.nanmax(y_vals) + 0.05*y_val_range
 
-                    if mask[x,y] == True:
+                    no_mask = False
+                    if aperture_mask == 'all' or aperture_mask == None:
+                        no_mask = True
+                        
+                    if mask[x,y] == True and no_mask == False:
                         with plt.rc_context(rc={"axes.linewidth":2, "axes.edgecolor":'red'}):
                             gax = fig.add_subplot(gs[self.shape[1] - x - 1,y])
                     else:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1179,7 +1179,7 @@ class TargetPixelFile(object):
         ax : `~matplotlib.axes.Axes`
             A matplotlib axes object to plot into. If no axes is provided,
             a new one will be generated.
-        normalized : bool
+        normalize : bool
             Default: False; if True, the normalized light curves will be plotted.
         periodogram : bool
             Default: False; if True, periodograms will be plotted, using normalized light curves.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1221,7 +1221,7 @@ class TargetPixelFile(object):
 
                 lc = self.to_lightcurve(aperture_mask=masks[j])
 
-                if normalize == True: # overrides corrector function
+                if normalize: # overrides corrector function
                     corrector_func = lambda x:x.normalize().remove_outliers()
                     lc_corr = corrector_func(lc)
                 elif corrector_func == None:
@@ -1230,18 +1230,18 @@ class TargetPixelFile(object):
                 else:
                     lc_corr = corrector_func(lc)
 
-                if periodogram == True:
+                if periodogram:
                     try:
                         pixel_list.append(lc_corr.to_periodogram(**kwargs))
                     except IndexError:
                         pixel_list.append(None)
                 else:
-                    if normalize == True:
+                    if normalize:
                         if len(lc_corr.remove_nans().flux) == 0:
                             pixel_list.append(None)
                         else:
                             pixel_list.append(lc_corr)
-                    elif normalize == False:
+                    elif not normalize:
                         if len(lc.remove_nans().flux) == 0:
                             pixel_list.append(None)
                         else:
@@ -1261,10 +1261,10 @@ class TargetPixelFile(object):
                 ax.get_xaxis().set_ticks([])
                 ax.get_yaxis().set_ticks([])
 
-                if periodogram == True:
+                if periodogram:
                     ax.set(title=title, xlabel='Frequency', ylabel='Power')
                 else:
-                    if normalize == True:
+                    if normalize:
                         ax.set(title=title, xlabel='Time', ylabel='Normalized Flux')
                     else:
                         ax.set(title=title, xlabel='Time', ylabel='Flux')
@@ -1275,14 +1275,14 @@ class TargetPixelFile(object):
                 if pixel_list[k]:
                     x, y = np.unravel_index(k, (self.shape[1], self.shape[2]))
 
-                    if periodogram == True:
+                    if periodogram:
                         x_vals = pixel_list[k].frequency.value
                         y_vals = pixel_list[k].power.value
                         x_axis_min = 0
                         x_axis_max = np.nanmax(x_vals)
                         y_axis_min = 0
                         y_axis_max = max(np.nanmax(y_vals),1e-99)
-                    elif periodogram == False:
+                    elif not periodogram:
                         x_vals = pixel_list[k].time.value
                         y_vals = pixel_list[k].flux.value
                         y_val_range = np.nanmax(y_vals) - np.nanmin(y_vals)
@@ -1292,26 +1292,26 @@ class TargetPixelFile(object):
                         y_axis_max = np.nanmax(y_vals) + 0.05*max(y_val_range, 0.1)
 
                     no_mask = False
-                    if aperture_mask == 'all' or aperture_mask == None:
+                    if len(np.unique(mask)) == 1:
                         no_mask = True
 
-                    if mask[x,y] == True and no_mask == False:
+                    if mask[x,y] and not no_mask:
                         with plt.rc_context(rc={"axes.linewidth":2, "axes.edgecolor":'red'}):
                             gax = fig.add_subplot(gs[self.shape[1] - x - 1,y])
                     else:
                         with plt.rc_context(rc={"axes.linewidth":1}):
                             gax = fig.add_subplot(gs[self.shape[1] - x - 1,y])
 
-                    if show_flux == True:
+                    if show_flux:
                         gax.set_facecolor(tpf_plot.cmap(tpf_plot.norm(self.flux[0,x,y])))
-                        if periodogram == True:
+                        if periodogram:
                             gax.plot(x_vals, y_vals, 'w-', lw=0.5)
-                        elif periodogram == False:
+                        elif not periodogram:
                             gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     else:
-                        if periodogram == True:
+                        if periodogram:
                             gax.plot(x_vals, y_vals, 'w-', lw=0.5)
-                        elif periodogram == False:
+                        elif not periodogram:
                             gax.plot(x_vals, y_vals, 'w.', ms=0.5)
                     
                     gax.set_xlim(x_axis_min, x_axis_max)

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1230,14 +1230,7 @@ class TargetPixelFile(object):
                         else:
                             pixel_list.append(lc)
 
-        if aperture_mask == 'pipeline':
-            mask = self.pipeline_mask
-        elif aperture_mask == 'threshold':
-            mask = self.create_threshold_mask(**kwargs)
-        elif aperture_mask == 'all' or aperture_mask == None:
-            mask = np.zeros((self.shape[1], self.shape[2]), dtype='bool')
-        else:
-            mask = aperture_mask
+mask = self._parse_aperture_mask(aperture_mask)
 
         with plt.style.context(style):
             if title is None:

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -619,14 +619,13 @@ def test_get_header():
         tpf.header
 
 def test_plot_pixels():
-    tpfs = [KeplerTargetPixelFile(filename_tpf_one_center), TessTargetPixelFile(filename_tpf_one_center)]
-    for tpf in tpfs:
-        tpf.plot_pixels()
-        tpf.plot_pixels(normalize=True)
-        tpf.plot_pixels(periodogram=True)
-        tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
-        tpf.plot_pixels(aperture_mask='all')
-        # tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
-        # tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
-        tpf.plot_pixels(show_flux=True)
+    tpf = KeplerTargetPixelFile(filename_tpf_one_center)
+    tpf.plot_pixels()
+    tpf.plot_pixels(normalize=True)
+    tpf.plot_pixels(periodogram=True)
+    tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
+    tpf.plot_pixels(aperture_mask='all')
+    # tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
+    # tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
+    tpf.plot_pixels(show_flux=True)
     plt.close('all')

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -625,7 +625,7 @@ def test_plot_pixels():
     tpf.plot_pixels(periodogram=True)
     tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
     tpf.plot_pixels(aperture_mask='all')
-    # tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
-    # tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
+    tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
+    tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
     tpf.plot_pixels(show_flux=True)
     plt.close('all')

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -625,7 +625,8 @@ def test_plot_pixels():
     tpf.plot_pixels(periodogram=True)
     tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
     tpf.plot_pixels(aperture_mask='all')
-    tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
-    tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
+    tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) 
+    tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) 
     tpf.plot_pixels(show_flux=True)
+    tpf.plot_pixels(corrector_func=lambda x:x)
     plt.close('all')

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -617,3 +617,16 @@ def test_get_header():
     # ``tpf.header`` is deprecated
     with pytest.warns(LightkurveDeprecationWarning, match='deprecated'):
         tpf.header
+
+def test_plot_pixels():
+    tpfs = [KeplerTargetPixelFile(filename_tpf_one_center), TessTargetPixelFile(filename_tpf_one_center)]
+    for tpf in tpfs:
+        tpf.plot_pixels()
+        tpf.plot_pixels(normalize=True)
+        tpf.plot_pixels(periodogram=True)
+        tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
+        tpf.plot_pixels(aperture_mask='all')
+        # tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) # fails - to look into
+        # tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) # fails - to look into
+        tpf.plot_pixels(show_flux=True)
+    plt.close('all')


### PR DESCRIPTION
Hi all,

In this PR, I'd like to introduce the `inspect_pixels()` function for Lightkurve TPFs. Modelled after [this old script](https://github.com/astrobel/chancealignments2/blob/master/4_pixels.py), `inspect_pixels()` produces a plot displaying either the light curves in each pixel, or their associated periodograms. The plots are displayed such that the pixels align with what you'd see using `interact()`.

Here's an example plot, showing the normalised light curves for KIC 2437317, as a result of this line of code:

```tpf.inspect_pixels(normalized=True, periodogram=False, aperture_mask='threshold', threshold=2)```

![image](https://user-images.githubusercontent.com/15132789/86306133-cc5bd080-bc56-11ea-9545-464b59bb712b.png)

Note also that the function plots an aperture mask, whether pipeline, threshold, or user-generated, and can take a threshold value as a kwarg.

There are still some things that need to be improved/tested, and I'd appreciate anyone's feedback & input:
- The pixel size to figure size ratio is fine for regular TPFs, but what about bright/saturated stars which have large TPFs?
- At the moment, the periodogram version takes a very long time to run. Any ideas for how to trim that down, or if it's possible?
- The normalized light curves often retain some long-term trends, making the periodograms slightly less useful at the moment.
- In my original version of this function, users have the option to limit the scale of the periodogram, so for example you might only want to see the first 10% of the frequency range up to the Nyquist frequency. Would people be interested in seeing that implemented here?

Thanks!