### PR TITLE
bugfix: tpf.wcs when expected headers do not exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ lightkurve.targetpixelfile
 - Modified `TargetPixelFactory` to support creating TESS Target Pixel Files
   and to enable it to populate all data columns. [#768, #857]
 
+- Fixed a bug in ``TargetPixelFile.wcs`` which caused it to raise Error if
+the tpf does not contain expected WCS keywords in the header. [#892]
+
 lightkurve.search
 ^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -375,7 +375,7 @@ class TargetPixelFile(object):
                             'NAXIS2': 'NAXIS2'}
             mywcs = {}
             for oldkey, newkey in wcs_keywords.items():
-                if (self.hdu[1].header[oldkey] != Undefined):
+                if self.hdu[1].header.get(oldkey, None) is not None:
                    mywcs[newkey] = self.hdu[1].header[oldkey]
             return WCS(mywcs)
 


### PR DESCRIPTION
Closes #892

I can't quite find an actual TPF that would trigger the problem (tried a recent TESSCut, tpf from sector 28 and sector 1). 
- Good news: the bug probably doesn't affect any typical usage.
- Bad news: I can't quite create a test for it. I first stumbled upon it when using another package (that copied the codes from lightkurve), but didn't quite have the tpf file that caused the error anymore (the package didn't save the tpf).
