### PR TITLE
Make `PLDCorrector` more robust

### DIFF
--- a/lightkurve/correctors/designmatrix.py
+++ b/lightkurve/correctors/designmatrix.py
@@ -269,6 +269,7 @@ class DesignMatrix():
             dm = self.copy()
         extra_df = pd.DataFrame(np.atleast_2d(np.ones(self.shape[0])).T, columns=['offset'])
         dm.df = pd.concat([self.df, extra_df], axis=1)
+        dm.columns = list(dm.df.columns)
         dm.prior_mu = np.append(self.prior_mu, prior_mu)
         dm.prior_sigma = np.append(self.prior_sigma, prior_sigma)
         return dm

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -115,7 +115,9 @@ class PLDCorrector(RegressionCorrector):
         return 'PLDCorrector (ID: {})'.format(self.lc.label)
 
     def create_design_matrix(self, pld_order=3, pca_components=16, pld_aperture_mask=None,
-                             spline_n_knots=None, spline_degree=3, sparse=False):
+                             background_aperture_mask='background', spline_n_knots=None,
+                             spline_degree=3, normalize_background_pixels=None,
+                             sparse=False):
         """Returns a `.DesignMatrixCollection` containing a `DesignMatrix` object
         for the background regressors, the PLD pixel component regressors, and
         the spline regressors.
@@ -165,6 +167,8 @@ class PLDCorrector(RegressionCorrector):
         # Validate the inputs
         pld_aperture_mask = self.tpf._parse_aperture_mask(pld_aperture_mask)
         self.pld_aperture_mask = pld_aperture_mask
+        background_aperture_mask = self.tpf._parse_aperture_mask(background_aperture_mask)
+        self.background_aperture_mask = background_aperture_mask
 
         if spline_n_knots is None:
             # Default to a spline per 50 data points
@@ -177,61 +181,80 @@ class PLDCorrector(RegressionCorrector):
             DMC = DesignMatrixCollection
             spline = create_spline_matrix
 
-        # We set the width of all coefficient priors to median flux divided
-        # by 3 to prevent the fit from going crazy.
-        prior_sigma = np.nanmedian(self.lc.flux.value)
+        # We set the width of all coefficient priors to 10 times the standard
+        # deviation to prevent the fit from going crazy.
+        prior_sigma = np.nanstd(self.lc.flux.value) * 10
 
-        # Flux-normalized pixel time series
-        regressors = self.tpf.flux[:, pld_aperture_mask].reshape(len(self.tpf.flux), -1)
-        regressors = np.array([r[np.isfinite(r)] for r in regressors])
-        #regressors = np.array([r / f for r, f in zip(regressors, self.lc.flux.value)])
+        # Flux normalize background components for K2 and not for TESS by default
+        bkg_pixels = self.tpf.flux[:, background_aperture_mask].reshape(len(self.tpf.flux), -1)
+        if normalize_background_pixels:
+            bkg_flux = np.nansum(self.tpf.flux[:, background_aperture_mask], -1)
+            bkg_pixels = np.array([r / f for r, f in zip(bkg_pixels, bkg_flux)])
+        else:
+            bkg_pixels = bkg_pixels.value
 
-        # Use the DesignMatrix infrastructure to apply PCA to the regressors.
+        # Remove NaNs
+        bkg_pixels = np.array([r[np.isfinite(r)] for r in bkg_pixels])
+
+        # Create background design matrix
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', message='.*low rank.*')
-            regressors_dm = DesignMatrix(regressors)
-        if isinstance(pca_components, (tuple, list)):
-            ncomp = pca_components[0]
-        else:
-            ncomp = pca_components
-        if ncomp > 0:
-            regressors_dm = regressors_dm.pca(ncomp)
-        regressors_pld = regressors_dm.values
+            dm_bkg = DesignMatrix(bkg_pixels, name='background')
+        # Apply PCA
+        dm_bkg = dm_bkg.pca(pca_components)
+        # Set prior sigma to 10 * standard deviation
+        dm_bkg.prior_sigma = np.ones(dm_bkg.shape[1]) * prior_sigma
 
-        # Create a DesignMatrix for each PLD order
-        all_pld = []
-        for order in range(1, pld_order+1):
-            reg_n = np.product(list(multichoose(regressors_pld.T, order)), axis=1).T
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', message='.*low rank.*')
-                pld_n = DesignMatrix(reg_n,
-                                     prior_sigma=np.ones(reg_n.shape[1]) * prior_sigma / reg_n.shape[1],
-                                     name=f"pld_order_{order}")
-            # Apply PCA. Check if pca_components has an entry for each order,
-            # otherwise use pca_components for PCA of higher order matrices.
-            if isinstance(pca_components, (tuple, list)):
-                ncomp = pca_components[order-1]
-            else:
-                ncomp = pca_components
-            if ncomp > 0:
-                pld_n = pld_n.pca(ncomp)
-                # Calling pca() resets the priors, so we set them again.
-                pld_n.prior_sigma = np.ones(pld_n.shape[1]) * prior_sigma / ncomp
-            all_pld.append(pld_n)
-
-        # Create the collection of DesignMatrix objects.
-        # DesignMatrix 1 contains the PLD pixel series
-        dm_pixels = DesignMatrixCollection(all_pld).to_designmatrix(name='pixel_series')
-        # DesignMatrix 2 contains splines plus a constant
+        # Create a design matric containing splines plus a constant
         dm_spline = spline(self.lc.time.value,
                            n_knots=spline_n_knots,
                            degree=spline_degree).append_constant()
-        # Set prior sigma to median flux / 3 to prevent crazy coefficients
+        # Set prior sigma to 10 * standard deviation
         dm_spline.prior_sigma = np.ones(dm_spline.shape[1]) * prior_sigma
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message='.*Not all matrices are `SparseDesignMatrix` objects..*')
-            dm_collection = DMC([dm_pixels, dm_spline])
+        # Create a PLD matrix if there are pixels in the pld_aperture_mask
+        if np.sum(pld_aperture_mask) != 0:
+            # Flux normalize the PLD components
+            pld_pixels = self.tpf.flux[:, pld_aperture_mask].reshape(len(self.tpf.flux), -1)
+            pld_pixels = np.array([r / f for r, f in zip(pld_pixels, self.lc.flux.value)])
+            # Remove NaNs
+            pld_pixels = np.array([r[np.isfinite(r)] for r in pld_pixels])
+
+            # Use the DesignMatrix infrastructure to apply PCA to the regressors.
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', message='.*low rank.*')
+                regressors_dm = DesignMatrix(pld_pixels)
+            if pca_components > 0:
+                regressors_dm = regressors_dm.pca(pca_components)
+            regressors_pld = regressors_dm.values
+
+            # Create a DesignMatrix for each PLD order
+            all_pld = []
+            for order in range(1, pld_order+1):
+                reg_n = np.product(list(multichoose(regressors_pld.T, order)), axis=1).T
+                with warnings.catch_warnings():
+                    warnings.filterwarnings('ignore', message='.*low rank.*')
+                    pld_n = DesignMatrix(reg_n,
+                                         prior_sigma=np.ones(reg_n.shape[1]) * prior_sigma / reg_n.shape[1],
+                                         name=f"pld_order_{order}")
+                # Apply PCA.
+                if pca_components > 0:
+                    pld_n = pld_n.pca(pca_components)
+                    # Calling pca() resets the priors, so we set them again.
+                    pld_n.prior_sigma = np.ones(pld_n.shape[1]) * prior_sigma / pca_components
+                all_pld.append(pld_n)
+
+            # Create the collection of DesignMatrix objects.
+            # DesignMatrix 1 contains the PLD pixel series
+            dm_pixels = DesignMatrixCollection(all_pld).to_designmatrix(name='pixel_series')
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', message='.*Not all matrices are `SparseDesignMatrix` objects..*')
+                dm_collection = DMC([dm_pixels, dm_bkg, dm_spline])
+        else:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', message='.*Not all matrices are `SparseDesignMatrix` objects..*')
+                dm_collection = DMC([dm_bkg, dm_spline])
         return dm_collection
 
     @deprecated_renamed_argument('n_pca_terms', 'pca_components', '2.0', warning_type=LightkurveDeprecationWarning)
@@ -239,10 +262,10 @@ class PLDCorrector(RegressionCorrector):
     @deprecated_renamed_argument('gp_timescale', None, '2.0', warning_type=LightkurveDeprecationWarning)
     @deprecated_renamed_argument('aperture_mask', None, '2.0', warning_type=LightkurveDeprecationWarning)
     def correct(self, pld_order=None, pca_components=None, pld_aperture_mask=None,
-                spline_n_knots=None, spline_degree=5, restore_trend=True,
-                sparse=False, cadence_mask=None, sigma=5, niters=5,
-                propagate_errors=False, use_gp=None, gp_timescale=None,
-                aperture_mask=None):
+                background_aperture_mask='background', spline_n_knots=None,
+                spline_degree=5, normalize_background_pixels=None, restore_trend=True,
+                sparse=False, cadence_mask=None, sigma=5, niters=5, propagate_errors=False,
+                use_gp=None, gp_timescale=None, aperture_mask=None):
         """Returns a systematics-corrected light curve.
 
         If the parameters `pld_order` and `pca_components` are None, their
