### PR TITLE
filter collection by TESS sector

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,7 +60,12 @@ lightkurve.targetpixelfile
   and to enable it to populate all data columns. [#768, #857]
 
 - Fixed a bug in ``TargetPixelFile.wcs`` which caused it to raise Error if
-the tpf does not contain expected WCS keywords in the header. [#892]
+  the tpf does not contain expected WCS keywords in the header. [#892]
+
+lightkurve.collections
+^^^^^^^^^^^^^^^^^^^^^^
+
+- Added the ability to filter a collection by `quarter`, `campaign` or `sector`. [#815]
 
 lightkurve.search
 ^^^^^^^^^^^^^^^^^

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -38,7 +38,7 @@ class Collection(object):
         return len(self.data)
 
     def __getitem__(self, indexOrMask):
-        if (isinstance(indexOrMask, (int, slice))):
+        if (isinstance(indexOrMask, (int, np.integer, slice))):
             return self.data[indexOrMask]
         else:
             # assume indexOrMask is array like, e.g., np.ndarray, collections.abc.Sequence, etc.

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -33,7 +33,7 @@ class Collection(object):
     --------
     Filter a collection by boolean array indexing.
 
-        >>> lcc_filtered = lcc[(lcc.sector == 13) & (lcc.sector <= 19)]  # doctest: +SKIP
+        >>> lcc_filtered = lcc[(lcc.sector >= 13) & (lcc.sector <= 19)]  # doctest: +SKIP
         >>> lc22 = lcc[lcc.sector == 22][0]  # doctest: +SKIP
 
     Filter a collection by integer array indexing to get the object at index 0 and 2.
@@ -50,23 +50,23 @@ class Collection(object):
     def __len__(self):
         return len(self.data)
 
-    def __getitem__(self, indexOrMask):
-        if (isinstance(indexOrMask, (int, np.integer, slice))):
-            return self.data[indexOrMask]
-        elif (all([isinstance(i, (bool, np.bool_)) for i in indexOrMask])):
+    def __getitem__(self, index_or_mask):
+        if (isinstance(index_or_mask, (int, np.integer, slice))):
+            return self.data[index_or_mask]
+        elif (all([isinstance(i, (bool, np.bool_)) for i in index_or_mask])):
             # case indexOrMask is bool array like, e.g., np.ndarray, collections.abc.Sequence, etc.
 
             # note: filter using nd.array is very slow
             #   np.array(self.data)[np.nonzero(indexOrMask)]
             # specifically, nd.array(self.data) is very slow, as it deep copies the data
             # so we create the filtered list on our own
-            if (len(indexOrMask) != len(self.data)):
+            if (len(index_or_mask) != len(self.data)):
                 raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} '
-                                 f'but corresponding boolean dimension is {len(indexOrMask)}')
-            return type(self)([self.data[i] for i in np.nonzero(indexOrMask)[0]])
-        elif (all([isinstance(i, (int, np.integer)) for i in indexOrMask])):
+                                 f'but corresponding boolean dimension is {len(index_or_mask)}')
+            return type(self)([self.data[i] for i in np.nonzero(index_or_mask)[0]])
+        elif (all([isinstance(i, (int, np.integer)) for i in index_or_mask])):
             # case int array like, follow ndarray behavior
-            return type(self)([self.data[i] for i in indexOrMask])
+            return type(self)([self.data[i] for i in index_or_mask])
         else:
             raise IndexError('only integers, slices (`:`) and integer or boolean arrays are valid indices')
 

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -18,14 +18,6 @@ log = logging.getLogger(__name__)
 
 __all__ = ['LightCurveCollection', 'TargetPixelFileCollection']
 
-def _safe_sector(lcOrTpf):
-    try:
-        return lcOrTpf.sector
-    except AttributeError:
-        # return np.nan instead of None, so that the returned value can be used in a comparison
-        # e.g., lcc[lcc.sector < 25]
-        return np.nan
-
 class Collection(object):
     """Base class for `LightCurveCollection` and `TargetPixelFileCollection`.
 
@@ -129,6 +121,11 @@ class Collection(object):
             result += '\n'
         return result
 
+    def _safeGetScalarAttr(self, attrName):
+        # return np.nan when the attribute is missing, so that the returned value can be used in a comparison
+        # e.g., lcc[lcc.sector < 25]
+        return np.array([getattr(lcOrTpf, attrName, np.nan) for lcOrTpf in self.data])
+
     @property
     def sector(self):
         """(TESS-specific) the sectors of the lightcurves / target pixel files.
@@ -147,8 +144,23 @@ class Collection(object):
             >>> lcc[lcc.sector == 22][0].plot()  # doctest: +SKIP
 
         """
-        return np.array([_safe_sector(lc) for lc in self.data])
+        return self._safeGetScalarAttr('sector')
 
+    @property
+    def quarter(self):
+        """(Kepler-specific) the quarters of the lightcurves / target pixel files.
+
+        The Kepler quarters of the lightcurves / target pixel files; `numpy.nan` for those with none.
+        """
+        return self._safeGetScalarAttr('quarter')
+
+    @property
+    def campaign(self):
+        """(K2-specific) the campaigns of the lightcurves / target pixel files.
+
+        The K2 campaigns of the lightcurves / target pixel files; `numpy.nan` for those with none.
+        """
+        return self._safeGetScalarAttr('campaign')
 
 class LightCurveCollection(Collection):
     """Class to hold a collection of LightCurve objects.

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -45,16 +45,21 @@ class Collection(object):
     def __getitem__(self, indexOrMask):
         if (isinstance(indexOrMask, (int, np.integer, slice))):
             return self.data[indexOrMask]
-        else:
-            # assume indexOrMask is array like, e.g., np.ndarray, collections.abc.Sequence, etc.
+        elif (all([isinstance(i, (bool, np.bool_)) for i in indexOrMask])):
+            # case indexOrMask is bool array like, e.g., np.ndarray, collections.abc.Sequence, etc.
 
             # note: filter using nd.array is very slow
             #   np.array(self.data)[np.nonzero(indexOrMask)]
-            # specifically, nd.array(self.data) is very slow, it probably deep copies the data
+            # specifically, nd.array(self.data) is very slow, as it deep copies the data
             # so we create the filtered list on our own
             if (len(indexOrMask) != len(self.data)):
                 raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} but corresponding boolean dimension is {len(indexOrMask)}')
             return type(self)([self.data[i] for i in np.nonzero(indexOrMask)[0]])
