### PR TITLE
Fix BLSPeriodogram apidoc ; change duration defaults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ lightkurve.periodogram
 - Modified ``create_transit_mask`` method to return ``True`` during transits and
   ``False`` elsewhere for consistent mask syntax. [#808]
 
+- Modified ``BoxLeastSquaresPeriodogram`` to use ``duration=[0.05, 0.10, 0.15, 0.20, 0.25, 0.33]``
+  by default, which yields more accurate results (albeit slower). [#859, #860]
+
 
 
 1.11.3 (2020-10-06)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1715,9 +1715,9 @@ class LightCurve(TimeSeries):
         power spectrum object.
 
         This method will call either
-        `lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve()` or
-        `lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve()`,
-        which in turn wrap `astropy.stats.LombScargle` and `astropy.stats.BoxLeastSquares`.
+        `LombScarglePeriodogram.from_lightcurve() <lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve>` or
+        `BoxLeastSquaresPeriodogram.from_lightcurve() <lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve>`,
+        which in turn wrap `astropy`'s `~astropy.timeseries.LombScargle` and `~astropy.timeseries.BoxLeastSquares`.
 
         Optional keywords accepted if ``method='lombscargle'`` are:
         ``minimum_frequency``, ``maximum_frequency``, ``mininum_period``,
@@ -1738,8 +1738,8 @@ class LightCurve(TimeSeries):
             and ``'boxleastsquares'``.
         kwargs : dict
             Keyword arguments passed to either
-            `~lightkurve.periodogram.LombScarglePeriodogram` or
-            `~lightkurve.periodogram.BoxLeastSquaresPeriodogram`.
+            `LombScarglePeriodogram <lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve>` or
+            `BoxLeastSquaresPeriodogram <lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve>`.
 
         Returns
         -------

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -924,7 +924,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
             The LightCurve from which to compute the Periodogram.
         duration : float, array_like, or `~astropy.units.Quantity`, optional
             The set of durations that will be considered.
-            Default to `0.25` if not specified.
+            Default to `[0.05, 0.10, 0.15, 0.20, 0.25, 0.33]` if not specified.
         period : array_like or `~astropy.units.Quantity`, optional
             The periods where the Periodogram should be computed.
             If not provided, a default will be created using
@@ -983,7 +983,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
             dy = None
 
         # Validate user input for `duration`
-        duration = kwargs.pop("duration", 0.25)
+        duration = kwargs.pop("duration", [0.05, 0.10, 0.15, 0.20, 0.25, 0.33])
         if duration is not None and ~np.all(np.isfinite(duration)):
             raise ValueError("`duration` parameter contains illegal nan or inf value(s)")
 

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -916,7 +916,53 @@ class BoxLeastSquaresPeriodogram(Periodogram):
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):
-        """Creates a Periodogram from a LightCurve using the Box Least Squares (BLS) method."""
+        """Creates a Periodogram from a LightCurve using the Box Least Squares (BLS) method.
+
+        Parameters
+        ----------
+        lc : `LightCurve` object
+            The LightCurve from which to compute the Periodogram.
+        duration : float, array_like, or `~astropy.units.Quantity`, optional
+            The set of durations that will be considered.
+            Default to `0.25` if not specified.
+        period : array_like or `~astropy.units.Quantity`, optional
+            The periods where the Periodogram should be computed.
+            If not provided, a default will be created using
+            `BoxLeastSquares.autoperiod()  <astropy.timeseries.BoxLeastSquares.autoperiod>`.
+        minimum_period, maximum_period : float or `~astropy.units.Quantity`, optional
+            If ``period`` is not provided, the minimum/maximum periods to search.
+            The defaults will be computed as described in the notes below.
+        frequency_factor : float, optional
+            If ``period`` is not provided, a factor to control the frequency spacing of periods
+            to be considered.
+        kwargs : dict
+            Keyword arguments passed to
+            `BoxLeastSquares.power() <astropy.timeseries.BoxLeastSquares.power>`
+
+        Returns
+        -------
+        Periodogram : `Periodogram` object
+            Returns a Periodogram object extracted from the lightcurve.
+
+        Notes
+        -----
+        If ``period`` is not provided, the default minimum period is computed from maximum duration and
+        the median observation time gap as
+
+        .. code-block:: python
+
+                minimum_period = max(median(diff(lc.time)) * 4,
+                                     max(duration) + median(diff(lc.time)))
+
+        The default maximum period is computed as
+
+        .. code-block:: python
+
+                maximum_period = (max(lc.time) - min(lc.time)) / 3
+
+        ensuring that any systems with at least 3 transits are within the range of searched periods.
+
+        """
         # BoxLeastSquares was added to `astropy.stats` in AstroPy v3.1 and then
         # moved to `astropy.timeseries` in v3.2, which makes the import below
         # somewhat complicated.

--- a/lightkurve/tests/test_periodogram.py
+++ b/lightkurve/tests/test_periodogram.py
@@ -287,7 +287,7 @@ def test_bls_period_recovery():
     flux_err = 0.01
 
     # Create the synthetic light curve
-    time = np.arange(0, 100, 0.1)
+    time = np.arange(0, 20, 0.02)
     flux = np.ones_like(time)
     transit_mask = np.abs((time-transit_time+0.5*period) % period-0.5*period) < 0.5*duration
     flux[transit_mask] = 1.0 - depth


### PR DESCRIPTION
1. Add apidoc for `BLSPeriodogram`, mainly to explain the parameters, especially those with defaults created by lightkurve (rather than just relying on underlying astropy).
2. Close #859 (`duration` defaults)

