### PR TITLE
Fix plotting in Google Colab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,13 @@ lightkurve.periodogram
 
 
 
+1.11.3 (2020-10-06)
+===================
+
+- Fixed inline plots not appearing in Jupyter Notebooks and Google Colab. [#865]
+
+
+
 1.11.2 (2020-08-28)
 ===================
 

--- a/lightkurve/__init__.py
+++ b/lightkurve/__init__.py
@@ -27,14 +27,6 @@ archivePrefix = "ascl",
 }"""
 
 
-# By default Matplotlib is configured to work with a graphical user interface
-# which may require an X11 connection (i.e. a display).  When no display is
-# available, errors may occur.  In this case, we default to the robust Agg backend.
-import platform
-if platform.system() == "Linux" and os.environ.get('DISPLAY', '') == '':
-    import matplotlib
-    matplotlib.use('Agg')
-
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())


### PR DESCRIPTION
At present, Lightkurve's `__init__` changes the matplotlib back-end if a headless Linux display is detected:

https://github.com/KeplerGO/lightkurve/blob/ea53c81f3d7617441a02288ed84c016e8ef80ceb/lightkurve/__init__.py#L30-L36

We did this to enable our plotting methods to be tested by continuous integration services (Travis, Azure, GitHub Actions).

Unfortunately, two recent issues (#861 & #863) demonstrate that this is a bad idea, e.g. because it messes with the behavior of matplotlib on Google Colab.

This PR removes the offending piece of code and will explore a different way to make GitHub Actions pass.