### PR TITLE
Ensure search functions return the correct target in a specific target search (fixes #718)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@
 - Added support for reading K2SFF and EVEREST community light curves via the
   `LightCurve.read()` and `search_lightcurve()` functions. [#739]
 
+- Modified the search functions such that exact mission target identifiers,
+  such as 'KIC 5112705' or 'TIC 261136679', only return products known under
+  those names, unless a search radius is specified. [#TBD]
+
 
 
 1.11.1 (2020-06-18)

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -55,7 +55,7 @@ class SearchResult(object):
                 self._add_columns()
 
     def _add_columns(self):
-        """Adds user-friendly ``idx`` and ``observation`` columns.
+        """Adds user-friendly index (``#``) column.
 
         These columns are not part of the MAST Portal API, but they make the
         display of search results much nicer in Lightkurve.
@@ -697,6 +697,10 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
         # At MAST, non-FFI Kepler pipeline products are known as "cube" products,
         # and non-FFI TESS pipeline products are listed as "timeseries".
         extra_query_criteria['dataproduct_type'] = ['cube', 'timeseries']
+    # Make sure `search_tesscut` always performs a cone search (i.e. always
+    # passed a radius value), because strict target name search does not apply.
+    if filetype.lower() == 'ffi' and radius is None:
+        radius = .0001 * u.arcsec
     observations = _query_mast(target, radius=radius,
                                project=mission,
                                provenance_name=provenance_name,
@@ -755,7 +759,8 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
             s = observations['sequence_number'][idx]
             # if the desired sector is available, add a row
             if s in np.atleast_1d(sector) or sector is None:
-                cutouts.append({'description': 'TESS FFI Cutout (sector {})'.format(s),
+                cutouts.append({'description': f'TESS FFI Cutout (sector {s})',
+                                'observation': f'TESS Sector {s}',
                                 'target_name': str(target),
                                 'targetid': str(target),
                                 'productFilename': 'TESSCut',

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -868,7 +868,8 @@ def _query_mast(target, radius=None,
                                            **query_criteria)
         # astroquery does not return distance if target_name is given;
         # we add it here so that the table returned always has this column.
-        obs['distance'] = 0.
+        if len(obs) > 0:
+            obs['distance'] = 0.
         return obs
 
     # Else, do a cone search using the MAST name resolver

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -310,5 +310,6 @@ def test_overlapping_targets_718():
 
 @pytest.mark.remote_data
 def test_tesscut_795():
-    """Regression test for #795."""
-    str(search_tesscut('KIC 8462852'))
+    """Regression test for #795: make sure the __repr__.of a TESSCut
+    SearchResult works."""
+    str(search_tesscut('KIC 8462852'))  # This raised a KeyError

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -222,9 +222,9 @@ def test_source_confusion():
     # When obtaining the TPF for target 6507433, @benmontet noticed that
     # a target 4 arcsec away was returned instead.
     # See https://github.com/KeplerGO/lightkurve/issues/148
-    desired_target = 6507433
+    desired_target = "KIC 6507433"
     tpf = search_targetpixelfile(desired_target, quarter=8).download()
-    assert tpf.targetid == desired_target
+    assert tpf.targetid == 6507433
 
 
 def test_empty_searchresult():
@@ -276,7 +276,7 @@ def test_corrupt_download_handling():
 def test_indexerror_631():
     """Regression test for #631; avoid IndexError."""
     # This previously triggered an exception:
-    result = search_lightcurve("KIC 8462852", sector=15)
+    result = search_lightcurve("KIC 8462852", sector=15, radius=1)
     assert len(result) == 1
 
 

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -290,3 +290,25 @@ def test_name_resolving_regression_764():
     c1 = MastClass().resolve_object(objectname="EPIC250105131")
     c2 = MastClass().resolve_object(objectname="EPIC 250105131")
     assert c1.separation(c2).to("arcsec").value < 0.1
+
+
+@pytest.mark.remote_data
+def test_overlapping_targets_718():
+    """Regression test for #718."""
+    # Searching for the following targets without radius should only return
+    # the requested targets, not their overlapping neighbors.
+    targets = ['KIC 5112705', 'KIC 10058374', 'KIC 5385723']
+    for target in targets:
+        search = search_lightcurve(target, quarter=11)
+        assert len(search) == 1
+        assert search.target_name[0] == f'kplr{target[4:].zfill(9)}'
+
+    # When using `radius=1` we should also retrieve the overlapping targets
+    search = search_lightcurve('KIC 5112705', quarter=11, radius=1*u.arcsec)
+    assert len(search) > 1
+
+
+@pytest.mark.remote_data
+def test_tesscut_795():
+    """Regression test for #795."""
+    str(search_tesscut('KIC 8462852'))


### PR DESCRIPTION
### Summary

This PR addresses the long-standing issue that searching data using a specific target identifier, e.g. `'KIC 5112705'`, sometimes returns data for *different* targets which happen to overlap with the requested target (e.g. see #718 for examples).

### Solution

This PR changes the behavior of the search function as follows:
* If a mission-specific target identifier string is passed, e.g. `KIC XXXXXXXXX`, `EPIC XXXXXXXXX`, or `TIC XXXXXXXXX`, the search functions will only return data products known under the corresponding `target_name` in the MAST Portal database.
* The only exception is if a search `radius` parameter is passed, in which case a cone search will be executed and any and all nearby or overlapping targets may be returned.

### Example

![source-confusion-fix](https://user-images.githubusercontent.com/817669/89462571-79c47700-d722-11ea-843e-8419b221d287.png)


(This PR also fixes the freshly-introduced bug #795.)