### PR TITLE
interact_bls enhancement: wheel zoom and normalize 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ lightkurve.lightcurve
 - Added a ``column`` parameter to ``LightCurve.remove_nans()`` to enable
   cadences to be removed which contain NaN values in a specific column. [#828]
 
+- ``interact_bls()``: added the support zoom by scrolling mouse wheel. [#854]
+
+- ``interact_bls()``: modified so that it normalizes the lightcurve to match the
+  generated transit model.  [#854]
+
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lightkurve/interact_bls.py
+++ b/lightkurve/interact_bls.py
@@ -268,7 +268,7 @@ def make_lightcurve_figure_elements(lc, model_lc, lc_source, model_lc_source, he
     """
     # Make figure
     fig = figure(title='Light Curve', plot_height=300, plot_width=900,
-                 tools="pan,box_zoom,reset",
+                 tools="pan,box_zoom,wheel_zoom,reset",
                  toolbar_location="below",
                  border_fill_color="#FFFFFF", active_drag="box_zoom")
     fig.title.offset = -10
@@ -329,7 +329,7 @@ def make_folded_figure_elements(f, f_model_lc, f_source, f_model_lc_source, help
 
     # Build Figure
     fig = figure(title='Folded Light Curve', plot_height=340, plot_width=450,
-                 tools="pan,box_zoom,reset",
+                 tools="pan,box_zoom,wheel_zoom,reset",
                  toolbar_location="below",
                  border_fill_color="#FFFFFF", active_drag="box_zoom")
     fig.title.offset = -10
@@ -383,7 +383,7 @@ def make_bls_figure_elements(result, bls_source, help_source):
 
     # Build Figure
     fig = figure(title='BLS Periodogram', plot_height=340, plot_width=450,
-                 tools="pan,box_zoom,tap,reset",
+                 tools="pan,box_zoom,wheel_zoom,tap,reset",
                  toolbar_location="below",
                  border_fill_color="#FFFFFF", x_axis_type='log', active_drag="box_zoom")
     fig.title.offset = -10

--- a/lightkurve/interact_bls.py
+++ b/lightkurve/interact_bls.py
@@ -433,6 +433,11 @@ def make_bls_figure_elements(result, bls_source, help_source):
     return fig, vertical_line
 
 
+def _preprocess_lc_for_bls(lc):
+    clean = lc.remove_nans()
+    return clean
+
+
 def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
                          maximum_period=None, resolution=2000):
     """Show the BLS interact widget.
@@ -752,6 +757,10 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
                             [Spacer(width=70), duration_slider, Spacer(width=50), npoints_slider],
                             [Spacer(width=70), double_button, Spacer(width=70), half_button, Spacer(width=300), text_output]
                                 ]))
+
+
+    # TODO: pre-process LC
+    lc = _preprocess_lc_for_bls(lc)
 
     output_notebook(verbose=False, hide_banner=True)
     return show(_create_interact_ui, notebook_url=notebook_url)

--- a/lightkurve/interact_bls.py
+++ b/lightkurve/interact_bls.py
@@ -435,6 +435,15 @@ def make_bls_figure_elements(result, bls_source, help_source):
 
 def _preprocess_lc_for_bls(lc):
     clean = lc.remove_nans()
+    # convert to  normalized unscaled flux if needed,
+    # so that its scale is the same as the BLS model lc (to be generated),
+    # making it easier to be visualized in the same plot.
+    if not clean.meta.get('NORMALIZED', False):
+        clean = clean.normalize()
+    elif clean.flux.unit != u.dimensionless_unscaled:
+        # case normalized, but in other units (percents, etc.)
+        clean.flux = clean.flux.to(u.dimensionless_unscaled)
+        clean.flux_err = clean.flux_err.to(u.dimensionless_unscaled)
     return clean
 
 

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -1649,8 +1649,7 @@ class LightCurve(QTimeSeries):
         .. [1] https://docs.astropy.org/en/stable/timeseries/bls.html
         """
         from .interact_bls import show_interact_widget
-        clean = self.remove_nans()
-        return show_interact_widget(clean, notebook_url=notebook_url, minimum_period=minimum_period,
+        return show_interact_widget(self, notebook_url=notebook_url, minimum_period=minimum_period,
                                     maximum_period=maximum_period, resolution=resolution)
 
     def to_table(self) -> Table:

--- a/lightkurve/tests/test_interact_bls.py
+++ b/lightkurve/tests/test_interact_bls.py
@@ -2,6 +2,7 @@
 import pytest
 
 from astropy.timeseries import BoxLeastSquares
+import numpy as np
 
 from ..lightcurve import KeplerLightCurve, TessLightCurve
 from .test_lightcurve import KEPLER10, TESS_SIM
@@ -66,6 +67,16 @@ def test_helper_functions():
     make_folded_figure_elements(lc.fold(1), lc.fold(1), f_source, f_source, f_help)
     make_bls_figure_elements(result, bls_source, bls_help)
 
+
+@pytest.mark.remote_data
+def test_preprocess_lc():
+    '''Test to ensure the lightcurve is pre-processed before applying BLS for correctness and consistent output'''
+    from ..interact_bls import _preprocess_lc_for_bls
+    lc = KeplerLightCurve.read(KEPLER10)
+    assert np.isnan(lc.flux).any()  # ensure the test data has nan in flux
+
+    clean = _preprocess_lc_for_bls(lc)
+    assert not np.isnan(clean.flux).any()   # ensure processed lc has no nan
 
 @pytest.mark.remote_data
 @pytest.mark.skipif(bad_optional_imports,

--- a/lightkurve/tests/test_interact_bls.py
+++ b/lightkurve/tests/test_interact_bls.py
@@ -2,6 +2,7 @@
 import pytest
 
 from astropy.timeseries import BoxLeastSquares
+import astropy.units as u
 import numpy as np
 
 from ..lightcurve import KeplerLightCurve, TessLightCurve
@@ -77,6 +78,16 @@ def test_preprocess_lc():
 
     clean = _preprocess_lc_for_bls(lc)
     assert not np.isnan(clean.flux).any()   # ensure processed lc has no nan
+    assert clean.meta.get('NORMALIZED', False)
+    assert clean.flux.unit == u.dimensionless_unscaled
+
+    # case the lc is normalized, but in other units
+    lc = lc.normalize(unit='percent')
+    clean = _preprocess_lc_for_bls(lc)
+    assert not np.isnan(clean.flux).any()   # ensure processed lc has no nan
+    assert clean.meta.get('NORMALIZED', False)
+    assert clean.flux.unit == u.dimensionless_unscaled
+
 
 @pytest.mark.remote_data
 @pytest.mark.skipif(bad_optional_imports,


### PR DESCRIPTION
Closes #854 

Two minor enhancement:
1. Normalize the lightcurve if needed so that its scale matches the generated transit model LC.
2. Added zoom by scrolling mouse wheel for all 3 plots, e.g.
![image](https://user-images.githubusercontent.com/250644/98743792-78c86480-2365-11eb-9b8d-8fa0f90a5b0b.png)

