### PR TITLE
Bugfix lightcurve attribute access

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -260,7 +260,9 @@ class LightCurve(TimeSeries):
     def __setattr__(self, name, value, **kwargs):
         """To get copied, attributes have to be stored in the meta dictionary!"""
         to_set_as_attr = False
-        if (name == 'time'):
+        if name in self.__dict__:
+            to_set_as_attr = True
+        elif (name == 'time'):
             self['time'] = value # astropy will convert value to Time if needed
         elif ('columns' in self.__dict__) and (name in self.__dict__['columns']):
             if not isinstance(value, Quantity):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1196,6 +1196,15 @@ def test_attr_access_others():
     lc.foo = val_of_col_updated  # should update the column rather than meta
     assert_array_equal(lc.foo, val_of_col_updated)
 
+    # case the same name is present as column name, meta key, and actual attribute
+    lc.bar = 'bar_attr_val'
+    lc['bar'] = [7, 8, 9]
+    lc.meta['BAR'] = 'bar_meta_val'
+    assert(lc.bar == 'bar_attr_val') # actual attribute takes priority
+
+    lc.bar = 'bar_attr_val_updated'
+    assert(lc.bar == 'bar_attr_val_updated') # the update should be done on actual attribute
+
 
 def test_create_transit_mask():
     """Test for `LightCurve.create_transit_mask()`."""

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1192,6 +1192,10 @@ def test_attr_access_others():
     lc.meta['FOO'] = val_of_meta_key
     assert_array_equal(lc.foo, val_of_col) # lc.foo refers to the column
 
+    val_of_col_updated = [6, 7, 8] * u_e_s
+    lc.foo = val_of_col_updated  # should update the column rather than meta
+    assert_array_equal(lc.foo, val_of_col_updated)
+
 
 def test_create_transit_mask():
     """Test for `LightCurve.create_transit_mask()`."""


### PR DESCRIPTION
This is a follow up on PR #864 , addressing issue #845

It occurred to me while I was taking a walk. 

For updating via attribute interface in the (really edge) case that the name exists as a real attribute, a column name, and a meta key.

I think it should update the real attribute. Even without the PR, the existing codes already chooses the real attribute in the get case. This fix brings the parity to the update / set case.
