### PR TITLE
Add `__citation__` property and `show_citation_instructions()` function

### DIFF
--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -6,6 +6,27 @@ import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 MPLSTYLE = '{}/data/lightkurve.mplstyle'.format(PACKAGEDIR)
 
+
+# Bibtex entry detailing how to cite the package
+__citation__ = """@MISC{2018ascl.soft12013L,
+    author = {{Lightkurve Collaboration} and {Cardoso}, J.~V.~d.~M. and
+                {Hedges}, C. and {Gully-Santiago}, M. and {Saunders}, N. and
+                {Cody}, A.~M. and {Barclay}, T. and {Hall}, O. and
+                {Sagear}, S. and {Turtelboom}, E. and {Zhang}, J. and
+                {Tzanidakis}, A. and {Mighell}, K. and {Coughlin}, J. and
+                {Bell}, K. and {Berta-Thompson}, Z. and {Williams}, P. and
+                {Dotson}, J. and {Barentsen}, G.},
+    title = "{Lightkurve: Kepler and TESS time series analysis in Python}",
+    keywords = {Software, NASA},
+howpublished = {Astrophysics Source Code Library},
+        year = 2018,
+    month = dec,
+archivePrefix = "ascl",
+    eprint = {1812.013},
+    adsurl = {http://adsabs.harvard.edu/abs/2018ascl.soft12013L},
+}"""
+
+
 # By default Matplotlib is configured to work with a graphical user interface
 # which may require an X11 connection (i.e. a display).  When no display is
 # available, errors may occur.  In this case, we default to the robust Agg backend.

--- a/lightkurve/data/show_citation_instructions.html
+++ b/lightkurve/data/show_citation_instructions.html
@@ -55,7 +55,7 @@ ASTROQUERY_CITATION
     </textarea>
 
     <p>
-        When using Lightkurve, we request that you cite the following packages:
+        When using Lightkurve, we kindly request that you cite the following packages:
         <ul>
             <li>
                 <a href="https://docs.lightkurve.org">lightkurve</a>
@@ -68,12 +68,12 @@ ASTROQUERY_CITATION
             <li>
                 <a href="https://astroquery.readthedocs.io">astroquery</a>
                 <button onclick="copyBibtex('astroquery')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
-                —  if you are using the <i>search</i> features.
+                —  if you are using <i>search_lightcurve()</i> or <i>search_targetpixelfile()</i>.
             </li>
             <li>
                 <a href="https://mast.stsci.edu/tesscut/">tesscut</a>
                 <button onclick="copyBibtex('tesscut')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
-                — if you are using <i>search_tesscut</i>>.
+                — if you are using <i>search_tesscut()</i>.
             </li>
         </ul>
     </p>