+        elif (all([isinstance(i, (int, np.integer)) for i in indexOrMask])):
+            # case int array like, follow ndarray behavior
+            return type(self)([self.data[i] for i in indexOrMask])
+        else:
+            raise IndexError('only integers, slices (`:`) and integer or boolean arrays are valid indices')
 
     def __setitem__(self, index, obj):
         self.data[index] = obj

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -1,6 +1,5 @@
 """Defines collections of data products."""
 import logging
-import warnings
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -17,6 +16,7 @@ from .utils import LightkurveDeprecationWarning
 log = logging.getLogger(__name__)
 
 __all__ = ['LightCurveCollection', 'TargetPixelFileCollection']
+
 
 class Collection(object):
     """Base class for `LightCurveCollection` and `TargetPixelFileCollection`.
@@ -61,7 +61,8 @@ class Collection(object):
             # specifically, nd.array(self.data) is very slow, as it deep copies the data
             # so we create the filtered list on our own
             if (len(indexOrMask) != len(self.data)):
-                raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} but corresponding boolean dimension is {len(indexOrMask)}')
+                raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} '
+                                 f'but corresponding boolean dimension is {len(indexOrMask)}')
             return type(self)([self.data[i] for i in np.nonzero(indexOrMask)[0]])
         elif (all([isinstance(i, (int, np.integer)) for i in indexOrMask])):
             # case int array like, follow ndarray behavior
@@ -162,6 +163,7 @@ class Collection(object):
         """
         return self._safeGetScalarAttr('campaign')
 
+
 class LightCurveCollection(Collection):
     """Class to hold a collection of LightCurve objects.
 
@@ -209,7 +211,7 @@ class LightCurveCollection(Collection):
             Stitched light curve.
         """
         if corrector_func is None:
