### PR TITLE
docfix - query_system_object()'s cadence_mask

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1167,12 +1167,12 @@ class LightCurve(TimeSeries):
         sigma : optional, float
             If `cadence_mask` is set to `"outlier"`, `sigma` will be used to identify
             outliers.
-        location : str
-            Spacecraft location. Options include `'kepler'` and `'tess'`.
+        location : optional, str
+            Spacecraft location. Options include `'kepler'` and `'tess'`. Default: `self.mission`
         cache : optional, bool
             If True will cache the search result in the astropy cache. Set to False
             to request the search again.
-        return_mask: bool
+        return_mask: optional, bool
             If True will return a boolean mask in time alongside the result
 
         Returns

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1203,6 +1203,8 @@ class LightCurve(TimeSeries):
                 cadence_mask = self.remove_outliers(sigma=sigma, return_mask=True)[1]
             elif cadence_mask == 'all':
                 cadence_mask = np.ones(len(self.time)).astype(bool)
+            else:
+                raise ValueError('invalid `cadence_mask` string argument')
         elif isinstance(cadence_mask, collections.abc.Sequence):
             cadence_mask = np.array(cadence_mask)
         elif isinstance(cadence_mask, (bool)):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1156,7 +1156,7 @@ class LightCurve(TimeSeries):
 
         Parameters
         ----------
-        cadence_mask : str, or boolean ndarray with length of self.time
+        cadence_mask : str, or boolean array with length of self.time
             mask in time to select which frames or points should be searched for SSOs.
             Default "outliers" will search for SSOs at points that are `sigma` from the mean.
             "all" will search all cadences. Alternatively, pass a boolean array with values of "True"

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -834,7 +834,7 @@ class LightCurve(TimeSeries):
                 ntime.append(t)
             ntime = np.asarray(ntime, float)
             in_original = np.in1d(ntime, lc.time.value)
-        
+
         # Fill in time points
         newdata['time'] = Time(ntime, format=lc.time.format, scale=lc.time.scale)
         f = np.zeros(len(ntime))
@@ -1156,10 +1156,10 @@ class LightCurve(TimeSeries):
 
         Parameters
         ----------
-        cadence_mask : str or bool
+        cadence_mask : str, or boolean ndarray with length of self.time
             mask in time to select which frames or points should be searched for SSOs.
             Default "outliers" will search for SSOs at points that are `sigma` from the mean.
-            "all" will search all cadences. Pass a boolean array with values of "True"
+            "all" will search all cadences. Alternatively, pass a boolean ndarray with values of "True"
             for times to search for SSOs.
         radius : optional, float
             Radius in degrees to search for bodies. If None, will search for
@@ -1181,6 +1181,12 @@ class LightCurve(TimeSeries):
             DataFrame object which lists the Solar System objects in frames
             that were identified to contain SSOs.  Returns `None` if no objects
             were found.
+
+        Examples
+        --------
+        Find if there are SSOs affecting the lightcurve for the given time frame:
+
+            >>> df_sso = lc.query_solar_system_objects(cadence_mask=np.logical_and(lc.time >= 2014.1, lc.time <= 2014.9))
         """
         for attr in ['ra', 'dec']:
             if not hasattr(self, '{}'.format(attr)):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1197,19 +1197,13 @@ class LightCurve(TimeSeries):
             if not hasattr(self, '{}'.format(attr)):
                 raise ValueError('Input does not have a `{}` attribute.'.format(attr))
 
-        sequence_type = None
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            # use the deprecated collections.Sequence to be compatible with python 2.7
-            sequence_type = collections.Sequence
-
         # Validate `cadence_mask`
         if isinstance(cadence_mask, str):
             if cadence_mask == 'outliers':
                 cadence_mask = self.remove_outliers(sigma=sigma, return_mask=True)[1]
             elif cadence_mask == 'all':
                 cadence_mask = np.ones(len(self.time)).astype(bool)
-        elif isinstance(cadence_mask, sequence_type):
+        elif isinstance(cadence_mask, collections.abc.Sequence):
             cadence_mask = np.array(cadence_mask)
         elif isinstance(cadence_mask, (bool)):
             # for boundary case of a single element tuple, e.g., (True)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1150,10 +1150,9 @@ class LightCurve(TimeSeries):
           object to determine the position of the search cone.
         * The size of the search cone is 15 spacecraft pixels by default. You
           can change this by passing the `radius` parameter (unit: degrees).
-        * This method will only search points in time during which he light
+        * By default, this method will only search points in time during which the light
           curve showed 3-sigma outliers in flux. You can override this behavior
-          and search all times by passing the `cadence_mask='all'` argument,
-          but this will be much slower.
+          and search for specific times by passing `cadence_mask`. See examples for details.
 
         Parameters
         ----------
@@ -1188,6 +1187,11 @@ class LightCurve(TimeSeries):
         Find if there are SSOs affecting the lightcurve for the given time frame:
 
             >>> df_sso = lc.query_solar_system_objects(cadence_mask=(lc.time.value >= 2014.1) & (lc.time.value <= 2014.9))  # doctest: +SKIP
+
+        Find if there are SSOs affecting the lightcurve for all times, but it will be much slower:
+
+            >>> df_sso = lc.query_solar_system_objects(cadence_mask='all')  # doctest: +SKIP
+
         """
         for attr in ['ra', 'dec']:
             if not hasattr(self, '{}'.format(attr)):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1187,7 +1187,7 @@ class LightCurve(TimeSeries):
         --------
         Find if there are SSOs affecting the lightcurve for the given time frame:
 
