### PR TITLE
Improve behavior of interact() on fast-cadence TESS TPFs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ lightkurve.targetpixelfile
   memory leak on indexing or slicing a tpf. [#829]
 
 - Modified ``interact()`` to use ``max_cadences=200000`` by default to allow
-  it to be used on fast-cadence TESS data.
+  it to be used on fast-cadence TESS data. [#856]
 
 lightkurve.search
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,9 @@ lightkurve.targetpixelfile
 - Fixed a bug in ``TargetPixelFile.__getitem__()`` which caused a substantial
   memory leak on indexing or slicing a tpf. [#829]
 
+- Modified ``interact()`` to use ``max_cadences=200000`` by default to allow
+  it to be used on fast-cadence TESS data.
+
 lightkurve.search
 ^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -563,19 +563,16 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
     # https://github.com/bokeh/bokeh/issues/7490
     n_cadences = len(lc.cadenceno)
     if n_cadences > max_cadences:
-        raise RuntimeError(
-            f"Interact cannot display more than {max_cadences} cadences "
-            "without suffering significant performance issues. You can "
-            "limit the number of cadences show using slicing, e.g. "
-            "`tpf[0:1000].interact()`. Alternatively, you can override "
-            "this limitation by passing the `max_cadences` argument."
-        )
+        log.error(f"Error: interact cannot display more than {max_cadences} "
+                  "cadences without suffering significant performance issues. "
+                  "You can limit the number of cadences show using slicing, e.g. "
+                  "`tpf[0:1000].interact()`. Alternatively, you can override "
+                  "this limitation by passing the `max_cadences` argument.")
     elif n_cadences > 30000:
-        warnings.warn(f"The Target Pixel File contains {n_cadences} cadences. "
-                       "The performance of interact() is very slow for such a "
-                       "large number of frames. Consider using slicing, e.g. "
-                       "`tpf[0:1000].interact()`, to make interact run faster.",
-                       LightkurveWarning)
+        log.warning(f"Warning: the pixel file contains {n_cadences} cadences. "
+                    "The performance of interact() is very slow for such a "
+                    "large number of frames. Consider using slicing, e.g. "
+                    "`tpf[0:1000].interact()`, to make interact run faster.")
 
     def create_interact_ui(doc):
         # The data source includes metadata for hover-over tooltips

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -444,7 +444,7 @@ def make_default_export_name(tpf, suffix='custom-lc'):
 
 def show_interact_widget(tpf, notebook_url='localhost:8888',
                          lc=None,
-                         max_cadences=30000,
+                         max_cadences=200000,
                          aperture_mask='default',
                          exported_filename=None,
                          transform_func=None,
@@ -561,9 +561,21 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
 
     # Bokeh cannot handle many data points
     # https://github.com/bokeh/bokeh/issues/7490
-    if len(lc.cadenceno) > max_cadences:
-        msg = 'Interact cannot display more than {} cadences.'
-        raise RuntimeError(msg.format(max_cadences))
+    n_cadences = len(lc.cadenceno)
+    if n_cadences > max_cadences:
+        raise RuntimeError(
+            f"Interact cannot display more than {max_cadences} cadences "
+            "without suffering significant performance issues. You can "
+            "limit the number of cadences show using slicing, e.g. "
+            "`tpf[0:1000].interact()`. Alternatively, you can override "
+            "this limitation by passing the `max_cadences` argument."
+        )
+    elif n_cadences > 30000:
+        warnings.warn(f"The Target Pixel File contains {n_cadences} cadences. "
+                       "The performance of interact() is very slow for such a "
+                       "large number of frames. Consider using slicing, e.g. "
+                       "`tpf[0:1000].interact()`, to make interact run faster.",
+                       LightkurveWarning)
 
     def create_interact_ui(doc):
         # The data source includes metadata for hover-over tooltips

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1029,7 +1029,7 @@ class TargetPixelFile(object):
             properly. If no protocol is supplied in the URL, e.g. if it is
             of the form "localhost:8888", then "http" will be used.
         max_cadences : int
-            Raise a RuntimeError if the number of cadences shown is larger than
+            Print an error message if the number of cadences shown is larger than
             this value. This limit helps keep browsers from becoming unresponsive.
         aperture_mask : array-like, 'pipeline', 'threshold', 'default', or 'all'
             A boolean array describing the aperture such that `True` means

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1002,7 +1002,7 @@ class TargetPixelFile(object):
             output_fn = "{}-targ.fits".format(self.targetid)
         self.hdu.writeto(output_fn, overwrite=overwrite, checksum=True)
 
-    def interact(self, notebook_url='localhost:8888', max_cadences=30000,
+    def interact(self, notebook_url='localhost:8888', max_cadences=200000,
                  aperture_mask='default', exported_filename=None,
                  transform_func=None, ylim_func=None, **kwargs):
         """Display an interactive Jupyter Notebook widget to inspect the pixel data.

--- a/lightkurve/tests/test_interact.py
+++ b/lightkurve/tests/test_interact.py
@@ -109,21 +109,6 @@ def test_transform_and_ylim_funcs():
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
-def test_max_cadences():
-    """Test what is the max number of cadences allowed"""
-    import bokeh
-    with warnings.catch_warnings():
-        # Ignore the "TELESCOP is not equal to TESS" warning
-        warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(TABBY_TPF),
-                TessTargetPixelFile(example_tpf)]
-    for tpf in tpfs:
-        with pytest.raises(RuntimeError) as exc:
-            tpf.interact(max_cadences=2)
-            assert('Interact cannot display more than' in exc.value.args[0])
-
-
-@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_interact_functions():
     """Do the helper functions in the interact module run without syntax error?"""
     import bokeh


### PR DESCRIPTION
## Problem

By default, `TargetPixelFile.interact()` has a limitation of `max_cadences=30000` to avoid freezing a user's computer.  This leads to a poor user experience with the new TESS fast-cadence (20s) data:

<img width="739" alt="Screen Shot 2020-09-24 at 11 54 10" src="https://user-images.githubusercontent.com/817669/94189381-82eade00-fe5f-11ea-9e8f-d589a5046724.png">

## Solution

This PR improves the default behavior in three ways:
* The default value for `max_cadences` is increased to 200000 so it doesn't crash out of the box with TESS fast-cadence data.
* A user-friendly warning (rather than error) is shown if the number of cadences exceeds 30000.
* The error message shown has been made much more user-friendly.

Example new warning message:

<img width="897" alt="Screen Shot 2020-09-24 at 12 18 05" src="https://user-images.githubusercontent.com/817669/94189796-10c6c900-fe60-11ea-9640-620e5af7f0f5.png">

Example new error message:

<img width="895" alt="Screen Shot 2020-09-24 at 12 18 25" src="https://user-images.githubusercontent.com/817669/94189806-13c1b980-fe60-11ea-9026-357d5a147e57.png">
