### PR TITLE
Improve the aperture mask plotting style (feedback welcome!)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ lightkurve.targetpixelfile
 - Modified ``to_lightcurve()`` to default to using ``aperture_mask='threshold'``
   if the 'pipeline' mask is missing or empty, e.g. for TESSCut files. [#812]
 
+- Modified `plot()` to use a more clear hatched style when visualizing the
+  aperture mask on top of pixel data. [#814]
+
 lightkurve.search
 ^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -956,7 +956,7 @@ class TargetPixelFile(object):
                         rect = patches.Rectangle(
                                         xy=(j+self.column-0.5, i+self.row-0.5),
                                         width=1, height=1, color=mask_color,
-                                        fill=False, hatch='..')
+                                        fill=False, hatch='//')
                         ax.add_patch(rect)
         return ax
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -863,7 +863,7 @@ class TargetPixelFile(object):
         return res
 
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, column='FLUX', aperture_mask=None,
-             show_colorbar=True, mask_color='pink', title=None, style='lightkurve',
+             show_colorbar=True, mask_color='red', title=None, style='lightkurve',
              **kwargs):
         """Plot the pixel data for a single frame (i.e. at a single time).
 
@@ -956,7 +956,7 @@ class TargetPixelFile(object):
                         rect = patches.Rectangle(
                                         xy=(j+self.column-0.5, i+self.row-0.5),
                                         width=1, height=1, color=mask_color,
-                                        fill=True, alpha=.6)
+                                        fill=False, hatch='..')
                         ax.add_patch(rect)
         return ax
 


### PR DESCRIPTION
The style we currently use to visualize aperture masks using `tpf.plot(aperture_mask=mask)` is not very clear because it uses faint pink transparency on top of blue/yellow pixels.  I would like to propose to change it to a less ambiguous red hatching style.  See the example below!

Is anyone against this change?

### Current style:

![aper-plot-before](https://user-images.githubusercontent.com/817669/91233954-3046c680-e6e7-11ea-8c58-3d3a75eda7a4.png)

### Proposed new style

![aper-plot-after](https://user-images.githubusercontent.com/817669/91233963-350b7a80-e6e7-11ea-8ddc-6b4dda3e48c5.png)
