### PR TITLE
Add check on uniform frequency spacing to ACF2D seismology estimators (Fixed #774)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,10 @@
   methods to default to the ``teff`` value in the meta data. [#766]
 
 - Added the ``TargetPixelFile.plot_pixels()`` method to plot light curves
-  and periodograms for each individual pixel in a TPF. [#771] 
+  and periodograms for each individual pixel in a TPF. [#771]
+
+- Added an error message to ``estimate_numax()`` or ``estimate_deltanu()`` if
+  the underlying periodogram does not have uniformly-spaced frequencies. [#780]
 
 
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -544,8 +544,6 @@ class Seismology(object):
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
 
-
-            print("CODE IS HERE")
             fs = np.mean(np.diff(self.periodogram.frequency))
             if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
                 raise ValueError("the ACF 2D method requires that the periodogram "

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -592,7 +592,7 @@ class Seismology(object):
 
             result = estimate_deltanu_acf2d(self.periodogram, numax=numax)
 
-        self.deltanu = resultq
+        self.deltanu = result
         return result
 
     def diagnose_deltanu(self, deltanu=None):

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -545,7 +545,7 @@ class Seismology(object):
             from .numax_estimators import estimate_numax_acf2d
 
             fs = np.mean(np.diff(self.periodogram.frequency))
-            if not np.isclose(np.median(np.diff(self.periodogram.append=frequency.value)), fs.value):
+            if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -547,7 +547,7 @@ class Seismology(object):
             # Detect whether the frequency grid is evenly-spaced
             # by verifying that the first differences are all equal
             freqdiff = np.diff(self.periodogram.frequency.value)
-            if not np.allclose(freqdiff[0], freqdiff)
+            if not np.allclose(freqdiff[0], freqdiff):
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 
@@ -590,7 +590,7 @@ class Seismology(object):
             # Detect whether the frequency grid is evenly-spaced
             # by verifying that the first differences are all equal
             freqdiff = np.diff(self.periodogram.frequency.value)
-            if not np.allclose(freqdiff[0], freqdiff)
+            if not np.allclose(freqdiff[0], freqdiff):
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -544,6 +544,8 @@ class Seismology(object):
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
 
+
+            print("CODE IS HERE")
             fs = np.mean(np.diff(self.periodogram.frequency))
             if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
                 raise ValueError("the ACF 2D method requires that the periodogram "

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -543,14 +543,6 @@ class Seismology(object):
         method = validate_method(method, supported_methods=["acf2d"])
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
-
-            # Detect whether the frequency grid is evenly-spaced
-            # by verifying that the first differences are all equal
-            freqdiff = np.diff(self.periodogram.frequency.value)
-            if not np.allclose(freqdiff[0], freqdiff):
-                raise ValueError("the ACF 2D method requires that the periodogram "
-                                 "has a grid of uniformly spaced frequencies.")
-
             result = estimate_numax_acf2d(self.periodogram, **kwargs)
         self.numax = result
         return result
@@ -583,19 +575,9 @@ class Seismology(object):
         """
         method = validate_method(method, supported_methods=["acf2d"])
         numax = self._validate_numax(numax)
-
         if method == "acf2d":
             from .deltanu_estimators import estimate_deltanu_acf2d
-
-            # Detect whether the frequency grid is evenly-spaced
-            # by verifying that the first differences are all equal
-            freqdiff = np.diff(self.periodogram.frequency.value)
-            if not np.allclose(freqdiff[0], freqdiff):
-                raise ValueError("the ACF 2D method requires that the periodogram "
-                                 "has a grid of uniformly spaced frequencies.")
-
             result = estimate_deltanu_acf2d(self.periodogram, numax=numax)
-
         self.deltanu = result
         return result
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -544,8 +544,10 @@ class Seismology(object):
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
 
-            fs = np.mean(np.diff(self.periodogram.frequency))
-            if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
+            # Detect whether the frequency grid is evenly-spaced
+            # by verifying that the first differences are all equal
+            freqdiff = np.diff(self.periodogram.frequency.value)
+            if not np.allclose(freqdiff[0], freqdiff)
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 
@@ -585,8 +587,10 @@ class Seismology(object):
         if method == "acf2d":
             from .deltanu_estimators import estimate_deltanu_acf2d
 
-            fs = np.mean(np.diff(self.periodogram.frequency))
-            if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
+            # Detect whether the frequency grid is evenly-spaced
+            # by verifying that the first differences are all equal
+            freqdiff = np.diff(self.periodogram.frequency.value)
+            if not np.allclose(freqdiff[0], freqdiff)
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -544,8 +544,8 @@ class Seismology(object):
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
 
-            fs = np.mean(np.diff(self.periodogramfrequency))
-            if not np.isclose(np.median(np.diff(self.periodogramfrequency.value)), fs.value):
+            fs = np.mean(np.diff(self.periodogram.frequency))
+            if not np.isclose(np.median(np.diff(self.periodogram.append=frequency.value)), fs.value):
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 
@@ -585,8 +585,8 @@ class Seismology(object):
         if method == "acf2d":
             from .deltanu_estimators import estimate_deltanu_acf2d
 
-            fs = np.mean(np.diff(self.periodogramfrequency))
-            if not np.isclose(np.median(np.diff(self.periodogramfrequency.value)), fs.value):
+            fs = np.mean(np.diff(self.periodogram.frequency))
+            if not np.isclose(np.median(np.diff(self.periodogram.frequency.value)), fs.value):
                 raise ValueError("the ACF 2D method requires that the periodogram "
                                  "has a grid of uniformly spaced frequencies.")
 

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -543,6 +543,12 @@ class Seismology(object):
         method = validate_method(method, supported_methods=["acf2d"])
         if method == "acf2d":
             from .numax_estimators import estimate_numax_acf2d
+
+            fs = np.mean(np.diff(self.periodogramfrequency))
+            if not np.isclose(np.median(np.diff(self.periodogramfrequency.value)), fs.value):
+                raise ValueError("the ACF 2D method requires that the periodogram "
+                                 "has a grid of uniformly spaced frequencies.")
+
             result = estimate_numax_acf2d(self.periodogram, **kwargs)
         self.numax = result
         return result
@@ -578,9 +584,15 @@ class Seismology(object):
 
         if method == "acf2d":
             from .deltanu_estimators import estimate_deltanu_acf2d
+
+            fs = np.mean(np.diff(self.periodogramfrequency))
+            if not np.isclose(np.median(np.diff(self.periodogramfrequency.value)), fs.value):
+                raise ValueError("the ACF 2D method requires that the periodogram "
+                                 "has a grid of uniformly spaced frequencies.")
+
             result = estimate_deltanu_acf2d(self.periodogram, numax=numax)
 
-        self.deltanu = result
+        self.deltanu = resultq
         return result
 
     def diagnose_deltanu(self, deltanu=None):

--- a/lightkurve/seismology/deltanu_estimators.py
+++ b/lightkurve/seismology/deltanu_estimators.py
@@ -77,6 +77,11 @@ def estimate_deltanu_acf2d(periodogram, numax):
         The average large frequency spacing of the seismic oscillation modes.
         In units of the periodogram frequency attribute.
     """
+    # The frequency grid must be evenly spaced
+    if not periodogram._is_evenly_spaced():
+        raise ValueError("the ACF 2D method requires that the periodogram "
+                         "has a grid of uniformly spaced frequencies.")
+
     # Run some checks on the passed in numaxs
     # Ensure input numax is in the correct units
     numax = u.Quantity(numax, periodogram.frequency.unit)

--- a/lightkurve/seismology/numax_estimators.py
+++ b/lightkurve/seismology/numax_estimators.py
@@ -89,6 +89,11 @@ def estimate_numax_acf2d(periodogram, numaxs=None, window_width=None, spacing=No
         The numax of the periodogram. In the units of the periodogram object
         frequency.
     """
+    # Detect whether the frequency grid is evenly-spaced
+    if not periodogram._is_evenly_spaced():
+        raise ValueError("the ACF 2D method requires that the periodogram "
+                         "has a grid of uniformly spaced frequencies.")
+
     # Calculate the window_width size
 
     #C: What is this doing? Why have these values been picked? This function is slow.

--- a/lightkurve/seismology/tests/test_butler.py
+++ b/lightkurve/seismology/tests/test_butler.py
@@ -70,6 +70,14 @@ def test_estimate_numax_basics():
     nmxday = u.Quantity(true_numax*u.microhertz, 1/u.day)
     assert(np.isclose(nmxday, numax, atol=.1*nmxday))
 
+    # Assert numax estimator fails when frequqencies are not uniform
+    f, p, true_numax, _ = generate_test_spectrum()
+    f += np.random.uniform(size=len(f))
+    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+
+    with pytest.raises(ValueError):
+        numax = snr.to_seismology().estimate_numax()
+
 
 def test_estimate_numax_kwargs():
     """Test if we can estimate a numax using its various keyword arguments."""
@@ -196,6 +204,14 @@ def test_estimate_deltanu_basics():
     deltanu = butler.estimate_deltanu()
     deltanuday = u.Quantity(true_deltanu*u.microhertz, 1/u.day)
     assert(np.isclose(deltanuday.value, deltanu.value, atol=.25*deltanuday.value))
+
+    # Assert deltanu estimator fails when frequqencies are not uniform
+    f, p, true_numax, _ = generate_test_spectrum()
+    f += np.random.uniform(size=len(f))
+    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+
+    with pytest.raises(ValueError):
+        deltanu = snr.to_seismology().estimate_deltanu()
 
 
 def test_estimate_deltanu_kwargs():

--- a/lightkurve/seismology/tests/test_butler.py
+++ b/lightkurve/seismology/tests/test_butler.py
@@ -75,8 +75,9 @@ def test_estimate_numax_basics():
     f += np.random.uniform(size=len(f))
     snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         numax = snr.to_seismology().estimate_numax()
+    assert "uniformly spaced" in str(exc)
 
 
 def test_estimate_numax_kwargs():
@@ -210,8 +211,9 @@ def test_estimate_deltanu_basics():
     f += np.random.uniform(size=len(f))
     snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         deltanu = snr.to_seismology().estimate_deltanu(numax=100)
+    assert "uniformly spaced" in str(exc)
 
 
 def test_estimate_deltanu_kwargs():

--- a/lightkurve/seismology/tests/test_butler.py
+++ b/lightkurve/seismology/tests/test_butler.py
@@ -77,8 +77,7 @@ def test_estimate_numax_basics():
 
     with pytest.raises(ValueError) as exc:
         numax = snr.to_seismology().estimate_numax()
-    assert "uniformly spaced" in str(exc)
-
+    assert "uniformly spaced" in str(exc.value)
 
 def test_estimate_numax_kwargs():
     """Test if we can estimate a numax using its various keyword arguments."""
@@ -213,8 +212,7 @@ def test_estimate_deltanu_basics():
 
     with pytest.raises(ValueError) as exc:
         deltanu = snr.to_seismology().estimate_deltanu(numax=100)
-    assert "uniformly spaced" in str(exc)
-
+    assert "uniformly spaced" in str(exc.value)
 
 def test_estimate_deltanu_kwargs():
     """Test if we can estimate a deltanu using its various keyword arguments

--- a/lightkurve/seismology/tests/test_butler.py
+++ b/lightkurve/seismology/tests/test_butler.py
@@ -211,7 +211,7 @@ def test_estimate_deltanu_basics():
     snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
 
     with pytest.raises(ValueError):
-        deltanu = snr.to_seismology().estimate_deltanu()
+        deltanu = snr.to_seismology().estimate_deltanu(numax=100)
 
 
 def test_estimate_deltanu_kwargs():


### PR DESCRIPTION
I've added a check when `estimate_numax()` or `estimate_deltanu()` are called that throws a `ValueError` if the underlying periodogram does not have uniformly spaced frequencies. An identical check was already in place in other `periodogram` functions that required uniform spacing, and not including it here was an oversight (so I'm glad it's now fixed!). 

