### PR TITLE
bugfix - TessLightCurveFile compatibility API

### DIFF
--- a/lightkurve/lightcurvefile.py
+++ b/lightkurve/lightcurvefile.py
@@ -7,4 +7,4 @@ from . import LightCurve, KeplerLightCurve, TessLightCurve
 
 LightCurveFile = LightCurve
 KeplerLightCurveFile = KeplerLightCurve.read
-TessLightCurveFile = TessLightCurve
+TessLightCurveFile = TessLightCurve.read

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -143,7 +143,7 @@ def test_KeplerLightCurveFile(path, mission):
                          ['hardest', 'hard', 'default', None,
                           1, 100, 2096639])
 def test_TessLightCurveFile(quality_bitmask):
-    lc = TessLightCurveFile.read(TESS_SIM, quality_bitmask=quality_bitmask, flux_column="sap_flux")
+    lc = TessLightCurveFile(TESS_SIM, quality_bitmask=quality_bitmask, flux_column="sap_flux")
     hdu = pyfits.open(TESS_SIM)
 
     assert lc.mission == 'TESS'


### PR DESCRIPTION
The fix also resolves the pytest failure on windows with python 3.8.5 seen in CI.

The stack overthrow comes from the following test:

```python
@pytest.mark.xfail  # LightCurveFile was removed in Lightkurve v2.x
def test_get_header():
    """Test the basic functionality of ``tpf.get_header()``"""
    lcf = TessLightCurveFile(filename_tess_custom)
    assert lcf.get_header()['CREATOR'] == lcf.get_keyword("CREATOR")
    assert lcf.get_header(ext=2)['EXTNAME'] == "APERTURE"
    # ``tpf.header`` is deprecated
    with pytest.warns(LightkurveWarning, match='deprecated'):
        lcf.header()
```

Without the fix, the string `filename_tess_custom` is treated as the actual lightcurve data  (time) rather than the filename of the data. Somehow it got into an infinite recursion in creating the lightcurve object with python 3.8.5 on windows (Normally it should raise `AttributeError: 'str' object has no attribute 'keys'`, then ignored by `xfail`). 
Python 3.7.3 on windows doesn't result in infinite recursion.
