### PR TITLE
Bugfix for #884: do not allow `stitch()` to change Quantity data type

### DIFF
--- a/lightkurve/collections.py
+++ b/lightkurve/collections.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy.table import vstack
 from astropy.utils.decorators import deprecated
+from astropy.units import Quantity
 
 from . import MPLSTYLE
 from .targetpixelfile import TargetPixelFile
@@ -146,7 +147,7 @@ class LightCurveCollection(Collection):
         # e.g. the `cadenceno` and `quality` columns.  This causes issues with
         # the __repr__ and the parsing of quality values.
         for col in stack.colnames:
-            if hasattr(stack[col], 'dtype') and stack[col].dtype != lcs[0][col].dtype:
+            if isinstance(stack[col], Quantity) and stack[col].dtype != lcs[0][col].dtype:
                 stack[col] = stack[col].astype(lcs[0][col].dtype)
 
         return stack

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from ..lightcurve import LightCurve
+from ..search import search_lightcurve
 from ..targetpixelfile import KeplerTargetPixelFile
 from ..collections import LightCurveCollection, TargetPixelFileCollection
 
@@ -106,3 +107,12 @@ def test_tpfcollection_plot():
     coll = TargetPixelFileCollection([tpf])
     coll.plot()
     plt.close('all')
+
+
+@pytest.mark.remote_data
+def test_stitch_repr():
+    """Regression test for #884."""
+    lc = search_lightcurve("Pi Men", mission='TESS', sector=1).download()
+    # The line below used to raise `ValueError: Unable to parse format string
+    # "{:10d}" for entry "70445.0" in column "cadenceno"`
+    LightCurveCollection((lc,lc)).stitch().__repr__()


### PR DESCRIPTION
The `LightCurveCollection.stitch()` is unexpectedly changing the data type of integer `Quantity` columns from `int` into `float`.  This is because the underlying `astropy.table.vstack` operation displays this behavior (see https://github.com/astropy/astropy/issues/10958)

For example:
<img width="639" alt="Screen Shot 2020-10-28 at 10 33 37" src="https://user-images.githubusercontent.com/817669/97474315-38023180-1909-11eb-8e9b-86e99bdb7645.png">

This PR implements a workaround for this behavior in an attempt to fix #884:

<img width="623" alt="Screen Shot 2020-10-28 at 10 34 36" src="https://user-images.githubusercontent.com/817669/97474326-3b95b880-1909-11eb-8779-9ec7d47f4ddd.png">

However, perhaps an alternative solution would be to always use `Column` instead of `Quantity` for integer columns. (/cc @orionlee)