-            corrector_func = lambda x: x
+            corrector_func = lambda x: x  # noqa: E731
         lcs = [corrector_func(lc) for lc in self]
         # Need `join_type='inner'` until AstroPy supports masked Quantities
         return vstack(lcs, join_type='inner', metadata_conflicts='silent')

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -47,6 +47,8 @@ class Collection(object):
             #   np.array(self.data)[np.nonzero(indexOrMask)]
             # specifically, nd.array(self.data) is very slow, it probably deep copies the data
             # so we create the filtered list on our own
+            if (len(indexOrMask) != len(self.data)):
+                raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} but corresponding boolean dimension is {len(indexOrMask)}')
             return type(self)([self.data[i] for i in np.nonzero(indexOrMask)[0]])
 
     def __setitem__(self, index, obj):

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -29,10 +29,24 @@ def _safe_sector(lcOrTpf):
 class Collection(object):
     """Base class for `LightCurveCollection` and `TargetPixelFileCollection`.
 
+    A collection can be indexed by standard Python list syntax.
+    Additionally, it can be indexed by a subset of `numpy.ndarray` syntax: boolean array indexing and integer array indexing.
+
     Attributes
     ----------
     data: array-like
         List of data objects.
+
+    Examples
+    --------
+    Filter a collection by boolean array indexing.
+
+        >>> lcc_filtered = lcc[(lcc.sector == 13) & (lcc.sector <= 19)]  # doctest: +SKIP
+        >>> lc22 = lcc[lcc.sector == 22][0]  # doctest: +SKIP
+
+    Filter a collection by integer array indexing to get the object at index 0 and 2.
+
+        >>>  lcc_filtered = lcc[0, 2]  # doctest: +SKIP
     """
     def __init__(self, data):
         if data is not None:
@@ -117,7 +131,21 @@ class Collection(object):
 
     @property
     def sector(self):
-        """(TESS-specific) the sectors of the lightcurves / target pixel files; np.nan for objects with no sector.
+        """(TESS-specific) the sectors of the lightcurves / target pixel files.
+
+        The TESS sectors of the lightcurves / target pixel files; `numpy.nan` for those with no sector.
+        The attribute is useful for filtering a collection by sector.
+
+        Examples
+        --------
+        Plot two lightcurves, one from TESS sectors 13 to 19, and one for sector 22
+
+            >>> import lightkurve as lk
+            >>> lcc = lk.search_lightcurve('TIC286923464', mission='TESS').download_all()  # doctest: +SKIP
+            >>> lcc_filtered = lcc[(lcc.sector >= 13) & (lcc.sector <= 19)]  # doctest: +SKIP
+            >>> lcc_filtered.plot()  # doctest: +SKIP
+            >>> lcc[lcc.sector == 22][0].plot()  # doctest: +SKIP
+
         """
         return np.array([_safe_sector(lc) for lc in self.data])
 

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -22,7 +22,9 @@ def _safe_sector(lcOrTpf):
     try:
         return lcOrTpf.sector
     except AttributeError:
-        return None
+        # return np.nan instead of None, so that the returned value can be used in a comparison
+        # e.g., lcc[lcc.sector < 25]
+        return np.nan
 
 class Collection(object):
     """Base class for `LightCurveCollection` and `TargetPixelFileCollection`.
@@ -115,7 +117,7 @@ class Collection(object):
 
     @property
     def sector(self):
-        """(TESS-specific) the sectors of the lightcurves / target pixel files
+        """(TESS-specific) the sectors of the lightcurves / target pixel files; np.nan for objects with no sector.
         """
         return np.array([_safe_sector(lc) for lc in self.data])
 

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -117,7 +117,7 @@ class Collection(object):
     def sector(self):
         """(TESS-specific) the sectors of the lightcurves / target pixel files
         """
-        return [_safe_sector(lc) for lc in self.data]
+        return np.array([_safe_sector(lc) for lc in self.data])
 
 
 class LightCurveCollection(Collection):

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -18,6 +18,11 @@ log = logging.getLogger(__name__)
 
 __all__ = ['LightCurveCollection', 'TargetPixelFileCollection']
 
+def _safe_sector(lcOrTpf):
+    try:
+        return lcOrTpf.sector
+    except AttributeError:
+        return None
 
 class Collection(object):
     """Base class for `LightCurveCollection` and `TargetPixelFileCollection`.
