### PR TITLE
Use relax=True in from_fits images

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1359,7 +1359,7 @@ class TargetPixelFile(object):
                 cutout_data = cutout.data
                 cutout_wcs = cutout.wcs
             return cutout_data, cutout_wcs
-        
+
         # Set the default extension if unspecified
         if extension is None:
             extension = 0
@@ -1380,7 +1380,7 @@ class TargetPixelFile(object):
                             0)[0]
         except Exception as e:
             raise e
-        
+
         # Create a factory and set default keyword values based on the middle image
         factory = TargetPixelFileFactory(n_cadences=len_images,
                                                n_rows=size[0],
@@ -1397,7 +1397,7 @@ class TargetPixelFile(object):
 
         allkeys = hdu0_keywords.copy()
         allkeys.update(carry_keywords)
-        
+
         img_list = [images_raw_cnts, images_flux, images_flux_err, images_flux_bkg, images_flux_bkg_err, images_cosmic_rays]
 
         for idx, img in tqdm(enumerate(images_flux), total=len_images):
@@ -1440,7 +1440,7 @@ class TargetPixelFile(object):
         ext_info['TFORM4'] = '{}J'.format(size[0] * size[1])
         ext_info['TDIM4'] = '({},{})'.format(size[0], size[1])
         ext_info.update(wcs.to_header(relax=True))
-        
+
         # TPF contains multiple data columns that require WCS
         for m in [4, 5, 6, 7, 8, 9]:
             if m > 4:

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1374,7 +1374,7 @@ class TargetPixelFile(object):
         try:
             mid_hdu = _open_image(images_flux[int(len_images / 2) - 1], extension)
 
-            wcs_ref = WCS(mid_hdu, relax=True)
+            wcs_ref = WCS(mid_hdu)
             column, row = wcs_ref.all_world2pix(
                             np.asarray([[position.ra.deg], [position.dec.deg]]).T,
                             0)[0]

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -1359,7 +1359,7 @@ class TargetPixelFile(object):
                 cutout_data = cutout.data
                 cutout_wcs = cutout.wcs
             return cutout_data, cutout_wcs
-
+        
         # Set the default extension if unspecified
         if extension is None:
             extension = 0
@@ -1374,13 +1374,13 @@ class TargetPixelFile(object):
         try:
             mid_hdu = _open_image(images_flux[int(len_images / 2) - 1], extension)
 
-            wcs_ref = WCS(mid_hdu)
+            wcs_ref = WCS(mid_hdu, relax=True)
             column, row = wcs_ref.all_world2pix(
                             np.asarray([[position.ra.deg], [position.dec.deg]]).T,
                             0)[0]
         except Exception as e:
             raise e
-
+        
         # Create a factory and set default keyword values based on the middle image
         factory = TargetPixelFileFactory(n_cadences=len_images,
                                                n_rows=size[0],
@@ -1397,7 +1397,7 @@ class TargetPixelFile(object):
 
         allkeys = hdu0_keywords.copy()
         allkeys.update(carry_keywords)
-
+        
         img_list = [images_raw_cnts, images_flux, images_flux_err, images_flux_bkg, images_flux_bkg_err, images_cosmic_rays]
 
         for idx, img in tqdm(enumerate(images_flux), total=len_images):
@@ -1429,7 +1429,7 @@ class TargetPixelFile(object):
             # Cutout (if neccessary) and get data
             cutout_list = [_cutout_image(hdu, position, wcs_ref, size) for hdu in hdu_list]
             # Flatten output list
-            cutout_list = flat_list = [item for sublist in cutout_list for item in sublist]
+            cutout_list = [item for sublist in cutout_list for item in sublist]
             raw_cnts, _, flux, wcs, flux_err, _, flux_bkg, _, flux_bkg_err, _, cosmic_rays, _ = cutout_list
 
             factory.add_cadence(frameno=idx, raw_cnts=raw_cnts, flux=flux, flux_err=flux_err,
@@ -1439,8 +1439,8 @@ class TargetPixelFile(object):
         ext_info = {}
         ext_info['TFORM4'] = '{}J'.format(size[0] * size[1])
         ext_info['TDIM4'] = '({},{})'.format(size[0], size[1])
-        ext_info.update(wcs.to_header())
-
+        ext_info.update(wcs.to_header(relax=True))
+        
         # TPF contains multiple data columns that require WCS
         for m in [4, 5, 6, 7, 8, 9]:
             if m > 4:


### PR DESCRIPTION
This PR is simply to add `relax=True` to the WCS creation in `from_fits_images` to suppress the warnings about non-standard FITS keys in the TESS FFIs (shown below). It also cleans up a redundant variable.

`WARNING: Some non-standard WCS keywords were excluded: A_ORDER, A_0_2, A_0_3, A_0_4, A_1_1, A_1_2, A_1_3, A_2_0, A_2_1, A_2_2, A_3_0, A_3_1, A_4_0, B_ORDER, B_0_2, B_0_3, B_0_4, B_1_1, B_1_2, B_1_3, B_2_0, B_2_1, B_2_2, B_3_0, B_3_1, B_4_0, AP_ORDER, AP_0_1, AP_0_2, AP_0_3, AP_0_4, AP_1_0, AP_1_1, AP_1_2, AP_1_3, AP_2_0, AP_2_1, AP_2_2, AP_3_0, AP_3_1, AP_4_0, BP_ORDER, BP_0_1, BP_0_2, BP_0_3, BP_0_4, BP_1_0, BP_1_1, BP_1_2, BP_1_3, BP_2_0, BP_2_1, BP_2_2, BP_3_0, BP_3_1, BP_4_0 Use the ``relax`` kwarg to control this. [astropy.wcs.wcs]`