### PR TITLE
Cache repeated MAST search queries using `lru_cache`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ lightkurve.search
   such as 'KIC 5112705' or 'TIC 261136679', only return products known under
   those names, unless a search radius is specified. [#796]
 
+- Improved the speed of all search functions by caching repeat queries. [#885]
+
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -1,6 +1,7 @@
 """Defines tools to retrieve Kepler data from the archive at MAST."""
 from __future__ import division
 import os
+from functools import lru_cache
 import glob
 import logging
 import re
@@ -388,6 +389,7 @@ class SearchResult(object):
         return path
 
 
+@lru_cache
 def search_targetpixelfile(target, radius=None, cadence=None,
                            mission=('Kepler', 'K2', 'TESS'),
                            author=('Kepler', 'K2', 'SPOC'),
@@ -497,6 +499,7 @@ def search_lightcurvefile(*args, **kwargs):
     return search_lightcurve(*args, **kwargs)
 
 
+@lru_cache
 def search_lightcurve(target, radius=None, cadence=None,
                       mission=('Kepler', 'K2', 'TESS'),
                       author=('Kepler', 'K2', 'SPOC'),
@@ -602,6 +605,7 @@ def search_lightcurve(target, radius=None, cadence=None,
         return SearchResult(None)
 
 
+@lru_cache
 def search_tesscut(target, sector=None):
     """Searches MAST for TESS Full Frame Image cutouts containing a desired target or region.
 


### PR DESCRIPTION
Work is ongoing within `astroquery` to ensure MAST search queries can be cached in a persistent way (e.g. https://github.com/astropy/astroquery/pull/1634).  The changes needed are non-trivial and may take a bit more time to complete.

In meanwhile, this PR proposes to add a quick & easy improvement by adding the `@lru_cache` decorator to the search functions.  This is a Python 3 standard library feature which automatically caches the 128 most-recent calls to a function within the lifetime of the kernel (i.e. the cache resets whenever the Python session ends).

It allows repeated search queries to be sped up from seconds to microseconds! See example below...

**Before this PR:**

```python
In [1]: import lightkurve as lk

In [2]: %time result = lk.search_lightcurve("Proxima Cen")
CPU times: user 476 ms, sys: 69.8 ms, total: 546 ms
Wall time: 2.69 s

In [3]: %time result = lk.search_lightcurve("Proxima Cen")
CPU times: user 156 ms, sys: 4.94 ms, total: 161 ms
Wall time: 1.47 s
```

**After this PR:**

```python
In [1]: import lightkurve as lk

In [2]: %time result = lk.search_lightcurve("Proxima Cen")
CPU times: user 486 ms, sys: 69.9 ms, total: 556 ms
Wall time: 2.85 s

In [3]: %time result = lk.search_lightcurve("Proxima Cen")
CPU times: user 6 µs, sys: 1 µs, total: 7 µs
Wall time: 9.06 µs
```