@@ -107,7 +112,7 @@ class Collection(object):
     def sector(self):
         """(TESS-specific) the sectors of the lightcurves / target pixel files
         """
-        return np.array([lc.sector for lc in self.data])
+        return [_safe_sector(lc) for lc in self.data]
 
 
 class LightCurveCollection(Collection):

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -57,6 +57,40 @@ def test_collection_getitem():
     with pytest.raises(IndexError):
         lcc[50]
 
+def test_collection_getitem_by_boolean_array():
+    """Tests Collection.__getitem__ , case the argument is a mask, i.e, indexed by boolean array"""
+    lc0 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
+                    flux_err=np.arange(1, 5), targetid=50000)
+    lc1 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
+                     flux_err=np.arange(10, 15), targetid=120334)
+    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
+                     flux_err=np.arange(15, 20), targetid=23456)
+    lcc = LightCurveCollection([lc0, lc1, lc2])
+
+    lcc_f = lcc[[True, False, True]]
+    assert(lcc_f.data == [lc0, lc2])
+    assert(type(lcc_f), LightCurveCollection)
+
+    # boundary case: 1 element
+    lcc_f = lcc[[False, True, False]]
+    assert(lcc_f.data == [lc1])
+    # boundary case: no element
+    lcc_f = lcc[[False, False, False]]
+    assert(lcc_f.data == [])
+    # other array-like input: tuple
+    lcc_f = lcc[(True, False, True)]
+    assert(lcc_f.data == [lc0, lc2])
+    # other array-like input: ndarray
+    lcc_f = lcc[np.array([True, False, True])]
+    assert(lcc_f.data == [lc0, lc2])
+
+    # boundary case: mask length not matching - shorter
+    with pytest.raises(IndexError):
+        lcc[[True, False]]
+
+    # boundary case: mask length not matching - longer
+    with pytest.raises(IndexError):
+        lcc[[True, False, True, True]]
 
 def test_collection_setitem():
     """Tests Collection. __setitem__"""
@@ -88,6 +122,10 @@ def test_tpfcollection():
     assert(tpfc[2] == tpf2)
     with pytest.raises(IndexError):
         tpfc[51]
+    # ensure index by boolean array also works for TPFs
+    tpfc_f = tpfc[[False, True, True]]
+    assert(tpfc_f.data == [tpf2, tpf2])
+    assert(type(tpfc_f), TargetPixelFileCollection)
     # Test __setitem__
     tpf3 = KeplerTargetPixelFile(filename_tpf_one_center, targetid=55)
     tpfc[1] = tpf3

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -199,13 +199,22 @@ def test_accessor_tess_sector():
                          flux_err=np.arange(10, 15), targetid=120334)
     lc1.sector = 26
     lcc = LightCurveCollection([lc0, lc1])
-    assert(lcc.sector == [14, 26])
+    assert((lcc.sector == [14, 26]).all())
+    # The sector accessor can be used to generate boolean array
+    # to support filter collection by sector
+    assert(((lcc.sector == 26) == [False, True]).all())
+    assert(((lcc.sector < 20) == [True, False]).all())
 
     # boundary condition: some lightcurve objects do not have sector
     lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
                      flux_err=np.arange(15, 20), targetid=23456)
     lcc.append(lc2)
-    assert(lcc.sector == [14, 26, None])
+    assert((lcc.sector == [14, 26, None]).all())
+    # The sector accessor can be used to generate boolean array
+    # to support filter collection by sector
+    assert(((lcc.sector == 26) == [False, True, False]).all())
+    # OPEN: does not work yet. as None < 20 yields type error
+    # assert(((lcc.sector < 20) == [True, False, False]).all())
 
     # ensure it works for TPFs too.
     tpf = TessTargetPixelFile(filename_tpf_all_zeros)
