### PR TITLE
bugfix: ensure LightCurve.time can be reassigned

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -225,7 +225,9 @@ class LightCurve(TimeSeries):
 
     def __setattr__(self, name, value, **kwargs):
         """To get copied, attributes have to be stored in the meta dictionary!"""
-        if ('columns' in self.__dict__) and (name in self.__dict__['columns']):
+        if (name == 'time'):
+            self['time'] = value # astropy will convert value to Time if needed
+        elif ('columns' in self.__dict__) and (name in self.__dict__['columns']):
             if not isinstance(value, Quantity):
                 value = Quantity(value, dtype=value.dtype)
             self.replace_column(name, value)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1075,6 +1075,24 @@ def test_mixed_instantiation():
     LightCurve(time=[1,2,3], flux=[1,2,3], data={'flux_err': [3,4,5]})
 
 
+def test_assignment_time():
+    """Ensure time property can be reassigned"""
+    lc = KeplerLightCurve(time=Time([1,2,3], scale='tdb', format='bkjd'), flux=[4,5,6], flux_err=[7,8,9])
+    time_adjusted = lc.time - 0.5
+    lc.time = time_adjusted
+    assert_array_equal(lc.time, time_adjusted)
+
+    # case the input is not given format / scale, ensure default format / scale is applied
+    time_adjusted_raw = [11., 12., 13.]
+    lc.time = time_adjusted_raw
+    assert_array_equal(lc.time, Time(time_adjusted_raw, scale='tdb', format='bkjd'))
+
+    # case the input is scalar
+    time_adjusted_raw_singular = 21
+    lc.time = time_adjusted_raw_singular
+    assert_array_equal(lc.time, Time(time_adjusted_raw_singular, scale='tdb', format='bkjd'))
+
+
 def test_create_transit_mask():
     """Test for `LightCurve.create_transit_mask()`."""
     # Set planet parameters

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1087,10 +1087,9 @@ def test_assignment_time():
     lc.time = time_adjusted_raw
     assert_array_equal(lc.time, Time(time_adjusted_raw, scale='tdb', format='bkjd'))
 
-    # case the input is scalar
-    time_adjusted_raw_singular = 21
-    lc.time = time_adjusted_raw_singular
-    assert_array_equal(lc.time, Time(time_adjusted_raw_singular, scale='tdb', format='bkjd'))
+    # case the input is scalar, it'd be broadcasted to the existing time's length
+    lc.time = 21
+    assert_array_equal(lc.time, Time([21, 21, 21], scale='tdb', format='bkjd'))
 
 
 def test_create_transit_mask():


### PR DESCRIPTION
Closes #839