@@ -258,14 +281,10 @@ class PLDCorrector(RegressionCorrector):
             (`n=1`) uses only the pixel fluxes to construct the design matrix.
             Higher order populates the design matrix with columns constructed
             from the products of pixel fluxes. Default 3 for K2 and 1 for TESS.
-        pca_components : int or tuple of int
+        pca_components : int
             Number of terms added to the design matrix for each order of PLD
             pixel fluxes. Increasing this value may provide higher precision
             at the expense of slower speed and/or overfitting.
-            If performing PLD with `pld_order > 1`, `pca_components` can be
-            a tuple containing the number of terms for each order of PLD.
-            If a single int is passed, the same number of terms will be used
-            for each order.  If zero is passed, PCA will not be performed.
         pld_aperture_mask : array-like, 'pipeline', 'all', 'threshold', or None
             A boolean array describing the aperture such that `True` means
             that the pixel will be used when selecting the PLD basis vectors.
@@ -319,16 +338,23 @@ class PLDCorrector(RegressionCorrector):
         if pld_aperture_mask is None:
             if self.tpf.meta.get('mission') == 'K2':
                 # K2 noise is dominated by motion
-                pld_aperture_mask = 'all'
+                pld_aperture_mask = 'threshold'
             else:
                 # TESS noise is dominated by background
