### PR TITLE
Ensure `download()` passes kwargs to the reader functions

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -116,7 +116,7 @@ class SearchResult(object):
         """Returns an array of dec values for targets in search"""
         return self.table['s_dec'].data.data
 
-    def _download_one(self, table, quality_bitmask, download_dir, cutout_size):
+    def _download_one(self, table, quality_bitmask, download_dir, cutout_size, **kwargs):
         """Private method used by `download()` and `download_all()` to download
         exactly one file from the MAST archive.
 
@@ -163,10 +163,10 @@ class SearchResult(object):
             path = Observations.download_products(table[:1], mrp_only=False,
                                                   download_dir=download_dir)['Local Path'][0]
             log.debug("Finished downloading.")
-            return read(path, quality_bitmask=quality_bitmask)
+            return read(path, quality_bitmask=quality_bitmask, **kwargs)
 
     @suppress_stdout
-    def download(self, quality_bitmask='default', download_dir=None, cutout_size=None):
+    def download(self, quality_bitmask='default', download_dir=None, cutout_size=None, **kwargs):
         """Returns a single `LightCurve` or `TargetPixelFile` object.
 
         If multiple files are present in `SearchResult.table`, only the first
@@ -194,6 +194,8 @@ class SearchResult(object):
         cutout_size : int, float or tuple
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
+        kwargs : dict
+            Extra keyword arguments passed on to the file format reader function.
 
         Returns
         -------
@@ -222,10 +224,11 @@ class SearchResult(object):
         return self._download_one(table=self.table[:1],
                                   quality_bitmask=quality_bitmask,
                                   download_dir=download_dir,
-                                  cutout_size=cutout_size)
+                                  cutout_size=cutout_size,
+                                  **kwargs)
 
     @suppress_stdout
-    def download_all(self, quality_bitmask='default', download_dir=None, cutout_size=None):
+    def download_all(self, quality_bitmask='default', download_dir=None, cutout_size=None, **kwargs):
         """Returns a `~lightkurve.collections.TargetPixelFileCollection` or
         `~lightkurve.collections.LightCurveCollection`.
 
@@ -251,6 +254,8 @@ class SearchResult(object):
         cutout_size : int, float or tuple
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
+        kwargs : dict
+            Extra keyword arguments passed on to the file format reader function.
 
         Returns
         -------
@@ -277,7 +282,8 @@ class SearchResult(object):
             products.append(self._download_one(table=self.table[idx:idx+1],
                                                quality_bitmask=quality_bitmask,
                                                download_dir=download_dir,
-                                               cutout_size=cutout_size))
+                                               cutout_size=cutout_size,
+                                               **kwargs))
         if isinstance(products[0], TargetPixelFile):
             return TargetPixelFileCollection(products)
         else:

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -318,3 +318,10 @@ def test_tesscut_795():
     """Regression test for #795: make sure the __repr__.of a TESSCut
     SearchResult works."""
     str(search_tesscut('KIC 8462852'))  # This raised a KeyError
+
+
+@pytest.mark.remote_data
+def test_download_flux_column():
+    """Can we pass reader keyword arguments to the download method?"""
+    lc = search_lightcurve("Pi Men", sector=12).download(flux_column='sap_flux')
+    assert_array_equal(lc.flux, lc.sap_flux)


### PR DESCRIPTION
The new LightCurve reader functions contain a number of optional keyword arguments.  For example, the TESS LightCurve reader allows the `flux_column` parameter to be passed to determine which column should be used to populate the `flux` column.

At present the `download()` method of the `SearchResult` class does not pass kwargs through to these reader functions.  This PR changes this, to allow e.g. the following use case:
```python
lc = lk.search_lightcurve("Pi Men", sector=12).download(flux_column='sap_flux')
```

(previously, `flux_column` could not be passed in the example above)