### PR TITLE
Fix memory seepage in TargetPixelFile.__getitem__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ lightkurve.targetpixelfile
 - Modified ``_parse_aperture_mask()`` to ensure that masks composed of integer
   or floats are always converted to booleans. [#694]
 
+- Fixed a bug in ``TargetPixelFile.__getitem__()`` which caused a substantial
+  memory leak on indexing or slicing a tpf. [#829]
+
 lightkurve.search
 ^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -9,7 +9,7 @@ import logging
 import collections
 
 from astropy.io import fits
-from astropy.io.fits import Undefined
+from astropy.io.fits import Undefined, BinTableHDU
 from astropy.nddata import Cutout2D
 from astropy.table import Table
 from astropy.wcs import WCS
@@ -94,8 +94,8 @@ class TargetPixelFile(object):
             warnings.simplefilter('ignore', UserWarning)
             # AstroPy added `HDUList.copy()` in v3.1, but we don't want to make
             # v3.1 a minimum requirement yet, so we copy in a funny way.
-            copy = fits.HDUList([myhdu.copy() for myhdu in self.hdu])
-            copy[1].data = copy[1].data[selected_idx]
+            copy = self.hdu.copy()
+            copy[1] = BinTableHDU(data=self.hdu[1].data[selected_idx], header=self.hdu[1].header)
         return self.__class__(copy, quality_bitmask=self.quality_bitmask, targetid=self.targetid)
 
     def __len__(self):

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -92,8 +92,8 @@ class TargetPixelFile(object):
         with warnings.catch_warnings():
             # Ignore warnings about empty fields
             warnings.simplefilter('ignore', UserWarning)
-            # AstroPy added `HDUList.copy()` in v3.1, but we don't want to make
-            # v3.1 a minimum requirement yet, so we copy in a funny way.
+            # AstroPy added `HDUList.copy()` in v3.1, allowing us to avoid manually
+            # copying the HDUs, which brought along unexpected memory leaks.
             copy = self.hdu.copy()
             copy[1] = BinTableHDU(data=self.hdu[1].data[selected_idx], header=self.hdu[1].header)
         return self.__class__(copy, quality_bitmask=self.quality_bitmask, targetid=self.targetid)

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -678,3 +678,22 @@ def test_tpf_meta():
     tpf = read(filename_tpf_one_center)
     assert tpf.meta.get('mission') == 'K2'
     assert tpf.meta.get('channel') == 45
+
+
+@pytest.mark.parametrize("tpf_type", [KeplerTargetPixelFile, TessTargetPixelFile])
+def test_tpf_slice(tpf_type):
+    """Test indexing and slicing of TargetPixelFile object."""
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpf = tpf_type(filename_tpf_all_zeros)
+
+    frame = tpf[5]
+    assert frame.shape[0] == 1
+    assert frame.shape[1:] == tpf.shape[1:]
+    assert_array_equal(frame.time[0], tpf.time[5])
+
+    frames = tpf[100:200]
+    assert frames.shape[0] == 100
+    assert frames.shape[1:] == tpf.shape[1:]
+    assert_array_equal(frames.time, tpf.time[100:200])

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -540,13 +540,31 @@ def test_tpf_tess():
     col, row = tpf.estimate_centroids()
 
 
-def test_tpf_slicing():
-    tpf = KeplerTargetPixelFile(filename_tpf_one_center)
+@pytest.mark.parametrize("tpf_type", [KeplerTargetPixelFile, TessTargetPixelFile])
+def test_tpf_slicing(tpf_type):
+    """Test indexing and slicing of TargetPixelFile objects."""
+    with warnings.catch_warnings():
+        # Ignore the "TELESCOP is not equal to TESS" warning
+        warnings.simplefilter("ignore", LightkurveWarning)
+        tpf = tpf_type(filename_tpf_one_center)
+
     assert tpf[0].time == tpf.time[0]
     assert tpf[-1].time == tpf.time[-1]
     assert tpf[5:10].shape == tpf.flux[5:10].shape
     assert tpf[0].targetid == tpf.targetid
     assert_array_equal(tpf[tpf.time < tpf.time[5]].time, tpf.time[0:5])
+
+    frame = tpf[5]
+    assert frame.shape[0] == 1
+    assert frame.shape[1:] == tpf.shape[1:]
+    assert_array_equal(frame.time[0], tpf.time[5])
+    assert_array_equal(frame.flux[0], tpf.flux[5])
+
+    frames = tpf[100:200]
+    assert frames.shape[0] == 100
+    assert frames.shape[1:] == tpf.shape[1:]
+    assert_array_equal(frames.time, tpf.time[100:200])
+    assert_array_equal(frames.flux, tpf.flux[100:200])
 
 
 def test_endianness():
@@ -678,22 +696,3 @@ def test_tpf_meta():
     tpf = read(filename_tpf_one_center)
     assert tpf.meta.get('mission') == 'K2'
     assert tpf.meta.get('channel') == 45
-
-
-@pytest.mark.parametrize("tpf_type", [KeplerTargetPixelFile, TessTargetPixelFile])
-def test_tpf_slice(tpf_type):
-    """Test indexing and slicing of TargetPixelFile object."""
-    with warnings.catch_warnings():
-        # Ignore the "TELESCOP is not equal to TESS" warning
-        warnings.simplefilter("ignore", LightkurveWarning)
-        tpf = tpf_type(filename_tpf_all_zeros)
-
-    frame = tpf[5]
-    assert frame.shape[0] == 1
-    assert frame.shape[1:] == tpf.shape[1:]
-    assert_array_equal(frame.time[0], tpf.time[5])
-
-    frames = tpf[100:200]
-    assert frames.shape[0] == 100
-    assert frames.shape[1:] == tpf.shape[1:]
-    assert_array_equal(frames.time, tpf.time[100:200])


### PR DESCRIPTION
Proposed fix for https://github.com/KeplerGO/lightkurve/issues/330#issuecomment-686618489

`TargetPixelFile.__getitem__` was essentially creating a full deepcopy of its associated HDUList, but on replacing the `data` part with the indexed range, the rest of the HDU's data seemed to keep lurking around in the murky regions of the FITS data model.
Trying to solve the issue by instead creating a new `BinTableHDU` from just the selected index range.

Notes:
1. Perhaps the test should also check the data in `tpf.flux`; do we have a test file that is not all zeros?

2. A single index still returns `tpf[i].shape == (i, N, M)`, rather than `(N, M)`, which might be confusing, but perhaps this is intended.

3. Since pip also gives `astropy >= 3.1` as dependency, it looks like this could be fairly easily backported to 1.11.x. Waiting on Milestone assignment for the changelog.