### PR TITLE
Allow `remove_nans()` to accept a user-defined ``column`` parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ lightkurve.lightcurve
   method to conveniently mask planet or eclipsing binary transits. [#808]
 
 - Added a ``column`` parameter to ``LightCurve.remove_nans()`` to enable
-  cadences to be removed which contain NaN values in a user-specified column.
+  cadences to be removed which contain NaN values in a specific column. [#828]
 
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ lightkurve.lightcurve
 - Added the ``LightCurve.create_transit_mask(period, transit_time, duration)``
   method to conveniently mask planet or eclipsing binary transits. [#808]
 
+- Added a ``column`` parameter to ``LightCurve.remove_nans()`` to enable
+  cadences to be removed which contain NaN values in a user-specified column.
+
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -775,15 +775,34 @@ class LightCurve(TimeSeries):
         lc.meta['normalized'] = True
         return lc
 
-    def remove_nans(self):
-        """Removes cadences where the flux is NaN.
+    def remove_nans(self, column: str = 'flux'):
+        """Removes cadences where ``column`` is a NaN.
+
+        Parameters
+        ----------
+        column : str
+            Column to check for NaNs.  Defaults to ``'flux'``.
 
         Returns
         -------
         clean_lightcurve : `LightCurve`
             A new light curve object from which NaNs fluxes have been removed.
+
+        Examples
+        --------
+            >>> import lightkurve as lk
+            >>> import numpy as np
+            >>> lc = lk.LightCurve({'time': [1, 2, 3], 'flux': [1., np.nan, 1.]})
+            >>> lc.remove_nans()
+            <LightCurve length=2>
+            time    flux  flux_err
+            <BLANKLINE>
+            object float64 float64
+            ------ ------- --------
+            1.0     1.0      nan
+            3.0     1.0      nan
         """
-        return self[~np.isnan(self.flux)]  # This will return a sliced copy
+        return self[~np.isnan(self[column])]  # This will return a sliced copy
 
     def fill_gaps(self, method: str = 'gaussian_noise'):
         """Fill in gaps in time.

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -718,9 +718,12 @@ def test_boolean_masking():
 def test_remove_nans():
     """Does LightCurve.__getitem__() allow slicing?"""
     time, flux = [1, 2, 3, 4], [100, np.nan, 102, np.nan]
-    lc_clean = LightCurve(time=time, flux=flux).remove_nans()
+    lc = LightCurve(time=time, flux=flux)
+    lc_clean = lc.remove_nans()
     assert_array_equal(lc_clean.time.value, [1, 3])
     assert_array_equal(lc_clean.flux, [100, 102])
+    lc_clean = lc.remove_nans('flux_err')
+    assert_array_equal(lc_clean.flux, [])
 
 
 def test_remove_outliers():


### PR DESCRIPTION
Over in #827, we encountered a bug related to the presence of NaNs in the `centroid_col` column of a `LightCurve`.

This PR adds an optional `column` parameter to `remove_nans()` such that these cadences can be removed using `lc.remove_nans(column='centroid_col')`.

Example use:

![remove-nans-example](https://user-images.githubusercontent.com/817669/92147699-55ff5a00-edd0-11ea-8c05-1b1362b4f395.png)