@@ -215,5 +224,5 @@ def test_accessor_tess_sector():
     tpf3 = TessTargetPixelFile(filename_tpf_one_center)
     tpf3.hdu[0].header['SECTOR'] = 1
     tpfc = TargetPixelFileCollection([tpf, tpf2, tpf3])
-    assert(tpfc.sector == [23, None, 1])
+    assert((tpfc.sector == [23, None, 1]).all())
 

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -4,9 +4,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_array_equal
 
+<<<<<<< HEAD
 from ..lightcurve import LightCurve
 from ..search import search_lightcurve
 from ..targetpixelfile import KeplerTargetPixelFile
+=======
+from ..lightcurve import LightCurve, TessLightCurve
+from ..targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
+>>>>>>> 1608e57... Collection.sector - test; handle boundary cases
 from ..collections import LightCurveCollection, TargetPixelFileCollection
 
 filename_tpf_all_zeros = get_pkg_data_filename("data/test-tpf-all-zeros.fits")
@@ -154,3 +159,31 @@ def test_stitch_repr():
     # The line below used to raise `ValueError: Unable to parse format string
     # "{:10d}" for entry "70445.0" in column "cadenceno"`
     LightCurveCollection((lc,lc)).stitch().__repr__()
+
+
+def test_accessor_tess_sector():
+    lc0 = TessLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
+                         flux_err=np.arange(1, 5), targetid=50000)
+    lc0.sector = 14
+    lc1 = TessLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
+                         flux_err=np.arange(10, 15), targetid=120334)
+    lc1.sector = 26
+    lcc = LightCurveCollection([lc0, lc1])
+    assert(lcc.sector == [14, 26])
+
+    # boundary condition: some lightcurve objects do not have sector
+    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
+                     flux_err=np.arange(15, 20), targetid=23456)
+    lcc.append(lc2)
+    assert(lcc.sector == [14, 26, None])
+
+    # ensure it works for TPFs too.
+    tpf = TessTargetPixelFile(filename_tpf_all_zeros)
+    tpf.hdu[0].header['SECTOR'] = 23
+    tpf2 = TessTargetPixelFile(filename_tpf_one_center)
+    # tpf2 has no sector defined
+    tpf3 = TessTargetPixelFile(filename_tpf_one_center)
+    tpf3.hdu[0].header['SECTOR'] = 1
+    tpfc = TargetPixelFileCollection([tpf, tpf2, tpf3])
+    assert(tpfc.sector == [23, None, 1])
+

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -229,13 +229,14 @@ def test_accessor_tess_sector():
     tpfc = TargetPixelFileCollection([tpf, tpf2, tpf3])
     assert((tpfc.sector == [23, None, 1]).all())
 
+
 def test_accessor_kepler_quarter():
     # scaled down version of tess sector test, as they share the same codepath
     lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
+                           flux_err=np.arange(1, 5), targetid=50000)
     lc0.quarter = 2
     lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
+                           flux_err=np.arange(10, 15), targetid=120334)
     lc1.quarter = 1
     lcc = LightCurveCollection([lc0, lc1])
     assert((lcc.quarter == [2, 1]).all())
@@ -248,13 +249,14 @@ def test_accessor_kepler_quarter():
     tpfc = TargetPixelFileCollection([tpf0, tpf1])
     assert((tpfc.quarter == [2, 1]).all())
 
+
 def test_accessor_k2_campaign():
     # scaled down version of tess sector test, as they share the same codepath
     lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
+                           flux_err=np.arange(1, 5), targetid=50000)
     lc0.campaign = 2
     lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
+                           flux_err=np.arange(10, 15), targetid=120334)
     lc1.campaign = 1
     lcc = LightCurveCollection([lc0, lc1])
     assert((lcc.campaign == [2, 1]).all())

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -209,12 +209,13 @@ def test_accessor_tess_sector():
     lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
                      flux_err=np.arange(15, 20), targetid=23456)
     lcc.append(lc2)
-    assert((lcc.sector == [14, 26, None]).all())
+    # expecting [14, 26, np.nan], need 2 asserts to do it.
+    assert((lcc.sector[:-1] == [14, 26]).all())
+    assert(np.isnan(lcc.sector[-1]))
     # The sector accessor can be used to generate boolean array
     # to support filter collection by sector
     assert(((lcc.sector == 26) == [False, True, False]).all())
