### PR TITLE
Code clean-up: K2 campaigns 9/10/11 now have consistent `sequence_number` values in the MAST portal

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -12,7 +12,6 @@ from astropy.table import join, Table, Row
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii
 from astropy import units as u
-from astropy.utils.exceptions import AstropyWarning
 from astropy.utils import deprecated
 
 from .targetpixelfile import TargetPixelFile
@@ -683,19 +682,6 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence='long',
         provenance_name = None
     else:
         provenance_name = np.atleast_1d(provenance_name).tolist()
-
-    # Temporary bug workaround: MAST assigned `sequence_number=92` to both
-    # C91 and C92 observations at the time of writing.
-    if (9 in np.atleast_1d(campaign)) or (91 in np.atleast_1d(campaign)):
-        campaign = np.atleast_1d(campaign).tolist()
-        campaign.append(91)
-        campaign.append(92)
-    # Temporary bug workaround: MAST assigned sequence_number 111 or 112
-    # to C11 observations; this code below makes `campaign=11` work regardless.
-    if 11 in np.atleast_1d(campaign):
-        campaign = np.atleast_1d(campaign).tolist()
-        campaign.append(111)
-        campaign.append(112)
 
     # Speed up by restricting the MAST query if we don't want FFI image data
     extra_query_criteria = {}

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -45,27 +45,18 @@ def test_search_targetpixelfile():
     assert(len(search_targetpixelfile("pi Men")[-1]) == 1)
 
 
-# The test below currently fail because the MAST portal does not consistently
-# assign `sequence_number` at the time of writing, i.e.
-# * C91 and C91 appear bundled into one observation with sequence number "91" (example: EPIC 228162462)
-# * C101 and C102 appear bundled together with sequence number "10" (example: EPIC 228726301)
-# * C111 and C112 appear as *separate* observations with sequence numbers "111" and "112" (example: EPIC 202975993)
-# This issue is expected to be resolved by September 2020, at which point
-# we should try and revive this test.
-@pytest.mark.xfail
 def test_search_split_campaigns():
-    """Searches should should work for split campaigns."""
-    campaigns = [[91, 92, 9], [101, 102, 10], [111, 112, 11]]
+    """Searches should should work for split campaigns.
+
+    K2 Campaigns 9, 10, and 11 were split into two halves for various technical
+    reasons (C91=C9a, C92=C9b, C101=C10a, C102=C10b, C111=C11a, C112=C11b).
+    We expect most targets from those campaigns to return two TPFs.
+    """
+    campaigns = [9, 10, 11]
     ids = ['EPIC 228162462', 'EPIC 228726301', 'EPIC 202975993']
     for c, idx in zip(campaigns, ids):
-        ca = search_targetpixelfile(idx, campaign=c[0]).table
-        cb = search_targetpixelfile(idx, campaign=c[1]).table
-        assert(len(ca) == 1)
-        assert(len(ca) == len(cb))
-        assert(~np.any(ca['description'] == cb['description']))
-        # If you specify the whole campaign, both split parts must be returned.
-        cc = search_targetpixelfile(idx, campaign=c[2]).table
-        assert(len(cc) == 2)
+        search = search_targetpixelfile(idx, campaign=c).table
+        assert(len(search) == 2)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
### Background

For spacecraft reasons, K2 Campaigns 9, 10, and 11 were split into two halves, and most targets have two target pixel files available for those campaigns.  This caused data search issues in the past because the campaign numbers (aka `sequence_number`) in the MAST portal were assigned in a complicated way:
* C91 and C91 were bundled into one observation with sequence number "91" (example: EPIC 228162462)
* C101 and C102 were bundled together with sequence number "10" (example: EPIC 228726301)
* C111 and C112 appeared as *separate* observations with sequence numbers "111" and "112" (example: EPIC 202975993)

### New situation

The awesome @scfleming notified me that this has now been fixed.  Going forward, all C9 observations have `sequence_number=9` in the MAST portal, all C10 observations have `sequence_number=10`, and all C11 observations have `sequence_number=11`.  As a result, users now simply enter `campaign=9`, `campaign=10`, or `campaign=11` in the Lightkurve search functions, rather than "91", "111", etc.

### Code clean-up

The change allows us to remove some workaround code in the `lightkurve.search` module, and restore a unit test which checks the correction behavior of searching split campaigns.  This PR makes those changes.