### PR TITLE
Build documentation improvement

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=..\..\lightkurve-docs
+set SPHINXOPTS=-j auto
 set SPHINXPROJ=lightkurve
 
 if "%1" == "" goto help

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -8,7 +8,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
-set BUILDDIR=build
+set BUILDDIR=..\..\lightkurve-docs
 set SPHINXPROJ=lightkurve
 
 if "%1" == "" goto help

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -12,6 +12,8 @@ set BUILDDIR=build
 set SPHINXPROJ=lightkurve
 
 if "%1" == "" goto help
+if "%1" == "clean" goto clean
+
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -27,6 +29,12 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:clean
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+rem Force autogenerating the API docs
+del source\api\lightkurve.*
 goto end
 
 :help

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,9 @@
+sphinx
+sphinx-automodapi
+sphinxcontrib-rawfiles
+amunra-sphinx-theme
+nbsphinx
+graphviz
+ghp-import
 numpydoc
+pandocfilters

--- a/docs/source/about/documentation.rst
+++ b/docs/source/about/documentation.rst
@@ -20,18 +20,14 @@ Building documentation
     latest version of the documentation is available online at
     `docs.lightkurve.org <https://docs.lightkurve.org/>`_ .
 
-Building the *lightkurve* documentation requires a few extra packages:
+Building the *lightkurve* documentation requires a `sphinx` and few extra packages. To install them::
 
-- amunra-sphinx-theme
-- sphinx
-- sphinx-automodapi
-- sphinxcontrib-rawfiles
-- nbsphinx
-- ghp-import
-- graphviz
-- `numpydoc <https://github.com/numpy/numpydoc>`_
+    $ cd docs
+    $ pip install -r requirements.txt
 
-These packages can be installed using `conda` or `pip`.
+If you encounter the error ``Pandoc wasn't found``, install `pandoc` as well. Follow its `installation instruction <https://pandoc.org/installing.html>`_  , or use `conda`::
+
+    $ conda install --channel=conda-forge pandoc
 
 To build the documentation in HTML format, execute::
 

--- a/docs/source/about/documentation.rst
+++ b/docs/source/about/documentation.rst
@@ -20,7 +20,7 @@ Building documentation
     latest version of the documentation is available online at
     `docs.lightkurve.org <https://docs.lightkurve.org/>`_ .
 
-Building the *lightkurve* documentation requires a `sphinx` and few extra packages. To install them::
+Building the *lightkurve* documentation requires `sphinx` and a few extra packages. To install them::
 
     $ cd docs
     $ pip install -r requirements.txt


### PR DESCRIPTION
1. Include all dependencies in a `docs/requirements.txt`, and update the instructions.
2. Make windows build behave the same as Linux/Mac.