-            >>> df_sso = lc.query_solar_system_objects(cadence_mask=np.logical_and(lc.time >= 2014.1, lc.time <= 2014.9))
+            >>> df_sso = lc.query_solar_system_objects(cadence_mask=(lc.time.value >= 2014.1) & (lc.time.value <= 2014.9))  # doctest: +SKIP
         """
         for attr in ['ra', 'dec']:
             if not hasattr(self, '{}'.format(attr)):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -848,6 +848,9 @@ class TargetPixelFile(object):
                     aper = 'all'
                 lc = self.to_lightcurve(aperture_mask=aper)
                 cadence_mask = lc.remove_outliers(sigma=sigma, return_mask=True)[1]
+                # Avoid searching times with NaN flux; this is necessary because e.g.
+                # `remove_outliers` includes NaNs in its mask.
+                cadence_mask &= ~np.isnan(lc.flux)
             elif cadence_mask == 'all':
                 cadence_mask = np.ones(len(self.time)).astype(bool)
             else:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -848,9 +848,10 @@ class TargetPixelFile(object):
                     aper = 'all'
                 lc = self.to_lightcurve(aperture_mask=aper)
                 cadence_mask = lc.remove_outliers(sigma=sigma, return_mask=True)[1]
-
-            if cadence_mask == 'all':
+            elif cadence_mask == 'all':
                 cadence_mask = np.ones(len(self.time)).astype(bool)
+            else:
+                raise ValueError('invalid `cadence_mask` string argument')
         elif isinstance(cadence_mask, collections.abc.Sequence):
             cadence_mask = np.array(cadence_mask)
         elif isinstance(cadence_mask, (bool)):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -792,7 +792,7 @@ class TargetPixelFile(object):
         Notes:
         * This method will use the `ra` and `dec` properties of the `LightCurve`
           object to determine the position of the search cone.
-        * The size of the search cone is 5 spacecraft pixels by default. You
+        * The size of the search cone is 5 spacecraft pixels + TPF dimension by default. You
           can change this by passing the `radius` parameter (unit: degrees).
         * By default, this method will only search points in time during which the light
           curve showed 3-sigma outliers in flux. You can override this behavior

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -792,7 +792,7 @@ class TargetPixelFile(object):
         Notes:
         * This method will use the `ra` and `dec` properties of the `LightCurve`
           object to determine the position of the search cone.
-        * The size of the search cone is 15 spacecraft pixels by default. You
+        * The size of the search cone is 5 spacecraft pixels by default. You
           can change this by passing the `radius` parameter (unit: degrees).
         * By default, this method will only search points in time during which the light
           curve showed 3-sigma outliers in flux. You can override this behavior

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -866,7 +866,7 @@ class TargetPixelFile(object):
             pixel_scale = 27
 
         if radius == None:
-            radius = (2**0.5*(pixel_scale * np.max(self.shape[1:])) + 5)*u.arcsecond.to(u.deg)
+            radius = (2**0.5*(pixel_scale * (np.max(self.shape[1:]) + 5)))*u.arcsecond.to(u.deg)
 
         res = _query_solar_system_objects(ra=self.ra, dec=self.dec, times=self.time.jd[cadence_mask],
                                       location=location, radius=radius, cache=cache)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -984,6 +984,11 @@ def test_SSOs():
     assert(len(result) == 1)
     result, mask = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(lc.flux))
+    try:
+        result = lc.query_solar_system_objects(cadence_mask='str-not-supported', cache=False)
+        pytest.fail("Unsupported cadence_mask should have thrown Error")
+    except ValueError:
+        pass
 
 
 @pytest.mark.xfail  # LightCurveFile was removed in Lightkurve v2.x

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -969,14 +969,18 @@ def test_bin_issue705():
         lc.bin(binsize=15)
 
 
-@pytest.mark.xfail  # As of June 2020 the SkyBot service is returning MySQL errors
 @pytest.mark.remote_data
 def test_SSOs():
     # TESS test
     lc = TessTargetPixelFile(asteroid_TPF).to_lightcurve(aperture_mask='all')
+    lc.mission = 'TESS' # needed to resolve default value for location argument
     result = lc.query_solar_system_objects(cadence_mask='all', cache=False)
     assert(len(result) == 1)
     result = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
+    assert(len(result) == 1)
+    result = lc.query_solar_system_objects(cadence_mask=[True], cache=False)
+    assert(len(result) == 1)
+    result = lc.query_solar_system_objects(cadence_mask=(True), cache=False)
     assert(len(result) == 1)
     result, mask = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(lc.flux))

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -122,11 +122,11 @@ def test_tpf_plot():
         with pytest.raises(ValueError):
             tpf.plot(scale="blabla")
         tpf.plot(column='FLUX')
-        tpf.plot(column='FLUX_ERR') 
-        tpf.plot(column='FLUX_BKG') 
-        tpf.plot(column='FLUX_BKG_ERR') 
-        tpf.plot(column='RAW_CNTS') 
-        tpf.plot(column='COSMIC_RAYS') 
+        tpf.plot(column='FLUX_ERR')
+        tpf.plot(column='FLUX_BKG')
+        tpf.plot(column='FLUX_BKG_ERR')
+        tpf.plot(column='RAW_CNTS')
+        tpf.plot(column='COSMIC_RAYS')
         with pytest.raises(ValueError):
             tpf.plot(column='not a column')
 
@@ -594,7 +594,6 @@ def test_aperture_photometry_nan():
     assert np.isnan(lc.flux_err[2])
 
 
-@pytest.mark.xfail  # As of June 2020 the SkyBot service is returning MySQL errors
 @pytest.mark.remote_data
 def test_SSOs():
     # TESS test
@@ -602,6 +601,10 @@ def test_SSOs():
     result = tpf.query_solar_system_objects(cadence_mask='all', cache=False)
     assert(len(result) == 1)
     result = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
+    assert(len(result) == 1)
+    result = tpf.query_solar_system_objects(cadence_mask=[True], cache=False)
+    assert(len(result) == 1)
+    result = tpf.query_solar_system_objects(cadence_mask=(True), cache=False)
     assert(len(result) == 1)
     result, mask = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(tpf.flux))
@@ -624,8 +627,8 @@ def test_plot_pixels():
     tpf.plot_pixels(periodogram=True)
     tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
     tpf.plot_pixels(aperture_mask='all')
-    tpf.plot_pixels(aperture_mask=tpf.pipeline_mask) 
-    tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask()) 
+    tpf.plot_pixels(aperture_mask=tpf.pipeline_mask)
+    tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask())
     tpf.plot_pixels(show_flux=True)
     tpf.plot_pixels(corrector_func=lambda x:x)
     plt.close('all')

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -608,6 +608,11 @@ def test_SSOs():
     assert(len(result) == 1)
     result, mask = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
     assert(len(mask) == len(tpf.flux))
+    try:
+        result = tpf.query_solar_system_objects(cadence_mask='str-not-supported', cache=False)
+        pytest.fail("Unsupported cadence_mask should have thrown Error")
+    except ValueError:
+        pass
 
 
 def test_get_header():

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -598,6 +598,8 @@ def test_aperture_photometry_nan():
 def test_SSOs():
     # TESS test
     tpf = TessTargetPixelFile(asteroid_TPF)
+    result = tpf.query_solar_system_objects() # default cadence_mask = 'outliers'
+    assert(result is None) # the TPF has only data for 1 epoch. The lone time is removed as outlier
     result = tpf.query_solar_system_objects(cadence_mask='all', cache=False)
     assert(len(result) == 1)
     result = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)


### PR DESCRIPTION
Closes #809 and closes #810

- The initial commits only changes the docstring in `LightCurve.query_system_object()`, assuming we stick with the existing behavior requiring `ndarray`. If agreed, similar changes will be added to `TargetPixelFile`

- I cannot verify the doc output. Somehow in my local build, the generated documentation does not have `query_system_object()` ( nor similarly relatively method `plot_river()`).
