### PR TITLE
Remove NaNs of centroids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,9 @@ lightkurve.correctors
 - Modified ``PLDCorrector`` to make use of the new ``RegressionCorrector``
   and ``DesignMatrix`` classes. [#746]
 
+- Fixed a bug in ``SFFCorrector`` which caused correction to fail if a light
+  curve's ``centroid_col`` or ``centroid_row`` columns contained NaNs. [#827]
+
 lightkurve.seismology
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -125,7 +125,7 @@ class SFFCorrector(RegressionCorrector):
                           LightkurveWarning)
 
         if centroid_col is None:
-            self.lc = self.lc[~np.isnan(self.lc.centroid_col)]
+            self.lc = self.lc.remove_nans(column='centroid_col')
             centroid_col = self.lc.centroid_col
         if centroid_row is None:
             self.lc = self.lc[~np.isnan(self.lc.centroid_row)]

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -125,8 +125,10 @@ class SFFCorrector(RegressionCorrector):
                           LightkurveWarning)
 
         if centroid_col is None:
+            self.lc = self.lc[~np.isnan(self.lc.centroid_col)]
             centroid_col = self.lc.centroid_col
         if centroid_row is None:
+            self.lc = self.lc[~np.isnan(self.lc.centroid_row)]
             centroid_row = self.lc.centroid_row
 
         if np.any([~np.isfinite(centroid_row), ~np.isfinite(centroid_col)]):

--- a/lightkurve/correctors/sffcorrector.py
+++ b/lightkurve/correctors/sffcorrector.py
@@ -128,7 +128,7 @@ class SFFCorrector(RegressionCorrector):
             self.lc = self.lc.remove_nans(column='centroid_col')
             centroid_col = self.lc.centroid_col
         if centroid_row is None:
-            self.lc = self.lc[~np.isnan(self.lc.centroid_row)]
+            self.lc = self.lc.remove_nans(column='centroid_row')
             centroid_row = self.lc.centroid_row
 
         if np.any([~np.isfinite(centroid_row), ~np.isfinite(centroid_col)]):

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -7,7 +7,8 @@ from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_array_equal
 
 from ... import LightCurve, KeplerLightCurve, \
-                TessLightCurve, LightkurveWarning
+                TessLightCurve, LightkurveWarning, \
+                search_lightcurve
 from .. import SFFCorrector
 
 
@@ -181,3 +182,12 @@ def test_sff_tess_warning():
     lc = TessLightCurve(flux=[1, 2, 3], meta={'mission': 'TESS'})
     with pytest.warns(LightkurveWarning, match='not suitable'):
         corr = SFFCorrector(lc)
+
+
+@pytest.mark.remote_data
+def test_sff_nan_centroids():
+    """Regression test for #827: SFF failed if light curve contained
+    NaNs in its `centroid_col` or `centroid_row` columns."""
+    lc = search_lightcurve("EPIC 211083408").download()
+    # This previously raised a ValueError:
+    lc[200:500].remove_nans().to_corrector("sff").correct()


### PR DESCRIPTION
For the default situation, the centroids are coming from raw fits file, but some of them may contain NaNs (e.g., ktwo211083408-c04_lc). It would be better to remove NaNs of centroids before the sff correction.