### PR TITLE
Clarify masking in `RegressionCorrector`

### DIFF
--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -397,8 +397,8 @@ class PLDCorrector(RegressionCorrector):
                                             s=10, label='Outliers', ax=ax)
             if self.user_mask is not None:
                 clc[~self.user_mask].scatter(normalize=False, c='dodgerblue',
-                                                marker='x', s=10, label='Masked',
-                                                ax=ax)
+                                             marker='x', s=10, label='Masked',
+                                             ax=ax)
             clc.plot(normalize=False, label='Corrected', ax=ax, c='k')
         return axs
 

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -393,12 +393,11 @@ class PLDCorrector(RegressionCorrector):
             # Plot final corrected light curve with outliers marked
             ax = axs[2]
             self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='Original')
-            clc[~self.cadence_mask].scatter(normalize=False, c='r', marker='x',
-                                            s=10, label='Outliers', ax=ax)
-            if self.user_mask is not None:
-                clc[~self.user_mask].scatter(normalize=False, c='dodgerblue',
-                                             marker='x', s=10, label='Masked',
-                                             ax=ax)
+            clc[self.outlier_mask].scatter(normalize=False, c='r', marker='x',
+                                            s=10, label='outlier_mask', ax=ax)
+            clc[~self.cadence_mask].scatter(normalize=False, c='dodgerblue',
+                                            marker='x', s=10, label='~cadence_mask',
+                                            ax=ax)
             clc.plot(normalize=False, label='Corrected', ax=ax, c='k')
         return axs
 

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -395,6 +395,10 @@ class PLDCorrector(RegressionCorrector):
             self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='Original')
             clc[~self.cadence_mask].scatter(normalize=False, c='r', marker='x',
                                             s=10, label='Outliers', ax=ax)
+            if self.user_mask is not None:
+                clc[~self.user_mask].scatter(normalize=False, c='dodgerblue',
+                                                marker='x', s=10, label='Masked',
+                                                ax=ax)
             clc.plot(normalize=False, label='Corrected', ax=ax, c='k')
         return axs
 

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -392,13 +392,13 @@ class PLDCorrector(RegressionCorrector):
 
             # Plot final corrected light curve with outliers marked
             ax = axs[2]
-            self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='Original')
+            self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='original')
             clc[self.outlier_mask].scatter(normalize=False, c='r', marker='x',
                                             s=10, label='outlier_mask', ax=ax)
             clc[~self.cadence_mask].scatter(normalize=False, c='dodgerblue',
                                             marker='x', s=10, label='~cadence_mask',
                                             ax=ax)
-            clc.plot(normalize=False, label='Corrected', ax=ax, c='k')
+            clc.plot(normalize=False, label='corrected', ax=ax, c='k')
         return axs
 
     def diagnose_masks(self):

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -211,8 +211,10 @@ class RegressionCorrector(Corrector):
 
         if cadence_mask is None:
             cadence_mask = np.ones(len(self.lc.time), bool)
+            self.user_mask = None
         else:
             cadence_mask = np.copy(cadence_mask)
+            self.user_mask = cadence_mask
 
         # Prepare for iterative masking of residuals
         clean_cadences = np.ones_like(cadence_mask)

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -294,7 +294,7 @@ class RegressionCorrector(Corrector):
                 (self.diagnostic_lightcurves[key] - np.median(self.diagnostic_lightcurves[key].flux) + np.median(self.lc.flux)).plot(ax=ax)
             ax.set_xlabel('')
             ax = axs[1]
-            self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='Original')
+            self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='original')
             self.corrected_lc[self.outlier_mask].scatter(
                                             normalize=False, c='r', marker='x',
                                             s=10, label='outlier_mask', ax=ax)
@@ -302,7 +302,7 @@ class RegressionCorrector(Corrector):
                                             normalize=False, c='dodgerblue',
                                             marker='x', s=10, label='~cadence_mask',
                                             ax=ax)
-            self.corrected_lc.plot(normalize=False, label='Corrected', ax=ax, c='k')
+            self.corrected_lc.plot(normalize=False, label='corrected', ax=ax, c='k')
         return axs
 
     def diagnose(self):

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -301,6 +301,11 @@ class RegressionCorrector(Corrector):
             self.corrected_lc[~self.cadence_mask].scatter(
                                             normalize=False, c='r', marker='x',
                                             s=10, label='Outliers', ax=ax)
+            if self.user_mask is not None:
+                self.corrected_lc[~self.user_mask].scatter(
+                                             normalize=False, c='dodgerblue',
+                                             marker='x', s=10, label='Masked',
+                                             ax=ax)
             self.corrected_lc.plot(normalize=False, label='Corrected', ax=ax, c='k')
         return axs
 


### PR DESCRIPTION
Currently, `RegressionCorrector` lumps the user-input `cadence_mask` together with the outlier mask. This makes the diagnostic plot a little confusing, because cadences included in the `cadence_mask` will be labeled as outliers. This super simple PR introduces a new parameter of `RegressionCorrector` called `user_mask` (or `input_mask`?) to differentiate between the two distinct sets of cadences.

### Before:
```python
tpf = lk.search_targetpixelfile('K2-199')[0].download()
pld = tpf.to_corrector('pld')
pld.correct(cadence_mask=transit_mask)
pld.diagnose()
```
![before](https://user-images.githubusercontent.com/17130840/88716303-97f2fd00-d0ba-11ea-887a-e5e251b61507.png)

### After:
```python
tpf = lk.search_targetpixelfile('K2-199')[0].download()
pld = tpf.to_corrector('pld')
pld.correct(cadence_mask=transit_mask)
pld.diagnose()
```
![after](https://user-images.githubusercontent.com/17130840/88716373-ae995400-d0ba-11ea-806a-75caf130bc6a.png)

The `cadence_mask` parameter remains unchanged and it will still include both outliers and masked points, so this change really only applies in the diagnostic plotting step.