-    # OPEN: does not work yet. as None < 20 yields type error
-    # assert(((lcc.sector < 20) == [True, False, False]).all())
+    assert(((lcc.sector < 20) == [True, False, False]).all())
 
     # ensure it works for TPFs too.
     tpf = TessTargetPixelFile(filename_tpf_all_zeros)

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -4,14 +4,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_array_equal
 
-<<<<<<< HEAD
-from ..lightcurve import LightCurve
+from ..lightcurve import LightCurve, KeplerLightCurve, TessLightCurve
 from ..search import search_lightcurve
-from ..targetpixelfile import KeplerTargetPixelFile
-=======
-from ..lightcurve import LightCurve, TessLightCurve
 from ..targetpixelfile import KeplerTargetPixelFile, TessTargetPixelFile
->>>>>>> 1608e57... Collection.sector - test; handle boundary cases
 from ..collections import LightCurveCollection, TargetPixelFileCollection
 
 filename_tpf_all_zeros = get_pkg_data_filename("data/test-tpf-all-zeros.fits")
@@ -227,3 +222,40 @@ def test_accessor_tess_sector():
     tpfc = TargetPixelFileCollection([tpf, tpf2, tpf3])
     assert((tpfc.sector == [23, None, 1]).all())
 
+def test_accessor_kepler_quarter():
+    # scaled down version of tess sector test, as they share the same codepath
+    lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
+                    flux_err=np.arange(1, 5), targetid=50000)
+    lc0.quarter = 2
+    lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
+                     flux_err=np.arange(10, 15), targetid=120334)
+    lc1.quarter = 1
+    lcc = LightCurveCollection([lc0, lc1])
+    assert((lcc.quarter == [2, 1]).all())
+
+    # ensure it works for TPFs too.
+    tpf0 = KeplerTargetPixelFile(filename_tpf_all_zeros)
+    tpf0.hdu[0].header['QUARTER'] = 2
+    tpf1 = KeplerTargetPixelFile(filename_tpf_one_center)
+    tpf1.hdu[0].header['QUARTER'] = 1
+    tpfc = TargetPixelFileCollection([tpf0, tpf1])
+    assert((tpfc.quarter == [2, 1]).all())
+
+def test_accessor_k2_campaign():
+    # scaled down version of tess sector test, as they share the same codepath
+    lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
+                    flux_err=np.arange(1, 5), targetid=50000)
+    lc0.campaign = 2
+    lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
+                     flux_err=np.arange(10, 15), targetid=120334)
+    lc1.campaign = 1
+    lcc = LightCurveCollection([lc0, lc1])
+    assert((lcc.campaign == [2, 1]).all())
+
+    # ensure it works for TPFs too.
+    tpf0 = KeplerTargetPixelFile(filename_tpf_all_zeros)
+    tpf0.hdu[0].header['CAMPAIGN'] = 2
+    tpf1 = KeplerTargetPixelFile(filename_tpf_one_center)
+    tpf1.hdu[0].header['CAMPAIGN'] = 1
+    tpfc = TargetPixelFileCollection([tpf0, tpf1])
+    assert((tpfc.campaign == [2, 1]).all())

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -97,6 +97,33 @@ def test_collection_getitem_by_boolean_array():
     with pytest.raises(IndexError):
         lcc[[True, False, True, True]]
 
