### PR TITLE
Move `DesignMatrix` validation to `RegressionCorrector.correct` to avoid confusing warning

### DIFF
--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -69,7 +69,6 @@ class DesignMatrix():
             prior_sigma = np.ones(len(df.T)) * np.inf
         self.prior_mu = np.atleast_1d(prior_mu)
         self.prior_sigma = np.atleast_1d(prior_sigma)
-        self.validate()
 
     @property
     def X(self):

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -209,6 +209,9 @@ class RegressionCorrector(Corrector):
         design_matrix_collection.validate()
         self.design_matrix_collection = design_matrix_collection
 
+        # Validate the design matrix. Emits a warning if the matrix has low rank.
+        self.design_matrix_collection.validate()
+
         if cadence_mask is None:
             self.cadence_mask = np.ones(len(self.lc.time), bool)
         else:

--- a/lightkurve/correctors/regressioncorrector.py
+++ b/lightkurve/correctors/regressioncorrector.py
@@ -206,11 +206,10 @@ class RegressionCorrector(Corrector):
                 design_matrix_collection = SparseDesignMatrixCollection([design_matrix_collection])
             elif isinstance(design_matrix_collection, DesignMatrix):
                 design_matrix_collection = DesignMatrixCollection([design_matrix_collection])
-        design_matrix_collection.validate()
-        self.design_matrix_collection = design_matrix_collection
 
         # Validate the design matrix. Emits a warning if the matrix has low rank.
-        self.design_matrix_collection.validate()
+        design_matrix_collection.validate()
+        self.design_matrix_collection = design_matrix_collection
 
         if cadence_mask is None:
             self.cadence_mask = np.ones(len(self.lc.time), bool)

--- a/lightkurve/correctors/tests/test_designmatrix.py
+++ b/lightkurve/correctors/tests/test_designmatrix.py
@@ -126,3 +126,4 @@ def test_designmatrix_rank():
         dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
                            'd': [1, 1, 1], 'e': [3, 4, 5]})
         assert dm.rank == 2
+        dm.validate(rank=True) # Should raise a warning

--- a/lightkurve/correctors/tests/test_sparsedesignmatrix.py
+++ b/lightkurve/correctors/tests/test_sparsedesignmatrix.py
@@ -133,6 +133,7 @@ def test_designmatrix_rank():
     with pytest.warns(LightkurveWarning, match='rank'):
         dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
                            'd': [1, 1, 1], 'e': [3, 4, 5]})
+        dm.validate(rank=True) # Should raise a warning
     dm = dm.to_sparse()
     assert dm.rank == 2
     with pytest.warns(LightkurveWarning, match='rank'):


### PR DESCRIPTION
Fixes #792. (thanks for pointing this out @rebekah9969!)

Super simple PR to move the `DesignMatrix` validation step to the `RegressionCorrector.correct` method. This also allows us to simplify the `PLDCorrector` by removing the `warnings.catch_warnings()` call.