### PR TITLE
Introduce simple `create_transit_mask` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,12 @@ lightkurve.seismology
 - Added an error message to ``estimate_numax()`` or ``estimate_deltanu()`` if
   the underlying periodogram does not have uniformly-spaced frequencies. [#780]
 
+lightkurve.periodogram
+^^^^^^^^^^^^^^^^^^^^^^
+
+- Modified ``create_transit_mask`` method to return ``True`` during transits and
+  ``False`` elsewhere for consistent mask syntax. [#808]
+
 
 
 1.11.1 (2020-06-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ lightkurve.lightcurve
 - Added a ``column`` parameter to ``LightCurve``'s ``plot()``, ``scatter()``,
   and ``errorbar()`` methods to enable any column to be plotted. [#765]
 
+- Added the ``LightCurve.create_transit_mask(period, transit_time, duration)``
+  method to conveniently mask planet or eclipsing binary transits. [#808]
+
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1922,17 +1922,16 @@ class LightCurve(TimeSeries):
     def create_transit_mask(self, period, transit_time, duration):
         """Returns a np.array that is False during transits and True everywhere else.
 
-        This function creates a `lightkurve.BLSPeriodogram` for the light curve,
-        and utilizes its `get_transit_mask` method. It is flexible to multi-planet
-        systems, allowing users to pass in transit parameters as arrays or lists.
+        This function is flexible to multi-planet systems, allowing users to pass
+        in transit parameters as arrays or lists.
 
         Parameters
         ----------
-        period : float, Quantity, or array-like
+        period : float, or array-like
             Period of the transits.
-        duration : float, Quantity, or array-like
+        duration : float, or array-like
             Duration of the transits.
-        transit_time : float, Quantity, or array-like
+        transit_time : float, or array-like
             Transit midpoint of the transits.
 
         Returns

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1922,7 +1922,7 @@ class LightCurve(TimeSeries):
     def create_transit_mask(self, period, transit_time, duration):
         """Returns a np.array that is False during transits and True everywhere else.
 
-        This function creates a `lightkurve.BLSPeriodogram` for the lightcurve,
+        This function creates a `lightkurve.BLSPeriodogram` for the light curve,
         and utilizes its `get_transit_mask` method. It is flexible to multi-planet
         systems, allowing users to pass in transit parameters as arrays or lists.
 
@@ -1940,11 +1940,14 @@ class LightCurve(TimeSeries):
         mask : np.array of Bool
             Mask that removes transits. Mask is True where there are no transits.
         """
-        # Instantiate the BLSPeriodogram
+        # It's necessary to replace NaN values with a small float to ensure that
+        # the output mask has the same dimensions as the input light curve
         temp_lc = self.copy()
         nanmask = np.where(np.isnan(temp_lc.flux_err.value))
         temp_lc.flux.value[nanmask] = 1e-10 * self.flux.unit
         temp_lc.flux_err.value[nanmask] = 1e-10 * self.flux_err.unit
+
+        # Instantiate the BLSPeriodogram
         bls = temp_lc.to_periodogram('bls')
 
         # Create a transit mask for a single planet

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -1080,9 +1080,8 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         return model
 
     def get_transit_mask(self, period=None, duration=None, transit_time=None):
-        """Computes the transit mask using the BLS, returns a lightkurve.LightCurve
-
-        True where there are no transits.
+        """Returns a boolean array that is ``True`` during transits and
+        ``False`` elsewhere.
 
         Parameters
         ----------
@@ -1095,11 +1094,11 @@ class BoxLeastSquaresPeriodogram(Periodogram):
 
         Returns
         -------
-        mask : np.array of Bool
-            Mask that removes transits. Mask is True where there are no transits.
+        transit_mask : np.array of bool
+            Mask that flags transits. Mask is ``True`` where there are transits.
         """
         model = self.get_transit_model(period=period, duration=duration, transit_time=transit_time)
-        return model.flux == np.median(model.flux)
+        return model.flux != np.median(model.flux)
 
     @property
     def transit_time_at_max_power(self):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1043,10 +1043,10 @@ def test_mixed_instantiation():
 
 
 def test_create_transit_mask():
-    """Can we create a transit mask for the light curve?"""
+    """Test for `LightCurve.create_transit_mask()`."""
     # Set planet parameters
     period = 2.0
-    transit_time = 0.5
+    transit_time = Time(2450000., format='jd')
     duration = 0.1
     depth = 0.2
     flux_err = 0.01
@@ -1054,7 +1054,7 @@ def test_create_transit_mask():
     # Create the synthetic light curve
     time = np.arange(0, 100, 0.1)
     flux = np.ones_like(time)
-    transit_mask = np.abs((time-transit_time+0.5*period) % period-0.5*period) < 0.5*duration
+    transit_mask = np.abs((time-transit_time.value+0.5*period) % period-0.5*period) < 0.5*duration
     flux[transit_mask] = 1.0 - depth
     flux += flux_err * np.random.randn(len(time))
     synthetic_lc = LightCurve(time=time, flux=flux)
@@ -1064,9 +1064,9 @@ def test_create_transit_mask():
                                             transit_time=transit_time)
 
     # Are all masked values out of transit?
-    assert(all(f > 0.9 for f in synthetic_lc[mask].flux.value))
+    assert(all(f > 0.9 for f in synthetic_lc[~mask].flux.value))
     # Are all unmasked values in transit?
-    assert(all(f < 0.9 for f in synthetic_lc[~mask].flux.value))
+    assert(all(f < 0.9 for f in synthetic_lc[mask].flux.value))
 
     # Can it handle multi-planet masks?
     period_2 = 3.0
@@ -1082,6 +1082,6 @@ def test_create_transit_mask():
                                             transit_time=[transit_time, transit_time_2])
 
     # Are all masked values out of transit?
-    assert(all(f > 0.9 for f in synthetic_lc[mask].flux.value))
+    assert(all(f > 0.9 for f in synthetic_lc[~mask].flux.value))
     # Are all unmasked values in transit?
-    assert(all(f < 0.9 for f in synthetic_lc[~mask].flux.value))
+    assert(all(f < 0.9 for f in synthetic_lc[mask].flux.value))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1040,3 +1040,48 @@ def test_mixed_instantiation():
 
     LightCurve(time=[1,2,3], flux=[1,2,3], data=Table({'flux_err': [3,4,5]}))
     LightCurve(time=[1,2,3], flux=[1,2,3], data={'flux_err': [3,4,5]})
+
+
+def test_create_transit_mask():
+    """Can we create a transit mask for the light curve?"""
+    # Set planet parameters
+    period = 2.0
+    transit_time = 0.5
+    duration = 0.1
+    depth = 0.2
+    flux_err = 0.01
+
+    # Create the synthetic light curve
+    time = np.arange(0, 100, 0.1)
+    flux = np.ones_like(time)
+    transit_mask = np.abs((time-transit_time+0.5*period) % period-0.5*period) < 0.5*duration
+    flux[transit_mask] = 1.0 - depth
+    flux += flux_err * np.random.randn(len(time))
+    synthetic_lc = LightCurve(time=time, flux=flux)
+
+    # Create planet mask
+    mask = synthetic_lc.create_transit_mask(period=period, duration=duration,
+                                            transit_time=transit_time)
+
+    # Are all masked values out of transit?
+    assert(all(f > 0.9 for f in synthetic_lc[mask].flux.value))
+    # Are all unmasked values in transit?
+    assert(all(f < 0.9 for f in synthetic_lc[~mask].flux.value))
+
+    # Can it handle multi-planet masks?
+    period_2 = 3.0
+    transit_time_2 = 0.75
+    duration_2 = 0.1
+    transit_mask_2 = np.abs((time-transit_time_2+0.5*period_2) % period_2-0.5*period_2) < 0.5*duration_2
+    flux[transit_mask_2] = 1.0 - depth
+    synthetic_lc = LightCurve(time=time, flux=flux)
+
+    # Create multi-planet planet mask
+    mask = synthetic_lc.create_transit_mask(period=[period, period_2],
+                                            duration=[duration, duration_2],
+                                            transit_time=[transit_time, transit_time_2])
+
+    # Are all masked values out of transit?
+    assert(all(f > 0.9 for f in synthetic_lc[mask].flux.value))
+    # Are all unmasked values in transit?
+    assert(all(f < 0.9 for f in synthetic_lc[~mask].flux.value))

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -267,7 +267,7 @@ def test_bls(caplog):
     mask = p.get_transit_mask(1, 0.1, 0)
     assert isinstance(mask, np.ndarray)
     assert isinstance(mask[0], np.bool_)
-    assert mask.sum() > (~mask).sum()
+    assert mask.sum() < (~mask).sum()
 
     assert isinstance(p.period_at_max_power, u.Quantity)
     assert isinstance(p.duration_at_max_power, u.Quantity)

--- a/lightkurve/tests/test_synthetic_data.py
+++ b/lightkurve/tests/test_synthetic_data.py
@@ -97,7 +97,7 @@ def test_transit_pld():
                                frequency_factor=0.05, duration=np.arange(0.1, 0.6, 0.1))
 
     # Re-do PLD with the suspected transits masked
-    cor_lc = corrector.correct(cadence_mask=pg.get_transit_mask()).normalize()
+    cor_lc = corrector.correct(cadence_mask=~pg.get_transit_mask()).normalize()
     pg = cor_lc.to_periodogram(method='bls', minimum_period=1, maximum_period=9,
                                frequency_factor=0.05, duration=np.arange(0.1, 0.6, 0.1))
 


### PR DESCRIPTION
This addition is in response to discussion about [this notebook](https://github.com/barentsen/notebooks/issues/1).

### Summary
It would be useful to have a function to create a transit mask with known parameters without the user needing to interact with a `BLSPeriodogram` object. This PR introduces the `create_transit_mask` method for `lightkurve.LightCurve` objects. It takes required arguments for `period`, `duration`, and `transit_time`. 

#### Choices I made that people might have strong opinions about
* I made this a method of `LightCurve`, which makes the most sense to me, though it could theoretically also be a method of `TargetPixelFile`, or just a standalone function in `utils` that takes a time array as well as these parameters.
* I wrapped `BLSPeriodogram` to allow the mask to be generated from a transit model, and to and reduce code repetition.
* At the beginning of the method, I create a copy of the `LightCurve`, and set the `flux` and `flux_err` that were `NaN` to something very small (`1e-10` instead of `0`) so that `to_periodogram` works without removing data points. This ensures that you can create a transit mask for a target even if you haven't removed `NaN`s. I added this because my output mask was a different size than expected and the error was uninformative. The alternative is to throw an exception unless the user calls `remove_nans` before creating their transit mask, but that feels restrictive. 
* `period`, `duration`, and `transit_time` can be passed in as lists or np.arrays so you can easily make multi-planet masks.

### Examples
```python
# single-planet mask
mask = lc.create_transit_mask(period=5.0, duration=0.5, transit_time=0.)

# multi-planet mask
mask = lc.create_transit_mask(period=[5.0, 10.0, 15.0], 
                              duration=[0.5, 0.75, 1.0], 
                              transit_time=[0., 1., 2.])
```


### Unrelated issue
While developing this, I found that every time I tried to create the `BLSPeriodogram` object, I got this error:
```
TypeError: Unsupported operand type(s) for ufunc add: 'Time,Quantity'
```
...but running the cell again worked fine. @barentsen @ojhall94 is this a known issue?