### PR TITLE
Attribute access for LightCurve meta / columns ; meta keys' case

### DIFF
--- a/docs/source/tutorials/01-what-are-lightcurves.ipynb
+++ b/docs/source/tutorials/01-what-are-lightcurves.ipynb
@@ -61,7 +61,7 @@
     }
    ],
    "source": [
-    "lc.meta['mission']"
+    "lc.meta['MISSION']"
    ]
   },
   {
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "lc.meta['quarter']"
+    "lc.meta['QUARTER']"
    ]
   },
   {

--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -51,7 +51,7 @@ class Collection(object):
         if (isinstance(self[0], TargetPixelFile)):
             labels = np.asarray([tpf.targetid for tpf in self])
         else:
-            labels = np.asarray([lc.meta.get('label') for lc in self])
+            labels = np.asarray([lc.meta.get('LABEL') for lc in self])
 
         try:
             unique_labels = np.sort(np.unique(labels))
@@ -153,7 +153,7 @@ class LightCurveCollection(Collection):
                 if kwarg in kwargs:
                     kwargs.pop(kwarg)
 
-            labels = np.asarray([lc.meta.get('label') for lc in self])
+            labels = np.asarray([lc.meta.get('LABEL') for lc in self])
             try:
                 unique_labels = np.sort(np.unique(labels))
             except TypeError:  # sorting will fail if labels includes None

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -318,24 +318,24 @@ class PLDCorrector(RegressionCorrector):
 
         # Set mission-specific values for pld_order and pca_components
         if pld_order is None:
-            if self.tpf.meta.get('mission') == 'K2':
+            if self.tpf.meta.get('MISSION') == 'K2':
                 pld_order = 3
             else:
                 pld_order = 1
         if pca_components is None:
-            if self.tpf.meta.get('mission') == 'K2':
+            if self.tpf.meta.get('MISSION') == 'K2':
                 pca_components = 16
             else:
                 pca_components = 3
         if pld_aperture_mask is None:
-            if self.tpf.meta.get('mission') == 'K2':
+            if self.tpf.meta.get('MISSION') == 'K2':
                 # K2 noise is dominated by motion
                 pld_aperture_mask = 'threshold'
             else:
                 # TESS noise is dominated by background
                 pld_aperture_mask = 'empty'
         if normalize_background_pixels is None:
-            if self.tpf.meta.get('mission') == 'K2':
+            if self.tpf.meta.get('MISSION') == 'K2':
                 normalize_background_pixels = True
             else:
                 normalize_background_pixels = False

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -179,7 +179,7 @@ def test_sff_breakindex():
 
 def test_sff_tess_warning():
     """SFF is not designed for TESS, so we raise a warning."""
-    lc = TessLightCurve(flux=[1, 2, 3], meta={'mission': 'TESS'})
+    lc = TessLightCurve(flux=[1, 2, 3], meta={'MISSION': 'TESS'})
     with pytest.warns(LightkurveWarning, match='not suitable'):
         corr = SFFCorrector(lc)
 

--- a/lightkurve/interact.py
+++ b/lightkurve/interact.py
@@ -148,7 +148,7 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
     step_renderer : GlyphRenderer
     vertical_line : Span
     """
-    mission = lc.meta.get('mission')
+    mission = lc.meta.get('MISSION')
     if mission == 'K2':
         title = "Lightcurve for {} (K2 C{})".format(
             lc.label, lc.campaign)
@@ -551,7 +551,7 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         aperture_mask = np.zeros(tpf.flux.shape[1:]).astype(bool)
         aperture_mask[0, 0] = True
 
-    lc.meta['aperture_mask'] = aperture_mask
+    lc.meta['APERTURE_MASK'] = aperture_mask
 
     if transform_func is not None:
         lc = transform_func(lc)
@@ -617,7 +617,7 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
             selected_indices = np.array(selected_pixel_indices)
             selected_mask = np.isin(pixel_index_array, selected_indices)
             lc_new = tpf.to_lightcurve(aperture_mask=selected_mask)
-            lc_new.meta['aperture_mask'] = selected_mask
+            lc_new.meta['APERTURE_MASK'] = selected_mask
             if transform_func is not None:
                 lc_transformed = transform_func(lc_new)
                 if (len(lc_transformed) != len(lc_new)):
@@ -626,7 +626,7 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
                             'Skipping the transformation...', LightkurveWarning)
                 else:
                     lc_new = lc_transformed
-                    lc_new.meta['aperture_mask'] = selected_mask
+                    lc_new.meta['APERTURE_MASK'] = selected_mask
             return lc_new
 
         def update_upon_pixel_selection(attr, old, new):
@@ -685,10 +685,10 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
                                                     transform_func=transform_func)
                 lc_new.to_fits(exported_filename, overwrite=True,
                                flux_column_name='SAP_FLUX',
-                               aperture_mask=lc_new.meta['aperture_mask'].astype(np.int),
+                               aperture_mask=lc_new.meta['APERTURE_MASK'].astype(np.int),
                                SOURCE='lightkurve interact',
                                NOTE='custom mask',
-                               MASKNPIX=np.nansum(lc_new.meta['aperture_mask']))
+                               MASKNPIX=np.nansum(lc_new.meta['APERTURE_MASK']))
                 if message_on_save.text == " ":
                     text = '<font color="black"><i>Saved file {} </i></font>'
                     message_on_save.text = text.format(exported_filename)

--- a/lightkurve/io/everest.py
+++ b/lightkurve/io/everest.py
@@ -54,9 +54,9 @@ def read_everest_lightcurve(filename,
                                 bitmask=quality_bitmask)
     lc = lc[quality_mask]
 
-    lc.meta['label'] = '{} (EVEREST)'.format(lc.meta.get("object"))
-    lc.meta['targetid'] = lc.meta.get('keplerid')
-    lc.meta['quality_bitmask'] = quality_bitmask
-    lc.meta['quality_mask'] = quality_mask
+    lc.meta['LABEL'] = '{} (EVEREST)'.format(lc.meta.get('OBJECT'))
+    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
+    lc.meta['QUALITY_BITMASK'] = quality_bitmask
+    lc.meta['QUALITY_MASK'] = quality_mask
 
     return KeplerLightCurve(data=lc, **kwargs)

--- a/lightkurve/io/generic.py
+++ b/lightkurve/io/generic.py
@@ -37,8 +37,7 @@ def read_generic_lightcurve(filename, flux_column,
     # Make sure the meta data also includes header fields from extension #0
     tab.meta.update(hdulist[0].header)
 
-    # Use lowercase for meta data fields
-    tab.meta = {k.lower(): v for k, v in tab.meta.items()}
+    tab.meta = {k : v for k, v in tab.meta.items()}
 
     # Some KEPLER files used to have a T column instead of TIME.
     if "T" in tab.colnames:
@@ -90,10 +89,10 @@ def read_generic_lightcurve(filename, flux_column,
     if 'centroid_row' not in tab.columns and centroid_row_column in tab.columns:
         tab.add_column(tab[centroid_row_column], name="centroid_row", index=5)
 
-    tab.meta['label'] = hdulist[0].header.get('OBJECT')
-    tab.meta['mission'] = hdulist[0].header.get('MISSION', hdulist[0].header.get('TELESCOP'))
-    tab.meta['ra'] = hdulist[0].header.get('RA_OBJ')
-    tab.meta['dec'] = hdulist[0].header.get('DEC_OBJ')
-    tab.meta['filename'] = filename
+    tab.meta['LABEL'] = hdulist[0].header.get('OBJECT')
+    tab.meta['MISSION'] = hdulist[0].header.get('MISSION', hdulist[0].header.get('TELESCOP'))
+    tab.meta['RA'] = hdulist[0].header.get('RA_OBJ')
+    tab.meta['DEC'] = hdulist[0].header.get('DEC_OBJ')
+    tab.meta['FILENAME'] = filename
 
     return LightCurve(time=time, data=tab)

--- a/lightkurve/io/k2sff.py
+++ b/lightkurve/io/k2sff.py
@@ -28,7 +28,7 @@ def read_k2sff_lightcurve(filename, ext="BESTAPER", **kwargs):
                                  time_format='bkjd',
                                  ext=ext)
 
-    lc.meta['label'] = '{} (K2SFF)'.format(lc.meta.get("object"))
-    lc.meta['targetid'] = lc.meta.get('keplerid')
+    lc.meta['LABEL'] = '{} (K2SFF)'.format(lc.meta.get('OBJECT'))
+    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
 
     return KeplerLightCurve(data=lc, **kwargs)

--- a/lightkurve/io/kepler.py
+++ b/lightkurve/io/kepler.py
@@ -45,7 +45,7 @@ def read_kepler_lightcurve(filename,
                                 bitmask=quality_bitmask)
     lc = lc[quality_mask]
 
-    lc.meta['targetid'] = lc.meta.get('keplerid')
-    lc.meta['quality_bitmask'] = quality_bitmask
-    lc.meta['quality_mask'] = quality_mask
+    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
+    lc.meta['QUALITY_BITMASK'] = quality_bitmask
+    lc.meta['QUALITY_MASK'] = quality_mask
     return KeplerLightCurve(data=lc)

--- a/lightkurve/io/tess.py
+++ b/lightkurve/io/tess.py
@@ -44,7 +44,7 @@ def read_tess_lightcurve(filename,
                                 bitmask=quality_bitmask)
     lc = lc[quality_mask]
 
-    lc.meta['targetid'] = lc.meta.get('ticid')
-    lc.meta['quality_bitmask'] = quality_bitmask
-    lc.meta['quality_mask'] = quality_mask
+    lc.meta['TARGETID'] = lc.meta.get('TICID')
+    lc.meta['QUALITY_BITMASK'] = quality_bitmask
+    lc.meta['QUALITY_MASK'] = quality_mask
     return TessLightCurve(data=lc)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -81,6 +81,10 @@ class LightCurve(TimeSeries):
     Note that you *cannot* create a new column using the attribute interface. If you do so,
     a new attribute is created instead, and a warning is raised.
 
+    If you do create such attributes on purpose, please note that the attributes are not carried
+    over when the lightcurve object is copied, or a new lightcurve object is derived
+    based on a copy, e.g., ``normalize()``.
+
 
     Examples
     --------
@@ -273,7 +277,8 @@ class LightCurve(TimeSeries):
             to_set_as_attr = True
         if to_set_as_attr:
             if name not in self.__dict__ and not name.startswith("_") and not self._new_attributes_relax:
-                warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name"
+                warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name."
+                               "A new attribute is created. It will not be carried over when the object is copied."
                                " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"),
                               UserWarning, stacklevel=2)
             super().__setattr__(name, value, **kwargs)

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -234,6 +234,8 @@ class LightCurve(TimeSeries):
         elif ('_meta' in self.__dict__) and (name in self.__dict__['_meta']):
             self.__dict__['_meta'][name] = value
         else:
+            warnings.warn("Lightkurve doesn't allow columns or meta values to be created via a new attribute name",
+                          UserWarning)
             super().__setattr__(name, value, **kwargs)
 
     def _base_repr_(self, html=False, descr_vals=None, **kwargs):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -265,9 +265,10 @@ class LightCurve(TimeSeries):
         else:
             to_set_as_attr = True
         if to_set_as_attr:
-            warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name"
-                           " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"),
-                          UserWarning)
+            if name not in self.__dict__:
+                warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name"
+                               " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"),
+                              UserWarning, stacklevel=2)
             super().__setattr__(name, value, **kwargs)
 
     def _base_repr_(self, html=False, descr_vals=None, **kwargs):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -62,6 +62,26 @@ class LightCurve(TimeSeries):
     **kwargs : dict
         Additional keyword arguments are passed to `~astropy.table.QTable`.
 
+    Attributes
+    ----------
+    meta : `dict`
+        meta data associated with the lightcurve. The header of the underlying FITS file (if applicable)
+        is available here as well.
+
+    Notes
+    -----
+    *Attribute access*: You can access a column or a ``meta`` value directly as an attribute.
+
+    >>> lc.flux    # shortcut for lc['flux']   # doctest: +SKIP
+    >>> lc.sector  # shortcut for lc.meta['SECTOR']   # doctest: +SKIP
+    >>> lc.flux = lc.flux * 1.05  # update the values of a column.   # doctest: +SKIP
+
+    In case the given name is both a column name and a key in ``meta``, the column will be returned.
+
+    Note that you *cannot* create a new column using the attribute interface. If you do so,
+    a new attribute is created instead, and a warning is raised.
+
+
     Examples
     --------
     >>> import lightkurve as lk
@@ -245,7 +265,8 @@ class LightCurve(TimeSeries):
         else:
             to_set_as_attr = True
         if to_set_as_attr:
-            warnings.warn("Lightkurve doesn't allow columns or meta values to be created via a new attribute name",
+            warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name"
+                           " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"),
                           UserWarning)
             super().__setattr__(name, value, **kwargs)
 

--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -860,8 +860,8 @@ class LombScarglePeriodogram(Periodogram):
 
         # Periodogram needs properties
         return LombScarglePeriodogram(frequency=frequency, power=power, nyquist=nyquist,
-                                      targetid=lc.meta.get('targetid'),
-                                      label=lc.meta.get('label'),
+                                      targetid=lc.meta.get('TARGETID'),
+                                      label=lc.meta.get('LABEL'),
                                       default_view=default_view, ls_obj=LS,
                                       nterms=nterms, ls_method=ls_method,
                                       meta=lc.meta)
@@ -888,7 +888,7 @@ class LombScarglePeriodogram(Periodogram):
         f = self._LS_object.model(time, frequency)
         lc = LightCurve(time=time,
                         flux=f,
-                        meta={'frequency':frequency},
+                        meta={'FREQUENCY':frequency},
                         label='LS Model',
                         targetid='{} LS Model'.format(self.targetid))
         return lc.normalize()
@@ -997,8 +997,8 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         return BoxLeastSquaresPeriodogram(frequency=1. / result.period,
                                           power=result.power,
                                           default_view='period',
-                                          label=lc.meta.get('label'),
-                                          targetid=lc.meta.get('targetid'),
+                                          label=lc.meta.get('LABEL'),
+                                          targetid=lc.meta.get('TARGETID'),
                                           transit_time=result.transit_time,
                                           duration=result.duration,
                                           depth=result.depth,

--- a/lightkurve/seismology/core.py
+++ b/lightkurve/seismology/core.py
@@ -604,10 +604,10 @@ class Seismology(object):
         This code structure borrows from work done in Bellinger et al. (2019), which
         also functions as an accessible explanation of seismic scaling relations.
 
-        If no value of effective temperature is given, this function will check the 
+        If no value of effective temperature is given, this function will check the
         meta data of the `Periodogram` object used to create the `Seismology` object.
-        These data will often contain an effective tempearture from the Kepler Input 
-        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+        These data will often contain an effective tempearture from the Kepler Input
+        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
         or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
         catalogues are estimated using photometry, and so have large associated uncertainties
         (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -642,10 +642,10 @@ class Seismology(object):
         numax = self._validate_numax(numax)
         deltanu = self._validate_deltanu(deltanu)
         if teff is None:
-            teff = self.periodogram.meta.get('teff')
+            teff = self.periodogram.meta.get('TEFF')
             if teff is None:
                 raise ValueError("You must provide an effective temperature argument (`teff`) to `estimate_radius`,"
-                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['teff']` is missing")
+                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['TEFF']` is missing")
             else:
                 log.info("Using value for effective temperature from the Kepler Input Catalogue."
                         "These temperatue values may sometimes differ significantly from modern estimates.")
@@ -675,10 +675,10 @@ class Seismology(object):
         This code structure borrows from work done in Bellinger et al. (2019), which
         also functions as an accessible explanation of seismic scaling relations.
 
-        If no value of effective temperature is given, this function will check the 
+        If no value of effective temperature is given, this function will check the
         meta data of the `Periodogram` object used to create the `Seismology` object.
-        These data will often contain an effective tempearture from the Kepler Input 
-        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+        These data will often contain an effective tempearture from the Kepler Input
+        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
         or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
         catalogues are estimated using photometry, and so have large associated uncertainties
         (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -697,7 +697,7 @@ class Seismology(object):
             degree. If not given an astropy unit, assumed to be in units of
             microhertz.
         teff : float
-            The effective temperature of the star. In units of Kelvin. 
+            The effective temperature of the star. In units of Kelvin.
         numax_err : float
             Error on numax. Assumed to be same units as numax
         deltanu_err : float
@@ -713,10 +713,10 @@ class Seismology(object):
         numax = self._validate_numax(numax)
         deltanu = self._validate_deltanu(deltanu)
         if teff is None:
-            teff = self.periodogram.meta.get('teff')
+            teff = self.periodogram.meta.get('TEFF')
             if teff is None:
                 raise ValueError("You must provide an effective temperature argument (`teff`) to `estimate_radius`,"
-                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['teff']` is missing")
+                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['TEFF']` is missing")
             else:
                 log.info("Using value for effective temperature from the Kepler Input Catalogue."
                         "These temperatue values may sometimes differ significantly from modern estimates.")
@@ -751,10 +751,10 @@ class Seismology(object):
         This code structure borrows from work done in Bellinger et al. (2019), which
         also functions as an accessible explanation of seismic scaling relations.
 
-        If no value of effective temperature is given, this function will check the 
+        If no value of effective temperature is given, this function will check the
         meta data of the `Periodogram` object used to create the `Seismology` object.
-        These data will often contain an effective tempearture from the Kepler Input 
-        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+        These data will often contain an effective tempearture from the Kepler Input
+        Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
         or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
         catalogues are estimated using photometry, and so have large associated uncertainties
         (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -782,10 +782,10 @@ class Seismology(object):
         """
         numax = self._validate_numax(numax)
         if teff is None:
-            teff = self.periodogram.meta.get('teff')
+            teff = self.periodogram.meta.get('TEFF')
             if teff is None:
                 raise ValueError("You must provide an effective temperature argument (`teff`) to `estimate_radius`,"
-                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['teff']` is missing")
+                        "because the Periodogram object does not contain it in its meta data (i.e. `pg.meta['TEFF']` is missing")
             else:
                 log.info("Using value for effective temperature from the Kepler Input Catalogue."
                         "These temperatue values may sometimes differ significantly from modern estimates.")

--- a/lightkurve/seismology/tests/test_butler.py
+++ b/lightkurve/seismology/tests/test_butler.py
@@ -287,7 +287,7 @@ def test_plot_deltanu_diagnostics():
 def test_stellar_estimator_calls():
     f, p, _, true_deltanu = generate_test_spectrum()
     snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
-    snr.meta = {'teff' : 3000}
+    snr.meta = {'TEFF': 3000}
 
     butler = snr.to_seismology()
     butler.estimate_numax()
@@ -304,10 +304,10 @@ def test_stellar_estimator_calls():
     log = butler.estimate_logg(3100)
 
     # Raise error if no teff available
-    butler.periodogram.meta['teff'] = None
+    butler.periodogram.meta['TEFF'] = None
     with pytest.raises(ValueError):
         mass = butler.estimate_mass()
-    with pytest.raises(ValueError):  
+    with pytest.raises(ValueError):
         rad = butler.estimate_radius()
     with pytest.raises(ValueError):
         log = butler.estimate_logg()

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -51,16 +51,17 @@ class HduToMetaMapping(collections.abc.Mapping):
     """Provides a read-only view of HDU header in `astropy.timeseries.TimeSeries.meta` format"""
 
     def __init__(self, hdu):
-        self._hdu = hdu
+        self._dict = {}
+        self._dict.update(hdu.header)
 
     def __getitem__(self, key):
-        return self._hdu.header[key]
+        return self._dict[key]
 
     def __len__(self):
-        return len(self._hdu.header)
+        return len(self._dict)
 
     def __iter__(self):
-        return iter(self._hdu.header)
+        return iter(self._dict)
 
 class TargetPixelFile(object):
     """Abstract class representing FITS files which contain time series imaging data.

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -47,6 +47,21 @@ __all__ = ['KeplerTargetPixelFile', 'TessTargetPixelFile']
 log = logging.getLogger(__name__)
 
 
+class HduToMetaMapping(collections.abc.Mapping):
+    """Provides a read-only view of HDU header in `astropy.timeseries.TimeSeries.meta` format"""
+
+    def __init__(self, hdu):
+        self._hdu = hdu
+
+    def __getitem__(self, key):
+        return self._hdu.header[key]
+
+    def __len__(self):
+        return len(self._hdu.header)
+
+    def __iter__(self):
+        return iter(self._hdu.header)
+
 class TargetPixelFile(object):
     """Abstract class representing FITS files which contain time series imaging data.
 
@@ -63,9 +78,7 @@ class TargetPixelFile(object):
         self.targetid = targetid
 
         # For consistency with `LightCurve`, provide a `meta` dictionary
-        self.meta = {}
-        self.meta.update(self.get_header(0))
-        self.meta = {k.lower(): v for k, v in self.meta.items()}
+        self.meta = HduToMetaMapping(self.hdu[0])
 
     def __getitem__(self, key):
         """Implements indexing and slicing.
@@ -1256,8 +1269,8 @@ class TargetPixelFile(object):
             warnings.simplefilter('ignore')
             newfits = fits.HDUList(hdus)
         return self.__class__(newfits, quality_bitmask=self.quality_bitmask)
-    
-    
+
+
     @staticmethod
     def from_fits_images(images_flux, position, images_raw_cnts=None, images_flux_err=None,
                          images_flux_bkg=None, images_flux_bkg_err=None, images_cosmic_rays=None,
@@ -1330,7 +1343,7 @@ class TargetPixelFile(object):
             else:
                 hdu = fits.open(img)[extension]
             return hdu
-        
+
         # Define a helper function to cutout images if not None
         def _cutout_image(hdu, position, wcs_ref, size):
             if hdu is None:
@@ -1383,16 +1396,16 @@ class TargetPixelFile(object):
 
         allkeys = hdu0_keywords.copy()
         allkeys.update(carry_keywords)
-        
+
         img_list = [images_raw_cnts, images_flux, images_flux_err, images_flux_bkg, images_flux_bkg_err, images_cosmic_rays]
 
         for idx, img in tqdm(enumerate(images_flux), total=len_images):
             # Open images if provided and get HDUs
             hdu_list = [_open_image(i[idx], extension) if i is not None else None for i in img_list]
-                
+
             # Use the header in the flux image for each frame
             hdu_idx = hdu_list[1].header
-            
+
             if idx == 0:  # Get default keyword values from the first flux image
                 factory.keywords = hdu_idx
 
@@ -1417,7 +1430,7 @@ class TargetPixelFile(object):
             # Flatten output list
             cutout_list = flat_list = [item for sublist in cutout_list for item in sublist]
             raw_cnts, _, flux, wcs, flux_err, _, flux_bkg, _, flux_bkg_err, _, cosmic_rays, _ = cutout_list
-            
+
             factory.add_cadence(frameno=idx, raw_cnts=raw_cnts, flux=flux, flux_err=flux_err,
                                 flux_bkg=flux_bkg, flux_bkg_err=flux_bkg_err, cosmic_rays=cosmic_rays,
                                 header=hdu_idx)
@@ -1735,7 +1748,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 'dec': self.dec,
                 'label': self.get_keyword('OBJECT', default=self.targetid),
                 'targetid': self.targetid}
-        meta = {'aperture_mask': aperture_mask}
+        meta = {'APERTURE_MASK': aperture_mask}
         return KeplerLightCurve(time=self.time,
                                 flux=flux,
                                 flux_err=flux_err,
@@ -1961,7 +1974,7 @@ class TargetPixelFileFactory(object):
                           'returning generic TargetPixelFile instead.', LightkurveWarning)
             tpf = TargetPixelFile(hdulist, **kwargs)
         return tpf
-    
+
     def _hdulist(self, hdu0_keywords, ext_info):
         """Returns an astropy.io.fits.HDUList object."""
         return fits.HDUList([self._make_primary_hdu(hdu0_keywords=hdu0_keywords),
@@ -2233,7 +2246,7 @@ class TessTargetPixelFile(TargetPixelFile):
                 'dec': self.dec,
                 'label': self.get_keyword('OBJECT', default=self.targetid),
                 'targetid': self.targetid}
-        meta = {'aperture_mask': aperture_mask}
+        meta = {'APERTURE_MASK': aperture_mask}
         return TessLightCurve(time=self.time,
                               flux=flux,
                               flux_err=flux_err,

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -997,7 +997,7 @@ def test_bin_issue705():
 def test_SSOs():
     # TESS test
     lc = TessTargetPixelFile(asteroid_TPF).to_lightcurve(aperture_mask='all')
-    lc.mission = 'TESS' # needed to resolve default value for location argument
+    lc.meta['MISSION'] = 'TESS' # needed to resolve default value for location argument
     result = lc.query_solar_system_objects(cadence_mask='all', cache=False)
     assert(len(result) == 1)
     result = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -121,11 +121,11 @@ def test_KeplerLightCurveFile(path, mission):
 
     assert lc.mission.lower() == mission.lower()
     if lc.mission.lower() == 'kepler':
-        assert lc.meta.get('campaign') is None
+        assert lc.meta.get('CAMPAIGN') is None
         assert lc.quarter == 8
     elif lc.mission.lower() == 'k2':
         assert lc.campaign == 8
-        assert lc.meta.get('quarter') is None
+        assert lc.meta.get('QUARTER') is None
     assert lc.time.format == 'bkjd'
     assert lc.time.scale == 'tdb'
     assert lc.flux.unit == u.electron / u.second
@@ -177,7 +177,7 @@ def test_bitmasking(quality_bitmask, answer):
 def test_lightcurve_fold():
     """Test the ``LightCurve.fold()`` method."""
     lc = KeplerLightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1,
-                          targetid=999, label='mystar', meta={'ccd': 2})
+                          targetid=999, label='mystar', meta={'CCD': 2})
     fold = lc.fold(period=1)
     assert_almost_equal(fold.phase[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
@@ -185,7 +185,7 @@ def test_lightcurve_fold():
     assert fold.targetid == lc.targetid
     assert fold.label == lc.label
     assert set(lc.meta).issubset(set(fold.meta))
-    assert lc.meta['ccd'] == fold.meta['ccd']
+    assert lc.meta['CCD'] == fold.meta['CCD']
     assert_array_equal(np.sort(fold.time_original), lc.time)
     assert len(fold.time_original) == len(lc.time)
     fold = lc.fold(period=1, epoch_time=-0.1)
@@ -1142,20 +1142,20 @@ def test_attr_access_meta():
     lc = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
 
     # Read/Write access of meta via attribute
-    lc.meta['sector'] = 14
-    assert(lc.sector == 14)
+    lc.meta['SECTOR'] = 14
+    assert(lc.sector == 14)  # uppercased meta key is accessed as lowercased attributes
 
     sector_corrected = 15
     lc.sector = sector_corrected
     assert(lc.sector == sector_corrected)
-    assert(lc.sector == lc.meta['sector'])
+    assert(lc.sector == lc.meta['SECTOR'])
 
     # meta key is an existing attribute / method: : attribute access not available
-    lc.meta['info'] = 'Some information'  # .info: an existing attribute
-    assert(lc.info != lc.meta['info'])
+    lc.meta['INFO'] = 'Some information'  # .info: an existing attribute
+    assert(lc.info != lc.meta['INFO'])
 
-    lc.meta['bin'] = 'Some value'  # .bin: an existing method
-    assert(lc.bin != lc.meta['bin'])
+    lc.meta['BIN'] = 'Some value'  # .bin: an existing method
+    assert(lc.bin != lc.meta['BIN'])
 
     # Create a attribute: it is created as a object attribute, rather than meta
     attr_value = 'bar_value'
@@ -1164,6 +1164,13 @@ def test_attr_access_meta():
     assert(lc.meta.get('foo', None) is None)
     assert(lc.foo == attr_value)
 
+    # Case meta has 2 keys that only differs in case
+    lc.meta['KEYCASE'] = 'VALUE UPPER'
+    lc.meta['keycase'] = 'value lower'
+    # they are two different entries (case sensitive)
+    assert(lc.meta['KEYCASE'] == 'VALUE UPPER')
+    assert(lc.meta['keycase'] == 'value lower')
+    assert(lc.keycase == 'value lower')  # the meta entry with exact case is retrieved
 
 
 def test_attr_access_others():
@@ -1175,7 +1182,7 @@ def test_attr_access_others():
     val_of_col = [5, 6, 7]
     val_of_meta_key = 'value'
     lc['foo'] = val_of_col
-    lc.meta['foo'] = val_of_meta_key
+    lc.meta['FOO'] = val_of_meta_key
     assert_array_equal(lc.foo, val_of_col) # lc.foo refers to the column
 
 

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1127,8 +1127,8 @@ def test_attr_access_columns():
 
     # Create a new column directly as an attribute: only attribute is created, not a column
     flux2_unitless = [6, 7, 8]
-    # TODO: assert UserWarning
-    lc.flux2 = flux2_unitless
+    with pytest.warns(UserWarning, match="new attribute name"):
+        lc.flux2 = flux2_unitless
     with pytest.raises(KeyError):
         lc['flux2']
     assert_array_equal(lc.flux2, flux2_unitless)
@@ -1156,6 +1156,14 @@ def test_attr_access_meta():
 
     lc.meta['bin'] = 'Some value'  # .bin: an existing method
     assert(lc.bin != lc.meta['bin'])
+
+    # Create a attribute: it is created as a object attribute, rather than meta
+    attr_value = 'bar_value'
+    with pytest.warns(UserWarning, match="new attribute name"):
+        lc.foo = attr_value
+    assert(lc.meta.get('foo', None) is None)
+    assert(lc.foo == attr_value)
+
 
 
 def test_attr_access_others():

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1134,6 +1134,13 @@ def test_attr_access_columns():
     assert_array_equal(lc.flux2, flux2_unitless)
     assert(type(lc.flux2) is list)  # as it's just an attribute, there is no conversion done to Quantity
 
+    # ensure no warning is raised when updating an existing attribute
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        lc.foo = 'bar'
+    with pytest.warns(None) as warn_record:
+        lc.foo = 'bar2'
+    assert len(warn_record) == 0
 
 
 def test_attr_access_meta():

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -717,14 +717,13 @@ def test_tpf_meta():
     tpf = read(filename_tpf_one_center)
     assert tpf.meta.get('MISSION') == 'K2'
     assert tpf.meta['MISSION'] == 'K2'
-    assert tpf.meta['mission'] == 'K2'  # for the underlying hdu[0].header, key is case in-sensitive
+    assert tpf.meta.get('mission', None) is None  # key is case in-sensitive
     assert tpf.meta.get('CHANNEL') == 45
     # ensure meta is read-only view of the underlying self.hdu[0].header
     with pytest.raises(TypeError):
         tpf.meta['CHANNEL'] = 44
     with pytest.raises(TypeError):
         tpf.meta['KEY-NEW'] = 44
-    tpf.hdu[0].header['key1'] = 'val1'
 
 
 def test_estimate_background():

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -687,7 +687,7 @@ def test_missing_pipeline_mask():
     tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=1)
     lc = tpf.to_lightcurve()
     assert np.isfinite(lc.flux).any()
-    assert lc.meta.get('aperture_mask', None) == 'threshold'
+    assert lc.meta.get('APERTURE_MASK', None) == 'threshold'
 
     with pytest.raises(ValueError):
         # if aperture_mask is explicitly set as pipeline,
@@ -715,8 +715,16 @@ def test_parse_numeric_aperture_masks():
 def test_tpf_meta():
     """Can we access meta data using tpf.meta?"""
     tpf = read(filename_tpf_one_center)
-    assert tpf.meta.get('mission') == 'K2'
-    assert tpf.meta.get('channel') == 45
+    assert tpf.meta.get('MISSION') == 'K2'
+    assert tpf.meta['MISSION'] == 'K2'
+    assert tpf.meta['mission'] == 'K2'  # for the underlying hdu[0].header, key is case in-sensitive
+    assert tpf.meta.get('CHANNEL') == 45
+    # ensure meta is read-only view of the underlying self.hdu[0].header
+    with pytest.raises(TypeError):
+        tpf.meta['CHANNEL'] = 44
+    with pytest.raises(TypeError):
+        tpf.meta['KEY-NEW'] = 44
+    tpf.hdu[0].header['key1'] = 'val1'
 
 
 def test_estimate_background():


### PR DESCRIPTION
Closes #845
- [x] Access columns / meta values via attributes ; emits warnings when user creates a new attribute (pandas behavior)
- [x] Document attribute access behavior and reference it in the warning.
- [x] retain meta key's case (i.e., uppercase for TESS / Kepler headers)
- [x] `TargetPixelFile` meta key's case