### PR TITLE
Fix #800: avoid "LightCurveFile.header is deprecated" warning when downloading light curves

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ===================
 
 - Fixed a warning being issued (``"LightCurveFile.header is deprecated"``)
-  when downloading light curve files from MAST.
+  when downloading light curve files from MAST. [#819]
 
 
 1.11.1 (2020-06-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.11.2 (2020-08-28)
+===================
+
+- Fixed a warning being issued (``"LightCurveFile.header is deprecated"``)
+  when downloading light curve files from MAST.
+
+
 1.11.1 (2020-06-18)
 ===================
 

--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -308,7 +308,7 @@ class KeplerLightCurveFile(LightCurveFile):
         super(KeplerLightCurveFile, self).__init__(path, **kwargs)
 
         # check to make sure the correct filetype has been provided
-        filetype = detect_filetype(self.header())
+        filetype = detect_filetype(self.get_header())
         if filetype == 'TessLightCurveFile':
             warnings.warn("A TESS data product is being opened using the "
                           "`KeplerLightCurveFile` class. "
@@ -466,7 +466,7 @@ class TessLightCurveFile(LightCurveFile):
         super(TessLightCurveFile, self).__init__(path, **kwargs)
 
         # check to make sure the correct filetype has been provided
-        filetype = detect_filetype(self.header())
+        filetype = detect_filetype(self.get_header())
         if filetype == 'KeplerLightCurveFile':
             warnings.warn("A Kepler data product is being opened using the "
                           "`TessLightCurveFile` class. "


### PR DESCRIPTION
In Lightkurve v1.11.1, an annoying deprecation warning is raised when downloading data:

![Screenshot from 2020-08-28 10-34-41](https://user-images.githubusercontent.com/817669/91597950-1a6d1780-e91a-11ea-9143-01ebe6b62d03.png)

This PR removes the cause and fixes #800 

This issue does not affect the current Lightkurve v2.x development on the master branch.  It only affects v1.11.1, and is being merged only into the `v1.11.x` branch so that in can be incorporated into a v1.11.2 bugfix release.