--- a/lightkurve/data/show_citation_instructions.html
+++ b/lightkurve/data/show_citation_instructions.html
@@ -1,0 +1,80 @@
+<head>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+
+<style>
+    button {
+        border: 1px solid;
+        padding: 0.2em;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        font-size: 0.8em;
+        margin: 0.2em;
+        cursor: pointer;
+    }
+
+    .citation-button-1 {background-color: #4CAF50;} /* Green */
+    .citation-button-2 {background-color: #008CBA;} /* Blue */
+</style>
+
+<script type="text/javascript">
+    function copyBibtex(package) {
+        var copyText = document.getElementById(package + "Text");
+        copyText.select();
+        document.execCommand("copy");
+        alert("BibTex has been copied to your clipboard")
+    }
+</script>
+</head>
+
+<body>
+    <textarea id="lightkurveText" style="position: absolute; left: -9999px; z-index: -9999;">
+LIGHTKURVE_CITATION
+    </textarea>
+    <textarea id="astropyText" style="position: absolute; left: -9999px; z-index: -9999;">
+ASTROPY_CITATION
+    </textarea>
+    <textarea id="astroqueryText" style="position: absolute; left: -9999px; z-index: -9999;">
+ASTROQUERY_CITATION
+    </textarea>
+    <textarea id="tesscutText" style="position: absolute; left: -9999px; z-index: -9999;">
+@MISC{2019ascl.soft05007B,
+        author = {{Brasseur}, C.~E. and {Phillip}, Carlita and {Fleming}, Scott W. and
+          {Mullally}, S.~E. and {White}, Richard L.},
+         title = "{Astrocut: Tools for creating cutouts of TESS images}",
+      keywords = {Software},
+          year = 2019,
+         month = may,
+           eid = {ascl:1905.007},
+         pages = {ascl:1905.007},
+ archivePrefix = {ascl},
+        eprint = {1905.007},
+        adsurl = {https://ui.adsabs.harvard.edu/abs/2019ascl.soft05007B},
+       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+    </textarea> 
+ 
+    <p>
+        When using Lightkurve, we request that you cite the following packages:
+        <ul>
+            <li>
+                <a href="https://docs.lightkurve.org">lightkurve</a>
+                <button onclick="copyBibtex('lightkurve')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
+            </li>
+            <li>
+                <a href="https://astropy.org">astropy</a>
+                <button onclick="copyBibtex('astropy')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
+            </li>
+            <li>
+                <a href="https://astroquery.readthedocs.io">astroquery</a>
+                <button onclick="copyBibtex('astroquery')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
+                —  for enabling the search features.
+            </li>
+            <li>
+                <a href="https://mast.stsci.edu/tesscut/">tesscut</a>
+                <button onclick="copyBibtex('tesscut')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
+                — for enabling the search_tesscut feature.
+            </li>
+        </ul>
+    </p>
+</body>

--- a/lightkurve/data/show_citation_instructions.html
+++ b/lightkurve/data/show_citation_instructions.html
@@ -52,8 +52,8 @@ ASTROQUERY_CITATION
         adsurl = {https://ui.adsabs.harvard.edu/abs/2019ascl.soft05007B},
        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
  }
-    </textarea> 
- 
+    </textarea>
+
     <p>
         When using Lightkurve, we request that you cite the following packages:
         <ul>
@@ -68,12 +68,12 @@ ASTROQUERY_CITATION
             <li>
                 <a href="https://astroquery.readthedocs.io">astroquery</a>
                 <button onclick="copyBibtex('astroquery')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
-                —  for enabling the search features.
+                —  if you are using the <i>search</i> features.
             </li>
             <li>
                 <a href="https://mast.stsci.edu/tesscut/">tesscut</a>
                 <button onclick="copyBibtex('tesscut')"><i class="fas fa-clipboard"></i> Copy BibTeX</button>
-                — for enabling the search_tesscut feature.
+                — if you are using <i>search_tesscut</i>>.
             </li>
         </ul>
     </p>

--- a/lightkurve/tests/test_utils.py
+++ b/lightkurve/tests/test_utils.py
@@ -1,11 +1,8 @@
-from __future__ import division, print_function
+import pytest
+import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
-from astropy.io import fits
-import pytest
-import warnings
-import os
 
 from ..utils import KeplerQualityFlags, TessQualityFlags
 from ..utils import module_output_to_channel, channel_to_module_output
@@ -13,9 +10,9 @@ from ..utils import LightkurveWarning
 from ..utils import running_mean, validate_method
 from ..utils import bkjd_to_astropy_time, btjd_to_astropy_time
 from ..utils import centroid_quadratic
+from ..utils import show_citation_instructions
 from ..lightcurve import LightCurve
 
-from .. import PACKAGEDIR
 
 def test_channel_to_module_output():
     assert channel_to_module_output(1) == (2, 1)
@@ -167,3 +164,7 @@ def test_centroid_quadratic_robustness():
     data[-1, -1] = 10
     col, row = centroid_quadratic(data)
     assert np.isfinite(col) & np.isfinite(row)
+
+
+def test_show_citation_instructions():
+    show_citation_instructions()

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -663,14 +663,45 @@ def _query_solar_system_objects(ra, dec, times, radius=0.1, location='kepler',
 
 def show_citation_instructions():
     """Show citation instructions."""
-    from pathlib import Path
-    from IPython.display import HTML
     from . import PACKAGEDIR, __citation__
-    import astroquery
+    if not is_notebook():
+        print(__citation__)
+    else:
+        from pathlib import Path
+        from IPython.display import HTML
+        import astroquery
+        templatefile = Path(PACKAGEDIR, 'data', 'show_citation_instructions.html')
+        template = open(templatefile, 'r').read()
+        template = template.replace("LIGHTKURVE_CITATION", __citation__)
+        template = template.replace("ASTROPY_CITATION", astropy.__citation__)
+        template = template.replace("ASTROQUERY_CITATION", astroquery.__citation__)
+        return HTML(template)
 
-    templatefile = Path(PACKAGEDIR, 'data', 'show_citation_instructions.html')
-    template = open(templatefile, 'r').read()
-    template = template.replace("LIGHTKURVE_CITATION", __citation__)
-    template = template.replace("ASTROPY_CITATION", astropy.__citation__)
-    template = template.replace("ASTROQUERY_CITATION", astroquery.__citation__)
-    return HTML(template)
+
+def _get_notebook_environment():
+    """Returns 'jupyter', 'colab', or 'terminal'.
+
+    One can detect whether or not a piece of Python is running by executing
+    `get_ipython().__class__`, which returns the following result:
+
+        * Jupyter notebook: `ipykernel.zmqshell.ZMQInteractiveShell`
+        * Google colab: `google.colab._shell.Shell`
+        * IPython terminal: `IPython.terminal.interactiveshell.TerminalInteractiveShell`
+        * Python terminal: `NameError: name 'get_ipython' is not defined`
+    """
+    try:
+        ipy = str(type(get_ipython())).lower()
+        if 'zmqshell' in ipy:
+            return 'jupyter'
+        if 'colab' in ipy:
+            return 'colab'
+    except NameError:
+        pass  # get_ipython() is not a builtin
+    return 'terminal'
+
+
+def is_notebook():
+    """Returns `True` if we are running in a notebook."""
+    if _get_notebook_environment() in ['jupyter', 'colab']:
+        return True
+    return False

--- a/lightkurve/utils.py
+++ b/lightkurve/utils.py
@@ -3,27 +3,30 @@ import logging
 import sys
 import os
 import warnings
+from functools import wraps
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
 import numpy as np
 import pandas as pd
+from tqdm import tqdm
 
+import astropy
 from astropy.utils.data import download_file
-from astropy.coordinates import SkyCoord
 from astropy.units.quantity import Quantity
 import astropy.units as u
 from astropy.visualization import (PercentileInterval, ImageNormalize,
                                    SqrtStretch, LinearStretch)
 from astropy.time import Time
-import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
-from functools import wraps
 
-from tqdm import tqdm
 
 log = logging.getLogger(__name__)
 
+
 __all__ = ['LightkurveError', 'LightkurveWarning',
            'KeplerQualityFlags', 'TessQualityFlags',
-           'bkjd_to_astropy_time', 'btjd_to_astropy_time']
+           'bkjd_to_astropy_time', 'btjd_to_astropy_time',
+           'show_citation_instructions']
 
 
 class QualityFlags(object):
@@ -656,3 +659,18 @@ def _query_solar_system_objects(ra, dec, times, radius=0.1, location='kepler',
     if df is not None:
         df.reset_index(drop=True)
     return df
+
+
+def show_citation_instructions():
+    """Show citation instructions."""
+    from pathlib import Path
+    from IPython.display import HTML
+    from . import PACKAGEDIR, __citation__
+    import astroquery
+
+    templatefile = Path(PACKAGEDIR, 'data', 'show_citation_instructions.html')
+    template = open(templatefile, 'r').read()
+    template = template.replace("LIGHTKURVE_CITATION", __citation__)
+    template = template.replace("ASTROPY_CITATION", astropy.__citation__)
+    template = template.replace("ASTROQUERY_CITATION", astroquery.__citation__)
+    return HTML(template)


### PR DESCRIPTION
Recently, @nksaunders proposed to show convenient BibTex copy/paste buttons in tutorial notebooks.

This PR explores adding a function to Lightkurve to show those buttons in a convenient way.  Demo:

![lk-citation](https://user-images.githubusercontent.com/817669/91903120-8b346c80-ec57-11ea-8aa7-6973695e678f.png)

This PR also adds the generic `__citation__` property to the package:

![lk-citation-2](https://user-images.githubusercontent.com/817669/91903195-b0c17600-ec57-11ea-89fa-967625ace90d.png)

Thoughts or comments anyone?

(Note: before merging, we have to make sure this function also works in a non-notebook environment.)