### PR TITLE
Enable quality flags that are astropy Quality objected to be parsed by QualityFlags.decode

### DIFF
--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -66,6 +66,20 @@ def test_quality_flag_decoding_tess():
         == [flags[3][1], flags[4][1], flags[5][1]]
 
 
+def test_quality_flag_deconding_quantity_object():
+    """Can a QUALITY flag that is a astropy quantity object be parsed correctly"""
+    from astropy.units.quantity import Quantity
+    flags = list(TessQualityFlags.STRINGS.items())
+    for key, value in flags:
+        assert TessQualityFlags.decode(Quantity(key, dtype='int32'))[0] == value
+    # Can we recover combinations of flags?
+    assert TessQualityFlags.decode(Quantity(flags[5][0], dtype='int32') + \
+        Quantity(flags[7][0], dtype='int32')) == [flags[5][1], flags[7][1]]
+    assert TessQualityFlags.decode(Quantity(flags[3][0], dtype='int32') + \
+        Quantity(flags[4][0], dtype='int32') + Quantity(flags[5][0], dtype='int32')) \
+        == [flags[3][1], flags[4][1], flags[5][1]]
+
+
 def test_quality_mask():
     """Can we create a quality mask using KeplerQualityFlags?"""
     quality = np.array([0, 0, 1])

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from astropy.utils.data import download_file
 from astropy.coordinates import SkyCoord
+from astropy.units.quantity import Quantity
 import astropy.units as u
 from astropy.visualization import (PercentileInterval, ImageNormalize,
                                    SqrtStretch, LinearStretch)
@@ -34,16 +35,16 @@ class QualityFlags(object):
 
     @classmethod
     def decode(cls, quality):
-        """Converts a Kepler QUALITY value into a list of human-readable strings.
+        """Converts a QUALITY value into a list of human-readable strings.
 
         This function takes the QUALITY bitstring that can be found for each
-        cadence in Kepler/K2's pixel and light curve files and converts into
+        cadence in Kepler/K2/TESS' pixel and light curve files and converts into
         a list of human-readable strings explaining the flags raised (if any).
 
         Parameters
         ----------
         quality : int
-            Value from the 'QUALITY' column of a Kepler/K2 pixel or lightcurve file.
+            Value from the 'QUALITY' column of a Kepler/K2/TESS pixel or lightcurve file.
 
         Returns
         -------
@@ -51,6 +52,9 @@ class QualityFlags(object):
             List of human-readable strings giving a short description of the
             quality flags raised.  Returns an empty list if no flags raised.
         """
+        # If passed an astropy quantity object, get the value
+        if isinstance(quality, Quantity):
+            quality = quality.value
         result = []
         for flag in cls.STRINGS.keys():
             if quality & flag > 0:


### PR DESCRIPTION
With Lightkurve shifting to having astropy tables are the backend API, data from TPF and LC files are now astropy Quantity objects. 
However, KeplerQualityFlags.decode() and TessQualityFlags.decode() does not accepted an astropy Quantity.
The PR addressed #804, and fixes this issue by checking if the passed value is a quantity and extracting the value from the quantity object.