-                pld_aperture_mask = 'background'
+                pld_aperture_mask = 'empty'
+        if normalize_background_pixels is None:
+            if self.tpf.meta.get('mission') == 'K2':
+                normalize_background_pixels = True
+            else:
+                normalize_background_pixels = False
 
         dm = self.create_design_matrix(pld_aperture_mask=pld_aperture_mask,
+                                       background_aperture_mask=background_aperture_mask,
                                        pld_order=pld_order,
                                        pca_components=pca_components,
                                        spline_n_knots=spline_n_knots,
                                        spline_degree=spline_degree,
+                                       normalize_background_pixels=normalize_background_pixels,
                                        sparse=sparse)
 
         clc = super().correct(dm, cadence_mask=cadence_mask, sigma=sigma,
@@ -363,6 +389,10 @@ class PLDCorrector(RegressionCorrector):
         uncorr_cdpp = self.lc.estimate_cdpp()
         corr_cdpp = clc.estimate_cdpp()
 
+        # Get y-axis limits
+        ylim = [min(min(self.lc.flux.value), min(clc.flux.value)),
+                max(max(self.lc.flux.value), max(clc.flux.value))]
+
         # Use lightkurve plotting style
         with plt.style.context(MPLSTYLE):
             # Plot background model
@@ -371,18 +401,18 @@ class PLDCorrector(RegressionCorrector):
             self.lc.plot(ax=ax, normalize=False, clip_outliers=True,
                          label=f'uncorrected ({uncorr_cdpp:.0f})')
             ax.set_xlabel('')
-            ylim = ax.get_ylim()  # use same ylim for plots below
+            ax.set_ylim(ylim)  # use same ylim for all plots
 
             # Plot pixel and spline components
             ax = axs[1]
             clc.plot(ax=ax, normalize=False, alpha=0.4,
                      label=f'corrected ({corr_cdpp:.0f})')
-            for key in names:
-                if key in ['pixel_series', 'spline']:
+            for key, color in zip(names, ['dodgerblue', 'r', 'C1']):
+                if key in ['background', 'spline', 'pixel_series']:
                     tmplc = self.diagnostic_lightcurves[key] \
                             - np.median(self.diagnostic_lightcurves[key].flux) \
                             + np.median(self.lc.flux)
-                    tmplc.plot(ax=ax)
+                    tmplc.plot(ax=ax, c=color)
             ax.set_xlabel('')
             ax.set_ylim(ylim)
 
@@ -416,7 +446,7 @@ class PLDCorrector(RegressionCorrector):
 
         # Use lightkurve plotting style
         with plt.style.context(MPLSTYLE):
-            _, axs = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
+            _, axs = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
             # Show light curve aperture mask
             ax = axs[0]
             self.tpf.plot(ax=ax, show_colorbar=False,
@@ -427,6 +457,10 @@ class PLDCorrector(RegressionCorrector):
             self.tpf.plot(ax=ax, show_colorbar=False,
                           aperture_mask=self.pld_aperture_mask,
                           title='pld_aperture_mask')
+            ax = axs[2]
+            self.tpf.plot(ax=ax, show_colorbar=False,
+                          aperture_mask=self.background_aperture_mask,
+                          title='background_aperture_mask')
         return axs
 
 

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -114,9 +114,8 @@ class PLDCorrector(RegressionCorrector):
     def __repr__(self):
         return 'PLDCorrector (ID: {})'.format(self.lc.label)
 
-    def create_design_matrix(self, pld_order=3, pca_components=16,
-                             background_aperture_mask='background', pld_aperture_mask=None,
-                             spline_n_knots=100, spline_degree=3, sparse=False):
+    def create_design_matrix(self, pld_order=3, pca_components=16, pld_aperture_mask=None,
+                             spline_n_knots=None, spline_degree=3, sparse=False):
         """Returns a `.DesignMatrixCollection` containing a `DesignMatrix` object
         for the background regressors, the PLD pixel component regressors, and
         the spline regressors.
@@ -142,11 +141,6 @@ class PLDCorrector(RegressionCorrector):
             If a single int is passed, the same number of terms will be used
             for each order. If zero is passed, PCA will not be performed.
             Defaults to 16 for K2 and 8 for TESS.
-        background_aperture_mask : array-like or None
-            A boolean array flagging the background pixels such that `True` means
-            that the pixel will be used to generate the background systematics model.
-            If `None`, all pixels which are fainter than 1-sigma above the median
-            flux will be used.
         pld_aperture_mask : array-like, 'pipeline', 'all', 'threshold', or None
             A boolean array describing the aperture such that `True` means
             that the pixel will be used when selecting the PLD basis vectors.
@@ -170,9 +164,11 @@ class PLDCorrector(RegressionCorrector):
         """
         # Validate the inputs
         pld_aperture_mask = self.tpf._parse_aperture_mask(pld_aperture_mask)
-        background_aperture_mask = self.tpf._parse_aperture_mask(background_aperture_mask)
         self.pld_aperture_mask = pld_aperture_mask
-        self.background_aperture_mask = background_aperture_mask
+
+        if spline_n_knots is None:
+            # Default to a spline per 50 data points
+            spline_n_knots = int(len(self.lc) / 50)
 
         if sparse:
             DMC = SparseDesignMatrixCollection
@@ -181,15 +177,14 @@ class PLDCorrector(RegressionCorrector):
             DMC = DesignMatrixCollection
             spline = create_spline_matrix
 
-        # First, we estimate the per-pixel background flux over time
-        bkg = self.tpf.estimate_background(aperture_mask=background_aperture_mask)
-        self.background_estimate = bkg
+        # We set the width of all coefficient priors to median flux divided
+        # by 3 to prevent the fit from going crazy.
+        prior_sigma = np.nanmedian(self.lc.flux.value)
 
-        # Background-subtracted, flux-normalized pixel time series
+        # Flux-normalized pixel time series
         regressors = self.tpf.flux[:, pld_aperture_mask].reshape(len(self.tpf.flux), -1)
-        regressors = regressors - bkg.flux.reshape(-1,1) * pld_aperture_mask.sum() * u.pixel
         regressors = np.array([r[np.isfinite(r)] for r in regressors])
-        regressors = np.array([r / f for r,f in zip(regressors, self.lc.flux.value)])
+        #regressors = np.array([r / f for r, f in zip(regressors, self.lc.flux.value)])
 
         # Use the DesignMatrix infrastructure to apply PCA to the regressors.
         with warnings.catch_warnings():
@@ -203,14 +198,15 @@ class PLDCorrector(RegressionCorrector):
             regressors_dm = regressors_dm.pca(ncomp)
         regressors_pld = regressors_dm.values
 
-
         # Create a DesignMatrix for each PLD order
         all_pld = []
         for order in range(1, pld_order+1):
             reg_n = np.product(list(multichoose(regressors_pld.T, order)), axis=1).T
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='.*low rank.*')
-                pld_n = DesignMatrix(reg_n)
+                pld_n = DesignMatrix(reg_n,
+                                     prior_sigma=np.ones(reg_n.shape[1]) * prior_sigma / reg_n.shape[1],
+                                     name=f"pld_order_{order}")
             # Apply PCA. Check if pca_components has an entry for each order,
             # otherwise use pca_components for PCA of higher order matrices.
             if isinstance(pca_components, (tuple, list)):
@@ -219,34 +215,31 @@ class PLDCorrector(RegressionCorrector):
                 ncomp = pca_components
             if ncomp > 0:
                 pld_n = pld_n.pca(ncomp)
+                # Calling pca() resets the priors, so we set them again.
+                pld_n.prior_sigma = np.ones(pld_n.shape[1]) * prior_sigma / ncomp
             all_pld.append(pld_n)
 
         # Create the collection of DesignMatrix objects.
         # DesignMatrix 1 contains the PLD pixel series
         dm_pixels = DesignMatrixCollection(all_pld).to_designmatrix(name='pixel_series')
-        # DesignMatrix 2 contains the average per-pixel background flux
-        # The prior on the background flux is set equal to the number of pixels
-        # in the light curve aperture mask; this assumes the background is additive.
-        bkg_prior_mu = self.tpf._parse_aperture_mask(self.lc.meta['aperture_mask']).sum()
-        dm_bkg = DesignMatrix(bkg.flux.value, name='background_model',
-                              prior_mu=bkg_prior_mu, prior_sigma=1)
-        # DesignMatrix 3 contains splines plus a constant
+        # DesignMatrix 2 contains splines plus a constant
         dm_spline = spline(self.lc.time.value,
                            n_knots=spline_n_knots,
                            degree=spline_degree).append_constant()
+        # Set prior sigma to median flux / 3 to prevent crazy coefficients
+        dm_spline.prior_sigma = np.ones(dm_spline.shape[1]) * prior_sigma
 
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', message='.*Not all matrices are `SparseDesignMatrix` objects..*')
-            dm_collection = DMC([dm_pixels, dm_bkg, dm_spline])
+            dm_collection = DMC([dm_pixels, dm_spline])
         return dm_collection
 
     @deprecated_renamed_argument('n_pca_terms', 'pca_components', '2.0', warning_type=LightkurveDeprecationWarning)
     @deprecated_renamed_argument('use_gp', None, '2.0', warning_type=LightkurveDeprecationWarning)
     @deprecated_renamed_argument('gp_timescale', None, '2.0', warning_type=LightkurveDeprecationWarning)
     @deprecated_renamed_argument('aperture_mask', None, '2.0', warning_type=LightkurveDeprecationWarning)
-    def correct(self, pld_order=None, pca_components=None,
-                background_aperture_mask='background', pld_aperture_mask=None,
-                spline_n_knots=40, spline_degree=5, restore_trend=True,
+    def correct(self, pld_order=None, pca_components=None, pld_aperture_mask=None,
+                spline_n_knots=None, spline_degree=5, restore_trend=True,
                 sparse=False, cadence_mask=None, sigma=5, niters=5,
                 propagate_errors=False, use_gp=None, gp_timescale=None,
                 aperture_mask=None):
@@ -273,11 +266,6 @@ class PLDCorrector(RegressionCorrector):
             a tuple containing the number of terms for each order of PLD.
             If a single int is passed, the same number of terms will be used
             for each order.  If zero is passed, PCA will not be performed.
-        background_aperture_mask : array-like or None
-            A boolean array flagging the background pixels such that `True` means
-            that the pixel will be used to generate the background systematics model.
-            If `None`, all pixels which are fainter than 1-sigma above the median
-            flux will be used.
         pld_aperture_mask : array-like, 'pipeline', 'all', 'threshold', or None
             A boolean array describing the aperture such that `True` means
             that the pixel will be used when selecting the PLD basis vectors.
@@ -319,18 +307,24 @@ class PLDCorrector(RegressionCorrector):
 
         # Set mission-specific values for pld_order and pca_components
         if pld_order is None:
-            if isinstance(self.tpf, KeplerTargetPixelFile):
+            if self.tpf.meta.get('mission') == 'K2':
                 pld_order = 3
             else:
                 pld_order = 1
         if pca_components is None:
-            if isinstance(self.tpf, KeplerTargetPixelFile):
+            if self.tpf.meta.get('mission') == 'K2':
                 pca_components = 16
             else:
-                pca_components = 7
+                pca_components = 3
+        if pld_aperture_mask is None:
+            if self.tpf.meta.get('mission') == 'K2':
+                # K2 noise is dominated by motion
+                pld_aperture_mask = 'all'
+            else:
+                # TESS noise is dominated by background
+                pld_aperture_mask = 'background'
 
-        dm = self.create_design_matrix(background_aperture_mask=background_aperture_mask,
-                                       pld_aperture_mask=pld_aperture_mask,
+        dm = self.create_design_matrix(pld_aperture_mask=pld_aperture_mask,
                                        pld_order=pld_order,
                                        pca_components=pca_components,
                                        spline_n_knots=spline_n_knots,
@@ -366,22 +360,23 @@ class PLDCorrector(RegressionCorrector):
         else:
             clc = self.corrected_lc
 
+        uncorr_cdpp = self.lc.estimate_cdpp()
+        corr_cdpp = clc.estimate_cdpp()
+
         # Use lightkurve plotting style
         with plt.style.context(MPLSTYLE):
             # Plot background model
             _, axs = plt.subplots(3, figsize=(10, 9), sharex=True)
             ax = axs[0]
-            self.lc.plot(ax=ax, normalize=False, label='original', alpha=0.4)
-            for key in ['background_model']:
-                tmplc = self.diagnostic_lightcurves[key] \
-                        - np.median(self.diagnostic_lightcurves[key].flux) \
-                        + np.median(self.lc.flux)
-                tmplc.plot(ax=ax)
+            self.lc.plot(ax=ax, normalize=False, clip_outliers=True,
+                         label=f'uncorrected ({uncorr_cdpp:.0f})')
             ax.set_xlabel('')
+            ylim = ax.get_ylim()  # use same ylim for plots below
 
             # Plot pixel and spline components
             ax = axs[1]
-            clc.plot(ax=ax, normalize=False, label='corrected', alpha=0.4)
+            clc.plot(ax=ax, normalize=False, alpha=0.4,
+                     label=f'corrected ({corr_cdpp:.0f})')
             for key in names:
                 if key in ['pixel_series', 'spline']:
                     tmplc = self.diagnostic_lightcurves[key] \
@@ -389,16 +384,20 @@ class PLDCorrector(RegressionCorrector):
                             + np.median(self.lc.flux)
                     tmplc.plot(ax=ax)
             ax.set_xlabel('')
+            ax.set_ylim(ylim)
 
             # Plot final corrected light curve with outliers marked
             ax = axs[2]
-            self.lc.plot(ax=ax, normalize=False, alpha=0.2, label='original')
+            self.lc.plot(ax=ax, normalize=False, alpha=0.2,
+                         label=f'uncorrected ({uncorr_cdpp:.0f})')
             clc[self.outlier_mask].scatter(normalize=False, c='r', marker='x',
-                                            s=10, label='outlier_mask', ax=ax)
+                                           s=10, label='outlier_mask', ax=ax)
             clc[~self.cadence_mask].scatter(normalize=False, c='dodgerblue',
                                             marker='x', s=10, label='~cadence_mask',
                                             ax=ax)
-            clc.plot(normalize=False, label='corrected', ax=ax, c='k')
+            clc.plot(normalize=False, ax=ax, c='k',
+                     label=f'corrected ({corr_cdpp:.0f})')
+            ax.set_ylim(ylim)
         return axs
 
     def diagnose_masks(self):
@@ -417,19 +416,14 @@ class PLDCorrector(RegressionCorrector):
 
         # Use lightkurve plotting style
         with plt.style.context(MPLSTYLE):
-            _, axs = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
+            _, axs = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
             # Show light curve aperture mask
             ax = axs[0]
             self.tpf.plot(ax=ax, show_colorbar=False,
                           aperture_mask=self.aperture_mask,
                           title='aperture_mask')
-            # Show background mask
-            ax = axs[1]
-            self.tpf.plot(ax=ax, show_colorbar=False,
-                          aperture_mask=self.background_aperture_mask,
-                          title='background_aperture_mask')
             # Show PLD pixel mask
-            ax = axs[2]
+            ax = axs[1]
             self.tpf.plot(ax=ax, show_colorbar=False,
                           aperture_mask=self.pld_aperture_mask,
                           title='pld_aperture_mask')

--- a/lightkurve/correctors/tests/test_pldcorrector.py
+++ b/lightkurve/correctors/tests/test_pldcorrector.py
@@ -23,8 +23,6 @@ def test_kepler_pld_corrector():
     # Did the correction with default values help?
     raw_lc = tpf.to_lightcurve(aperture_mask='threshold')
     assert(clc.estimate_cdpp() < raw_lc.estimate_cdpp())
-    # Can we pass a tuple in for higher order components?
-    clc = pld.correct(pld_order=2, pca_components=(16, 5))
 
 
 @pytest.mark.remote_data

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1264,7 +1264,7 @@ class LightCurve(TimeSeries):
     def _create_plot(self, method='plot', column='flux', ax=None, normalize=False,
                      xlabel=None, ylabel=None, title='', style='lightkurve',
                      show_colorbar=True, colorbar_label='', offset=None,
-                     **kwargs) -> matplotlib.axes.Axes:
+                     clip_outliers=False, **kwargs) -> matplotlib.axes.Axes:
         """Implements `plot()`, `scatter()`, and `errorbar()` to avoid code duplication.
 
         Parameters
@@ -1296,6 +1296,8 @@ class LightCurve(TimeSeries):
             Offset value to apply to the Y axis values before plotting. Use this
             to avoid light curves from overlapping on the same plot. By default,
             no offset is applies.
+        clip_outliers : bool
+            If ``True``, clip the y axis limit to the 95%-percentile range.
         kwargs : dict
             Dictionary of arguments to be passed to Matplotlib's `plot`,
             `scatter`, or `errorbar` methods.
@@ -1384,6 +1386,11 @@ class LightCurve(TimeSeries):
             legend_labels = ax.get_legend_handles_labels()
             if (np.sum([len(a) for a in legend_labels]) != 0):
                 ax.legend(loc='best')
+
+            if clip_outliers and len(flux) > 0:
+                ymin, ymax = np.percentile(flux.value, [2.5, 97.5])
+                margin = 0.05 * (ymax - ymin)
+                ax.set_ylim(ymin - margin, ymax + margin)
 
         return ax
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -521,6 +521,7 @@ class TargetPixelFile(object):
             with 'threshold' as the fallback.
             If 'background' is passed, all pixels fainter than the median flux
             will be used.
+            If 'empty' is passed, no pixels will be used.
 
         Returns
         -------
@@ -553,6 +554,8 @@ class TargetPixelFile(object):
             elif aperture_mask == 'background':
                 aperture_mask = ~self.create_threshold_mask(threshold=0,
                                                             reference_pixel=None)
+            elif aperture_mask == 'empty':
+                aperture_mask = np.zeros((self.shape[1], self.shape[2]), dtype=bool)
             elif np.issubdtype(aperture_mask.dtype, np.integer) and \
                 ((aperture_mask & 2) == 2).any():
                 # Kepler and TESS pipeline style integer flags

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -712,3 +712,13 @@ def test_tpf_meta():
     tpf = read(filename_tpf_one_center)
     assert tpf.meta.get('mission') == 'K2'
     assert tpf.meta.get('channel') == 45
+
+
+def test_estimate_background():
+    """Verifies tpf.estimate_background()."""
+    # Create a TPF with 100 electron/second in every pixel
+    tpf = read(filename_tpf_all_zeros) + 100.
+    # The resulting background should be 100 e/s/pixel
+    bg = tpf.estimate_background(aperture_mask='all')
+    assert_array_equal(bg.flux.value, 100)
+    assert bg.flux.unit == tpf.flux.unit / u.pixel


### PR DESCRIPTION
The `PLDCorrector` does not appear to work out of the box for most TESS targets right now.  I'm opening this PR to share some ideas with @nksaunders as to how we might simplify `PLDCorrector` to make it more robust for random TESS targets.

Changes I explored in this PR are:
* Changed the default `pca_components` value from 7 to 3 for TESS targets, to make the default more robust against overfitting.
* Changed the default `pld_aperture_mask` to `'background'` for TESS targets, to help prevent overfitting the stellar signal.
* Modified the default value of `spline_n_knots` to be `len(lc) / 50` so that light curves with more data points automatically have more spline knots.
* The PLD and spline coefficients were not being regularized by the priors at all, so I modified their `prior_sigma` to be equal to `median(flux) / pca_components`.  This is a fairly weak constraint but I believe it helps prevent the fit from going crazy.
* Removed the `background` design matrix and `background_aperture_mask` argument for now. The PLD coefficients were often degenerate with the background model coefficient.
* Modified the `pld.diagnose()` method so that the labels show the CDPP values before/after correction.  Also changed the Y axis limits so that all three panels use the same limits, which makes comparisons easier.
* Commented out `regressors = np.array([r / f for r, f in zip(regressors, self.lc.flux.value)])` for now because it makes TESS corrections significantly worse, as far as I can tell.

Going forward, what we urgently need are a set of unit tests which verify PLD detrending against a set of CBV-corrected Kepler/K2/TESS light curves from MAST, so that we can automatically verify whether the default PLD settings do a reasonable job at all times.  It is too complicated to verify this by hand!

## Before this PR (significant overfitting)

<img width="979" alt="Screen Shot 2020-09-18 at 18 30 54" src="https://user-images.githubusercontent.com/817669/93656162-201bc180-f9dd-11ea-9126-e56a70b186e8.png">


## After this PR (no more overfitting)

<img width="990" alt="Screen Shot 2020-09-18 at 18 29 43" src="https://user-images.githubusercontent.com/817669/93656167-2611a280-f9dd-11ea-9f35-6b8bbc206751.png">
