### PR TITLE
Fix `to_lightcurve()` to work on TESSCut-produced TPFs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ lightkurve.targetpixelfile
   column in a pixel file to be plotted (e.g. ``column="BKG_FLUX"``). [#738]
 
 - Modified ``to_lightcurve()`` to default to using ``aperture_mask='threshold'``
-  if the 'pipeline' mask is missing or empty, e.g. for TESSCut files.
+  if the 'pipeline' mask is missing or empty, e.g. for TESSCut files. [#812]
 
 lightkurve.search
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ lightkurve.targetpixelfile
 - Added a ``column`` parameter to ``TargetPixelFile.plot()`` to enable any
   column in a pixel file to be plotted (e.g. ``column="BKG_FLUX"``). [#738]
 
+- Modified ``to_lightcurve()`` to default to using ``aperture_mask='threshold'``
+  if the 'pipeline' mask is missing or empty, e.g. for TESSCut files.
+
 lightkurve.search
 ^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -505,7 +505,8 @@ class TargetPixelFile(object):
             that the pixel will be used.
             If None or 'all' are passed, all pixels will be used.
             If 'pipeline' is passed, the mask suggested by the official pipeline
-            will be returned.
+            will be returned.  If the pipeline mask is missing or empty, we
+            automatically fall back on the 'threshold' mask instead.
             If 'threshold' is passed, all pixels brighter than 3-sigma above
             the median flux will be used.
             If 'background' is passed, all pixels fainter than the median flux
@@ -516,6 +517,13 @@ class TargetPixelFile(object):
         aperture_mask : ndarray
             2D boolean numpy array containing `True` for selected pixels.
         """
+        # If 'pipeline' mask is requested but missing, fall back to 'threshold'
+        if isinstance(aperture_mask, str) and (aperture_mask == 'pipeline') \
+           and ~np.any(self.pipeline_mask):
+            log.debug("_parse_aperture_mask: 'pipeline' mask is missing or "
+                      "empty, falling back on 'threshold' mask instead.")
+            aperture_mask = 'threshold'
+
         # Input validation
         if hasattr(aperture_mask, 'shape') and (aperture_mask.shape != self.flux[0].shape):
             raise ValueError("`aperture_mask` has shape {}, "
@@ -674,8 +682,10 @@ class TargetPixelFile(object):
         aperture_mask : 'pipeline', 'threshold', 'all', or array-like
             Which pixels contain the object to be measured, i.e. which pixels
             should be used in the estimation?  If None or 'all' are passed,
-            all pixels in the pixel file will be used.  If 'pipeline' is passed,
-            the mask suggested by the official pipeline will be used.
+            all pixels in the pixel file will be used.
+            If 'pipeline' is passed, the mask suggested by the official pipeline
+            will be returned.  If the pipeline mask is missing or empty, we
+            automatically fall back on the 'threshold' mask instead.
             If 'threshold' is passed, all pixels brighter than 3-sigma above
             the median flux will be used.
             Alternatively, users can pass a boolean array describing the
@@ -991,12 +1001,13 @@ class TargetPixelFile(object):
         max_cadences : int
             Raise a RuntimeError if the number of cadences shown is larger than
             this value. This limit helps keep browsers from becoming unresponsive.
-        aperture_mask : array-like, 'pipeline', 'threshold' or 'all'
+        aperture_mask : array-like, 'pipeline', 'threshold', or 'all'
             A boolean array describing the aperture such that `True` means
             that the pixel will be used.
             If None or 'all' are passed, all pixels will be used.
             If 'pipeline' is passed, the mask suggested by the official pipeline
-            will be returned.
+            will be returned.  If the pipeline mask is missing or empty, we
+            automatically fall back on the 'threshold' mask instead.
             If 'threshold' is passed, all pixels brighter than 3-sigma above
             the median flux will be used.
         exported_filename: str
@@ -1475,7 +1486,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
             that the pixel will be used.
             If None or 'all' are passed, all pixels will be used.
             If 'pipeline' is passed, the mask suggested by the official pipeline
-            will be returned.
+            will be returned.  If the pipeline mask is missing or empty, we
+            automatically fall back on the 'threshold' mask instead.
             If 'threshold' is passed, all pixels brighter than 3-sigma above
             the median flux will be used.
         centroid_method : str, 'moments' or 'quadratic'
@@ -2101,7 +2113,8 @@ class TessTargetPixelFile(TargetPixelFile):
             that the pixel will be used.
             If None or 'all' are passed, all pixels will be used.
             If 'pipeline' is passed, the mask suggested by the official pipeline
-            will be returned.
+            will be returned.  If the pipeline mask is missing or empty, we
+            automatically fall back on the 'threshold' mask instead.
             If 'threshold' is passed, all pixels brighter than 3-sigma above
             the median flux will be used.
             The default behaviour is to use the TESS pipeline mask.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -594,7 +594,7 @@ class TargetPixelFile(object):
         # Calculate the theshold value in flux units
         mad_cut = (1.4826 * MAD(vals) * threshold) + np.nanmedian(median_image)
         # Create a mask containing the pixels above the threshold flux
-        threshold_mask = np.nan_to_num(median_image) > mad_cut
+        threshold_mask = np.nan_to_num(median_image) >= mad_cut
         if (reference_pixel is None) or (not threshold_mask.any()):
             # return all regions above threshold
             return threshold_mask

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -516,9 +516,9 @@ def test_threshold_aperture_mask():
     assert tpf.create_threshold_mask(threshold=2., reference_pixel='center').sum() == 25
     assert tpf.create_threshold_mask(threshold=2., reference_pixel=None).sum() == 28
     assert tpf.create_threshold_mask(threshold=2., reference_pixel=(5, 0)).sum() == 2
-    # A mask which contains zero pixels should work without crashing
+    # A mask which contains zero-flux pixels should work without crashing
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
-    assert tpf.create_threshold_mask().sum() == 0
+    assert tpf.create_threshold_mask().sum() == 9
 
 
 def test_tpf_tess():

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -639,7 +639,7 @@ def test_missing_pipeline_mask():
     TPFs produced by TESSCut contain an empty pipeline mask.  When the pipeline
     mask is missing or empty, we want `to_lightcurve()` to fall back on the
     'threshold' mask, to avoid creating a light curve based on zero pixels."""
-    tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=3)
+    tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=1)
     lc = tpf.to_lightcurve()
     assert np.isfinite(lc.flux).any()
     lc = tpf.to_lightcurve(aperture_mask='pipeline')


### PR DESCRIPTION
The current default behavior of `tpf.to_lightcurve()` is to use `aperture_mask='pipeline'`.  This is because all official Target Pixel Files used to include a suitable pipeline-generated aperture mask by default.

This default is not suitable for TPFs obtained via `TESSCut`, because the header of `TESSCut`-produced TPFs are populated with an empty pixel aperture mask.  As a result, the following example creates an all-NaN light curve, which is confusing to users:

```python
>>> tpf = lk.search_tesscut("Proxima Cen", sector=12).download(cutout_size=3)
>>> lc = tpf.to_lightcurve()
>>> lc.flux.value
array([nan, nan, nan, ..., nan, nan, nan], dtype=float32)
```

This PR changes the default behavior to automatically fall back on using the `aperture_mask='threshold'` mask if the `'pipeline'` mask is found to be missing or empty, i.e. the new behavior is as follows:

```python
>>> tpf = lk.search_tesscut("Proxima Cen", sector=12).download(cutout_size=3)
>>> lc = tpf.to_lightcurve()
>>> lc.flux.value
array([4432.453 , 4465.996 , 4493.9775, ..., 3811.1558, 3804.6597, 3817.3662], dtype=float32)
```

Fixes #791.