### PR TITLE
doc tweak: state `python -m pip` rather than just `pip`

### DIFF
--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -39,7 +39,7 @@ In brief, the steps are as follows:
 .. code-block:: bash
 
     $ cd lightkurve
-    $ pip install -e .
+    $ python -m pip install -e .
 
 4. Add the KeplerGO remote to your GitHub enviroment:
 

--- a/docs/source/about/install.rst
+++ b/docs/source/about/install.rst
@@ -8,7 +8,7 @@ Using conda
 ===========
 
 The easiest way to install *Lightkurve* and all of its dependencies is to use
-the ``conda`` package manager, which is part of the 
+the ``conda`` package manager, which is part of the
 `Anaconda Python <https://www.continuum.io/downloads>`_ distribution.
 With ``conda`` installed, simply run the following command in a terminal window::
 
@@ -35,6 +35,9 @@ To install *Lightkurve*, run the following command in a terminal window::
 
 The ``--upgrade`` flag is optional, but recommended if you already
 have *Lightkurve* installed and want to upgrade to the latest version.
+
+Depending on the specific Python environment, you may need to replace ``python``
+with the correct Python interpreter, e.g., ``python3``.
 
 If you encounter any compilation errors using this command, then we recommend
 that you use the ``conda`` package manager instead.
@@ -78,7 +81,7 @@ If you want to experiment with the latest development version of
 
     $ git clone https://github.com/KeplerGO/lightkurve.git
     $ cd lightkurve
-    $ pip install -e .
+    $ python -m pip install -e .
 
 This is recommended for anyone who wants to edit the source code.
 Please see our guide on :ref:`contributing to lightkurve<contributing>`

--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -100,7 +100,7 @@ I can't run any tests.
 
 We run our unit tests using `pytest <https://docs.pytest.org/en/stable/>`_. This should have been installed when you installed *Lightkurve*. However, if your tests don't run, you may want to check all the test dependencies are installed by running (with `pip`)::
 
-    pip install -r requirements-test.txt
+    python -m pip install -r requirements-test.txt
 
 or equivalently if you are managing your Python environment using `conda`::
 
@@ -112,7 +112,7 @@ How to generate HTML report?
 
 Use `pytest-html` extension. Install it by::
 
-    pip install pytest-html
+    python -m pip install pytest-html
 
 or in `conda`::
 

--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -16,7 +16,7 @@
     "$ conda install --channel conda-forge lightkurve\n",
     "```\n",
     "\n",
-    "If you are using a different Python distribution, you can also install Lightkurve using `pip install lightkurve`.  See our [installation instructions](about/install.html) page for details and troubleshooting information.\n",
+    "If you are using a different Python distribution, you can also install Lightkurve using `python -m pip install lightkurve`.  See our [installation instructions](about/install.html) page for details and troubleshooting information.\n",
     "\n",
     "With Lightkurve installed, it is easy to extract brightness time series data (astronomers call this a *light curve*)\n",
     "from the tiny images of stars collected by NASA's Kepler and TESS planet-hunting telescopes.\n",


### PR DESCRIPTION
Closes #834 

The main callout of `python` is in `install.rst`

![image](https://user-images.githubusercontent.com/250644/92662420-a0db0f00-f2b3-11ea-831b-ad7ce9c05ad8.png)

I am not quite convinced it's clear, but feel if we say anything more, it'd be somewhat lengthy explanation on where python is, with various combination of OSes and python environment.


