### PR TITLE
Make `PLDCorrector` robust when the flux in a cadence is all-zero

### DIFF
--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -102,11 +102,14 @@ class PLDCorrector(RegressionCorrector):
     .. [4] EVEREST pipeline webpage, https://rodluger.github.io/everest
     """
     def __init__(self, tpf, aperture_mask=None):
-        self.tpf = tpf
         if aperture_mask is None:
             aperture_mask = tpf.create_threshold_mask(3)
         self.aperture_mask = aperture_mask
-        lc = self.tpf.to_lightcurve(aperture_mask=aperture_mask)
+        lc = tpf.to_lightcurve(aperture_mask=aperture_mask)
+        # Remove cadences that have NaN flux
+        nan_mask = np.isnan(lc.flux)
+        lc = lc[~nan_mask]
+        self.tpf = tpf[~nan_mask]
         super().__init__(lc=lc)
 
     def __repr__(self):

--- a/lightkurve/correctors/pldcorrector.py
+++ b/lightkurve/correctors/pldcorrector.py
@@ -106,7 +106,8 @@ class PLDCorrector(RegressionCorrector):
             aperture_mask = tpf.create_threshold_mask(3)
         self.aperture_mask = aperture_mask
         lc = tpf.to_lightcurve(aperture_mask=aperture_mask)
-        # Remove cadences that have NaN flux
+        # Remove cadences that have NaN flux (cf. #874). We don't simply call
+        # `lc.remove_nans()` here because we need to mask both lc & tpf.
         nan_mask = np.isnan(lc.flux)
         lc = lc[~nan_mask]
         self.tpf = tpf[~nan_mask]

--- a/lightkurve/correctors/tests/test_pldcorrector.py
+++ b/lightkurve/correctors/tests/test_pldcorrector.py
@@ -2,7 +2,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 
-from ... import search_targetpixelfile, KeplerLightCurve, TessLightCurve
+from ... import search_targetpixelfile, search_tesscut, KeplerLightCurve, TessLightCurve
 from .. import PLDCorrector
 
 
@@ -91,3 +91,10 @@ def test_pld_corrector():
     assert(corrected_lc.estimate_cdpp() < raw_lc.estimate_cdpp())
     # make sure the returned object is the correct type (`TessLightCurve`)
     assert(isinstance(corrected_lc, TessLightCurve))
+
+
+@pytest.mark.remote_data
+def test_tpf_with_zero_flux_cadence():
+    """Regression test for #873."""
+    tpf = search_tesscut("TIC 123835353", sector=6).download(cutout_size=5)
+    tpf.to_corrector('pld').correct()

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -784,6 +784,11 @@ class TargetPixelFile(object):
         is_allnan = ~np.any(np.isfinite(self.flux[:, apmask]), axis=1)
         flux[is_allnan] = np.nan
 
+        # Similarly, if *all* pixel values across the TPF are exactly zero,
+        # we propagate NaN (cf. #873 for an example of this happening)
+        is_allzero = np.all(self.flux == 0, axis=(1, 2))
+        flux[is_allzero] = np.nan
+
         # Estimate flux_err
         with warnings.catch_warnings():
             # Ignore warnings due to negative errors

--- a/lightkurve/tests/test_targetpixelfile.py
+++ b/lightkurve/tests/test_targetpixelfile.py
@@ -149,9 +149,9 @@ def test_tpf_zeros():
     lc = tpf.to_lightcurve(aperture_mask="all")
     assert len(lc.time) == len(lc.flux)
     assert np.all(lc.time == tpf.time)
-    assert np.all(lc.flux == 0)
+    assert np.all(np.isnan(lc.flux)) # we expect all NaNs because of #874
     # The default QUALITY bitmask should have removed all NaNs in the TIME
-    #assert ~np.any(np.isnan(tpf.time))
+    assert ~np.any(np.isnan(tpf.time.value))
 
 @pytest.mark.parametrize("centroid_method", [("moments"), ("quadratic")])
 def test_tpf_ones(centroid_method):


### PR DESCRIPTION
`PLDCorrector` currently fails to initialize when a TPF contains a cadence where `tpf.flux` is all-zero.  See #873 for a real-world example of such a cadence.

This PR modifies the constructor to automatically ignore such problematic cadences.

**Example failure:**

<img width="1229" alt="Screen Shot 2020-10-10 at 17 33 40" src="https://user-images.githubusercontent.com/817669/95667757-353cc980-0b1f-11eb-8c5b-5661c95bab2c.png">