+def test_collection_getitem_by_other_array():
+    """Tests Collection.__getitem__ , case the argument an non-boolean array"""
+    lc0 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
+                    flux_err=np.arange(1, 5), targetid=50000)
+    lc1 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
+                     flux_err=np.arange(10, 15), targetid=120334)
+    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
+                     flux_err=np.arange(15, 20), targetid=23456)
+    lcc = LightCurveCollection([lc0, lc1, lc2])
+
+    # case: an int array-like, follow ndarray behavior
+    lcc_f = lcc[[2, 0]]
+    assert(lcc_f.data == [lc2, lc0])
+    lcc_f = lcc[np.array([2, 0])]
+    assert(lcc_f.data == [lc2, lc0])
+    # boundary condition: True / False is interpreted as 1/0 in an bool/int mixed array-like
+    lcc_f = lcc[[True, False, 2]]
+    assert(lcc_f.data == [lc1, lc0, lc2])
+    # boundary condition: some index is out of bound
+    with pytest.raises(IndexError):
+        lcc[[2, 99]]
+    # boundary conditions: array-like of neither bool or int, follow ndarray behavior
+    with pytest.raises(IndexError):
+        lcc[['abc', 'def']]
+    with pytest.raises(IndexError):
+        lcc[[True, 'def']]
+
 def test_collection_setitem():
     """Tests Collection. __setitem__"""
     lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -112,6 +112,9 @@ def test_collection_getitem_by_other_array():
     assert(lcc_f.data == [lc2, lc0])
     lcc_f = lcc[np.array([2, 0])]
     assert(lcc_f.data == [lc2, lc0])
+    # support other int types in np too
+    lcc_f = lcc[np.array([np.int64(2), np.uint8(0)])]
+    assert(lcc_f.data == [lc2, lc0])
     # boundary condition: True / False is interpreted as 1/0 in an bool/int mixed array-like
     lcc_f = lcc[[True, False, 2]]
     assert(lcc_f.data == [lc1, lc0, lc2])

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -192,10 +192,10 @@ def test_stitch_repr():
 def test_accessor_tess_sector():
     lc0 = TessLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
                          flux_err=np.arange(1, 5), targetid=50000)
-    lc0.sector = 14
+    lc0.meta['SECTOR'] = 14
     lc1 = TessLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
                          flux_err=np.arange(10, 15), targetid=120334)
-    lc1.sector = 26
+    lc1.meta['SECTOR'] = 26
     lcc = LightCurveCollection([lc0, lc1])
     assert((lcc.sector == [14, 26]).all())
     # The sector accessor can be used to generate boolean array
@@ -234,10 +234,10 @@ def test_accessor_kepler_quarter():
     # scaled down version of tess sector test, as they share the same codepath
     lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
                            flux_err=np.arange(1, 5), targetid=50000)
-    lc0.quarter = 2
+    lc0.meta['QUARTER'] = 2
     lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
                            flux_err=np.arange(10, 15), targetid=120334)
-    lc1.quarter = 1
+    lc1.meta['QUARTER'] = 1
     lcc = LightCurveCollection([lc0, lc1])
     assert((lcc.quarter == [2, 1]).all())
 
@@ -254,10 +254,10 @@ def test_accessor_k2_campaign():
     # scaled down version of tess sector test, as they share the same codepath
     lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
                            flux_err=np.arange(1, 5), targetid=50000)
-    lc0.campaign = 2
+    lc0.meta['CAMPAIGN'] = 2
     lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
                            flux_err=np.arange(10, 15), targetid=120334)
-    lc1.campaign = 1
+    lc1.meta['CAMPAIGN'] = 1
     lcc = LightCurveCollection([lc0, lc1])
     assert((lcc.campaign == [2, 1]).all())
 


### PR DESCRIPTION
Closes #621 

The commits are a first cut for review.

From API users' perspective, he/she can then filter a LightCurve / TargetPixelFile Collection by  the following.

``` python

# Assuming lc_col has 3 LightCurves, in sectors 24, 25 and 26.

> filtered = lc_col[lc_col.sector == 25]
LightCurveCollection of 1 objects: # the one for sector 25

> filtered = lc_col[np.in1d(lc_col.sector, (25, 26))]
LightCurveCollection of 2 objects: # the one for sector 25, 26

# To get the lightcurve of one sector
> lc_col[lc_col.sector == 25][0]

```

Notes:
- The return results are LightCurve / TargetPixelFile Collection, so users can use the usual APIs e.g., stitch, plot, etc.
- Implementation-wise, I have to add TESS-specific `sector` property to `Collection` base class. And Kepler-specific ones `campaign` and `quarter` will be needed as well. It's a bit ugly, but I don't know how we can get around it, unless we have new TESS / Kepler-specific collections (4 additional classes), something like:

```python
class TessLightCurveCollection(LightCurveCollection, TessPropertiesMixin):
   ...
```


