### PR TITLE
Update unit test doc and refactor test requirements

### DIFF
--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -10,6 +10,8 @@ However, running these tests online can take a long time. Running the tests loca
 How do I run tests locally?
 ---------------------------
 
+*Lightkurve* uses `pytest <https://docs.pytest.org/en/stable/>`_ for testing.
+
 First off, you need to find the directory that your *Lightkurve* installation is in. You can check this by looking at the *Lightkurve* path::
 
     import lightkurve as lk
@@ -96,10 +98,10 @@ Ideally, any PR opened to *Lightkurve* with new functionality should include som
 I can't run any tests.
 ----------------------
 
-We run our unit tests using `pytest`. This should have been installed when you installed *Lightkurve*. However, if your tests don't run, you may want to check all the test dependencies are installed by running (with `pip`)::
+We run our unit tests using `pytest <https://docs.pytest.org/en/stable/>`_. This should have been installed when you installed *Lightkurve*. However, if your tests don't run, you may want to check all the test dependencies are installed by running (with `pip`)::
 
-    pip install pytest pytest-cov pytest-remotedata
+    pip install -r requirements-test.txt
 
 or equivalently if you are managing your Python environment using `conda`::
 
-    conda install pytest pytest-cov pytest-remotedata
+    conda install --file=requirements-test.txt

--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -105,3 +105,20 @@ We run our unit tests using `pytest <https://docs.pytest.org/en/stable/>`_. This
 or equivalently if you are managing your Python environment using `conda`::
 
     conda install --file=requirements-test.txt
+
+
+How to generate HTML report?
+----------------------------
+
+Use `pytest-html` extension. Install it by::
+
+    pip install pytest-html
+
+or in `conda`::
+
+    conda install pytest-html
+
+Then you can generate an HTML report. For example::
+
+    pytest --html=build/report.html test_targetpixelfile.py
+

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+pytest>=6.0.1
+pytest-remotedata
+pytest-doctestplus
+pytest-cov
+codecov
+codacy-coverage

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ exec(open('lightkurve/version.py').read())
 with open('requirements.txt') as f:
     install_requires = f.read().splitlines()
 # 2. What dependencies required to run the unit tests? (i.e. `pytest --remote-data`)
-tests_require = ['pytest', 'pytest-cov', 'pytest-remotedata', 'codecov', 'pytest-doctestplus', 'codacy-coverage']
+with open('requirements-test.txt') as f:
+    tests_require = f.read().splitlines()
 extras_require = {"test": tests_require}
 
 setup(name='lightkurve',


### PR DESCRIPTION
The [documentation](https://docs.lightkurve.org/about/testing.html#i-can-t-run-any-tests) on unit test setup is outdated (on the list of dependent packages). This PR:
1. fix the doc
2. extract the dependencies into `requirements-test.txt`, so that any future changes does not require updating the doc.
