### PR TITLE
Use `pip install .` instead of `pip install -e .` in the continuous integration

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies]
+        name: [3.6, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies, 3.9]
         include:
           - name: 3.6
             python-version: 3.6
@@ -27,7 +27,7 @@ jobs:
             pytest-command: pytest
           - name: 3.7
             python-version: 3.7
-            pip-command: pip install -e .[all,test]
+            pip-command: python setup.py install  # also try setup.py for coverage
             pytest-command: pytest
           - name: 3.8-remote-data
             python-version: 3.8
@@ -36,6 +36,10 @@ jobs:
           - name: 3.8-no-optional-dependencies
             python-version: 3.8
             pip-command: pip install -e .[test]
+            pytest-command: pytest
+          - name: 3.9
+            python-version: 3.9
+            pip-command: pip install -e .[all,test]
             pytest-command: pytest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -23,19 +23,19 @@ jobs:
         include:
           - name: 3.6
             python-version: 3.6
-            pip-command: pip install -e .[all,test]
+            pip-command: pip install .[all,test]
             pytest-command: pytest
           - name: 3.7
             python-version: 3.7
-            pip-command: python setup.py install  # also try setup.py for coverage
+            pip-command: pip install .[all,test]
             pytest-command: pytest
           - name: 3.8-remote-data
             python-version: 3.8
-            pip-command: pip install -e .[all,test]
+            pip-command: pip install .[all,test]
             pytest-command: pytest --remote-data --doctest-modules
           - name: 3.8-no-optional-dependencies
             python-version: 3.8
-            pip-command: pip install -e .[test]
+            pip-command: pip install .[test]
             pytest-command: pytest
     steps:
     - uses: actions/checkout@v1
@@ -68,7 +68,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -e .[test]
+        pip install .[test]
     - name: Test with pytest --remote-data
       run: |
         pytest --remote-data
@@ -88,7 +88,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -e .[all,test]
+        pip install .[all,test]
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies, 3.9]
+        name: [3.6, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies]
         include:
           - name: 3.6
             python-version: 3.6
@@ -36,10 +36,6 @@ jobs:
           - name: 3.8-no-optional-dependencies
             python-version: 3.8
             pip-command: pip install -e .[test]
-            pytest-command: pytest
-          - name: 3.9
-            python-version: 3.9
-            pip-command: pip install -e .[all,test]
             pytest-command: pytest
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,7 @@ with open('requirements.txt') as f:
 # 2. What dependencies required to run the unit tests? (i.e. `pytest --remote-data`)
 tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov', 'pytest-doctestplus', 'codacy-coverage']
 # 3. What dependencies are required for optional features?
-# `BoxLeastSquaresPeriodogram` requires astropy>=3.1.
 # `interact()` requires bokeh>=1.0, ipython.
-# `PLDCorrector` requires pybind11, celerite.
 extras_require = {"all":  ["bokeh>=1.0", "ipython"],
                   "test": tests_require}
 


### PR DESCRIPTION
We should properly install Lightkurve using `pip install .` when running the unit tests on GitHub actions.

Right now we symlink the package by calling `pip install -e .` before running the tests.  This led to installation issue #788 from going undetected.

This PR fixes the tests!