### PR TITLE
Periodogram now automatically removes nans from lightcurve

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1604,8 +1604,6 @@ class LightCurve(TimeSeries):
             from . import LombScarglePeriodogram
 
             if (~np.isfinite(self.flux)).any():
-                log.warning('Lightcurve contains NaN values.'
-                            'These are removed before creating the periodogram.')
                 return LombScarglePeriodogram.from_lightcurve(lc=self.remove_nans(), **kwargs)
             else:
                 return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1602,7 +1602,13 @@ class LightCurve(TimeSeries):
             return BoxLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
         else:
             from . import LombScarglePeriodogram
-            return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)
+
+            if (~np.isfinite(self.flux)).any():
+                log.warning('Lightcurve contains NaN values.'
+                            'These are removed before creating the periodogram.')
+                return LombScarglePeriodogram.from_lightcurve(lc=self.remove_nans(), **kwargs)
+            else:
+                return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)
 
     def to_seismology(self, **kwargs):
         """Returns a `~lightkurve.seismology.Seismology` object for estimating

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1602,11 +1602,7 @@ class LightCurve(TimeSeries):
             return BoxLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
         else:
             from . import LombScarglePeriodogram
-
-            if (~np.isfinite(self.flux)).any():
-                return LombScarglePeriodogram.from_lightcurve(lc=self.remove_nans(), **kwargs)
-            else:
-                return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)
+            return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)
 
     def to_seismology(self, **kwargs):
         """Returns a `~lightkurve.seismology.Seismology` object for estimating

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -725,7 +725,7 @@ class LombScarglePeriodogram(Periodogram):
         """
         # Input validation
         normalization = validate_method(normalization, ['psd', 'amplitude'])
-        if (~np.isfinite(lc.flux)).any():
+        if np.isnan(lc.flux).any():
             lc = lc.remove_nans()
             log.debug('Lightcurve contains NaN values.'
             'These are removed before creating the periodogram.')

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -767,10 +767,6 @@ class LombScarglePeriodogram(Periodogram):
             raise ValueError('You have input keyword arguments for both frequency and period. '
                              'Please only use one.')
 
-        if (~np.isfinite(lc.flux)).any():
-            raise ValueError('Lightcurve contains NaN values. Use lc.remove_nans()'
-                             ' to remove NaN values from a LightCurve.')
-
         time = lc.time.copy()
 
         # Approximate Nyquist Frequency and frequency bin width in terms of days

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -725,6 +725,10 @@ class LombScarglePeriodogram(Periodogram):
         """
         # Input validation
         normalization = validate_method(normalization, ['psd', 'amplitude'])
+        if (~np.isfinite(lc.flux)).any():
+            lc = lc.remove_nans()
+            log.debug('Lightcurve contains NaN values.'
+            'These are removed before creating the periodogram.')
 
         # Setting default frequency units
         if freq_unit is None:

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -728,7 +728,7 @@ class LombScarglePeriodogram(Periodogram):
         if np.isnan(lc.flux).any():
             lc = lc.remove_nans()
             log.debug('Lightcurve contains NaN values.'
-            'These are removed before creating the periodogram.')
+                      'These are removed before creating the periodogram.')
 
         # Setting default frequency units
         if freq_unit is None:

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -330,13 +330,6 @@ def test_error_messages():
     with pytest.raises(ValueError) as err:
         lc.to_periodogram(frequency=np.arange(10), period=np.arange(10))
 
-    # Don't accept NaNs
-    with pytest.raises(ValueError) as err:
-        lc_with_nans = lc.copy()
-        lc_with_nans.flux[0] = np.nan
-        lc_with_nans.to_periodogram()
-    assert('Lightcurve contains NaN values.' in err.value.args[0])
-
     # No unitless periodograms
     with pytest.raises(ValueError) as err:
         Periodogram([0], [1])

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -26,6 +26,8 @@ def test_periodogram_basics():
     pg.show_properties()
     pg.to_table()
     str(pg)
+    lc[400:500] = np.nan
+    pg = lc.to_periodogram()
 
 
 def test_periodogram_normalization():
@@ -329,6 +331,7 @@ def test_error_messages():
     # Can't specify periods and frequencies
     with pytest.raises(ValueError) as err:
         lc.to_periodogram(frequency=np.arange(10), period=np.arange(10))
+
 
     # No unitless periodograms
     with pytest.raises(ValueError) as err:


### PR DESCRIPTION
Following a discussion had on the development of a tutorial, I've updated the `LightCurve` and `Periodogram` classes so that the check for NaN values in the light curve is now checked in the `LightCurve.to_periodogram()` function, instead of the `Periodogram.from_lightcurve()` function. If there are NaN values present when `to_periodogram()` is called, the function removes them and logs a warning informing the user of what's happening.

