### PR TITLE
Fix `fill_gaps` in Lightkurve v1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.11.3 (2020-10-06)
+===================
+
+- Fixed a bug in ``KeplerLightCurve.fill_gaps()`` which caused a ValueError
+  to be raised. [#862]
+
+
 1.11.2 (2020-08-28)
 ===================
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -814,8 +814,11 @@ class LightCurve(object):
             if column == "quality":
                 continue
             old_values = getattr(lc, column)
-            new_values = np.empty(len(ntime), dtype=old_values.dtype)
-            new_values[~in_original] = np.nan
+            new_values = np.zeros(len(ntime), dtype=old_values.dtype)
+            try:
+                new_values[~in_original] = np.nan
+            except ValueError:
+                pass
             new_values[in_original] = np.copy(old_values)
             setattr(nlc, column, new_values)
 


### PR DESCRIPTION
This PR intends to fix #862. 

The bug only affects Lightkurve v1.x, and hence will be merged into the v1.11.x branch only.