### PR TITLE
Bugfix: ensure tpf.cutout() maintains the `quality_bitmask`

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1223,7 +1223,8 @@ class TargetPixelFile(object):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             newfits = fits.HDUList(hdus)
-        return self.__class__(newfits)
+        return self.__class__(newfits, quality_bitmask=self.quality_bitmask)
+
 
     def plot_pixels(self, ax=None, periodogram=False, aperture_mask=None,
                     show_flux=False, corrector_func=None, style='lightkurve',


### PR DESCRIPTION
At present, `tpf.cutout()` does not pass the `quality_bitmask` parameter on.  For example, this test fails:

```python
url = "/home/gb/dev/lightkurve/lightkurve/tests/data/test-tpf-non-zero-center.fits"
tpf = lk.read(url, quality_bitmask=8192)
tpfcut = tpf.cutout()
assert(len(tpf) == len(tpfcut))
```

This PR fixes this shortcoming!