### PR TITLE
Fix two unit bugs in `fill_gaps`

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -832,13 +832,13 @@ class LightCurve(TimeSeries):
         # Find missing time points
         # Most precise method, taking into account time variation due to orbit
         if hasattr(lc, 'cadenceno'):
-            dt = lc.time.value - np.median(np.diff(lc.time.value)) * lc.cadenceno
-            ncad = np.arange(lc.cadenceno[0], lc.cadenceno[-1] + 1, 1)
-            in_original = np.in1d(ncad, lc.cadenceno)
+            dt = lc.time.value - np.median(np.diff(lc.time.value)) * lc.cadenceno.value
+            ncad = np.arange(lc.cadenceno.value[0], lc.cadenceno.value[-1] + 1, 1)
+            in_original = np.in1d(ncad, lc.cadenceno.value)
             ncad = ncad[~in_original]
-            ndt = np.interp(ncad, lc.cadenceno, dt)
+            ndt = np.interp(ncad, lc.cadenceno.value, dt)
 
-            ncad = np.append(ncad, lc.cadenceno)
+            ncad = np.append(ncad, lc.cadenceno.value)
             ndt = np.append(ndt, dt)
             ncad, ndt = ncad[np.argsort(ncad)], ndt[np.argsort(ncad)]
             ntime = ndt + np.median(np.diff(lc.time.value)) * ncad
@@ -866,10 +866,10 @@ class LightCurve(TimeSeries):
         fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
         if method == 'gaussian_noise':
             try:
-                std = lc.estimate_cdpp()*1e-6
+                std = lc.estimate_cdpp().to(lc.flux.unit).value
             except:
-                std = lc.flux.std()
-            f[~in_original] = np.random.normal(lc.flux.mean(), std.value, (~in_original).sum())
+                std = np.nanstd(lc.flux.value)
+            f[~in_original] = np.random.normal(np.nanmean(lc.flux.value), std, (~in_original).sum())
         else:
             raise NotImplementedError("No such method as {}".format(method))
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -873,8 +873,8 @@ class LightCurve(TimeSeries):
         else:
             raise NotImplementedError("No such method as {}".format(method))
 
-        newdata['flux'] = f
-        newdata['flux_err'] = fe
+        newdata['flux'] = Quantity(f, lc.flux.unit)
+        newdata['flux_err'] = Quantity(fe, lc.flux_err.unit)
 
         if hasattr(lc, 'quality'):
             quality = np.zeros(len(ntime), dtype=lc.quality.dtype)

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1144,8 +1144,18 @@ def test_row_repr():
     lc[0]._repr_html_()
 
 
-def test_fill_gaps_units():
-    """Does `fill_gaps` behave correctly when flux is in units ppm?"""
+def test_fill_gaps_with_cadenceno():
+    """Does `fill_gaps` work when a ``cadenceno`` column is present?
+    This is a regression test for #868."""
+    lc = LightCurve({'time': [1, 2, 4, 5],
+                     'flux': [1, 1, 1, 1],
+                     'cadenceno': [11, 12, 14, 15]})
+    lc.fill_gaps()  # raised a `UnitConversionError` in the past, cf. #868
+
+
+def test_fill_gaps_after_normalization():
+    """Does `fill_gaps` work correctly after normalization?
+    This is a regression test for #868."""
     lc = LightCurve({'time': [1, 2, 4, 5],
                      'flux': [1, 1, 1, 1],
                      'flux_err':[0.1, 0.1, 0.1, 0.1]})

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1142,3 +1142,16 @@ def test_row_repr():
     lc = LightCurve({'time': [1,2,3], 'flux':[1.,1.,1.]})
     lc[0].__repr__()
     lc[0]._repr_html_()
+
+
+def test_fill_gaps_units():
+    """Does `fill_gaps` behave correctly when flux is in units ppm?"""
+    lc = LightCurve({'time': [1, 2, 4, 5],
+                     'flux': [1, 1, 1, 1],
+                     'flux_err':[0.1, 0.1, 0.1, 0.1]})
+    lc = lc.normalize("ppm")
+    lc2 = lc.fill_gaps()
+    assert lc2.time[2].value == 3.
+    assert lc2.flux[2].value == 1e6
+    assert lc2.flux[2].unit == u.cds.ppm
+    assert lc2.flux_err[2] == 0.1


### PR DESCRIPTION
This PR fixes two bugs in `LightCurve.fill_gaps()`:

## Bug 1: exception raised if cadence numbers are present

The following error was encountered due to the incorrect handling of units:

```python
>>> import lightkurve as lk
>>> lc = lk.LightCurve({'time': [1, 2, 4, 5],
                        'flux': [1, 1, 1, 1],
                        'cadenceno': [11, 12, 14, 15]})
>>> lc.fill_gaps()
UnitConversionError: only quantities with time units can be used to instantiate Time instances.
```

## Bug 2: incorrect gap filling after normalization

Filling gaps after normalization yielded incorrect results, also due to the incorrect handling of units.

```python
>>> import lightkurve as lk
>>> lc = lk.LightCurve({'time': [1, 2, 4, 5],
...                     'flux': [1, 1, 1, 1]})
>>> lc.normalize("ppm").fill_gaps()
<LightCurve length=5>
 time     flux   flux_err

object  float64  float64
------ --------- --------
   1.0 1000000.0      nan
   2.0 1000000.0      nan
   3.0       1.0      nan
   4.0 1000000.0      nan
   5.0 1000000.0      nan
```

This PR fixes both issues.  It only affect Lightkurve v2, because units were not used prior.