### PR TITLE
Add a dedicated `correctors.metrics` module for under- and overfitting metrics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ lightkurve.lightcurve
   generated transit model.  [#854]
 
 - Added the ``LightCurve.search_neighbors()`` convenience method to search for
-  light curves around an existing one.
+  light curves around an existing one. [#907]
 
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,10 +117,10 @@ lightkurve.correctors
   curve's ``centroid_col`` or ``centroid_row`` columns contained NaNs. [#827]
 
 - Improved the ``Corrector`` abstract base class to better document the desired
-  structure of its sub-classes.
+  structure of its sub-classes. [#907]
 
 - Added a ``metrics`` module with two functions to measure the degree of
-  over- and under-fitting of a corrected light curve.
+  over- and under-fitting of a corrected light curve. [#907]
 
 lightkurve.seismology
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ lightkurve.lightcurve
 - ``interact_bls()``: modified so that it normalizes the lightcurve to match the
   generated transit model.  [#854]
 
+- Added the ``LightCurve.search_neighbors()`` convenience method to search for
+  light curves around an existing one.
+
 lightkurve.targetpixelfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -96,6 +99,8 @@ lightkurve.search
 - Improved the performance of `download()` operations by checking if a file
   exists in local cache prior to contacting MAST. [#915]
 
+- Added automated caching of the search operations. [#907]
+
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -110,6 +115,12 @@ lightkurve.correctors
 
 - Fixed a bug in ``SFFCorrector`` which caused correction to fail if a light
   curve's ``centroid_col`` or ``centroid_row`` columns contained NaNs. [#827]
+
+- Improved the ``Corrector`` abstract base class to better document the desired
+  structure of its sub-classes.
+
+- Added a ``metrics`` module with two functions to measure the degree of
+  over- and under-fitting of a corrected light curve.
 
 lightkurve.seismology
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -117,7 +117,7 @@ class Corrector(ABC):
         """
         pass
 
-    def overfit_metric(self, **kwargs) -> float:
+    def compute_overfit_metric(self, **kwargs) -> float:
         """Uses a LombScarglePeriodogram to assess the change in broad-band
         power in a corrected light curve to measure the degree of over-fitting.
 
@@ -139,7 +139,7 @@ class Corrector(ABC):
             **kwargs
         )
 
-    def underfit_metric(self, **kwargs) -> float:
+    def compute_underfit_metric(self, **kwargs) -> float:
         """Measures the degree of under-fitting the noise.
 
         See the docstring of `lightkurve.correctors.metrics.underfit_metric_neighbors`

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -118,15 +118,10 @@ class Corrector(ABC):
         pass
 
     def compute_overfit_metric(self, **kwargs) -> float:
-        """Uses a LombScarglePeriodogram to assess the change in broad-band
-        power in a corrected light curve to measure the degree of over-fitting.
+        """ Measures the degree of over-fitting in the correction.
 
-        The to_periodogram Lomb-Scargle method is used and the sampling band is
-        from one frequency separation to the Nyquist frequency
-
-        This over-fitting goodness metric is calibrated such that a metric
-        value of 0.5 means the introduced noise due to over-fitting is at the
-        same power level as the uncertainties in the light curve.
+        See the docstring of `lightkurve.correctors.metrics.overfit_metric_lombscargle`
+        for details.
 
         Returns
         -------
@@ -134,13 +129,14 @@ class Corrector(ABC):
             A float in the range [0,1] where 0 => Bad, 1 => Good
         """
         return overfit_metric_lombscargle(
+            # Ignore masked cadences in the computation
             self.original_lc[self.cadence_mask],
             self.corrected_lc[self.cadence_mask],
             **kwargs
         )
 
     def compute_underfit_metric(self, **kwargs) -> float:
-        """Measures the degree of under-fitting the noise.
+        """Measures the degree of under-fitting the correction.
 
         See the docstring of `lightkurve.correctors.metrics.underfit_metric_neighbors`
         for details.

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -139,7 +139,7 @@ class Corrector(ABC):
             **kwargs
         )
 
-    def under_metric(self, **kwargs) -> float:
+    def underfit_metric(self, **kwargs) -> float:
         """Measures the degree of under-fitting the noise.
 
         See the docstring of `lightkurve.correctors.metrics.underfit_metric_neighbors`

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -1,17 +1,43 @@
-"""Implements the abstract `Corrector` base class to document the generic
-methods the subclasses should aim to provide.
-
-`Corrector` classes must adopt the following design:
-- `__init__()` takes the required data (e.g. LightCurve, TargetPixelFile);
-- `correct()` takes optional parameters and returns a LightCurve;
-- `diagnose()` creates plots to elucidate the user's most recent call to `correct()`.
+"""Implements the abstract `Corrector` base class.
 """
-class Corrector(object):
-    """Abstract base class."""
-    def correct(self):
-        """Returns a corrected LightCurve."""
-        raise NotImplementedError("This is an abstract base class.")
+from abc import ABC, abstractmethod
 
-    def diagnose(self):
+import matplotlib
+from .. import LightCurve
+
+
+class Corrector(ABC):
+    """Abstract base class documenting the structure of classes intended
+    to remove systematic noise from light curves.
+
+    Attributes
+    ----------
+    lc : LightCurve
+        Original, uncorrected light curve, usually assigned by the constructor.
+    corrected_lc : LightCurve
+        Corrected light curve, assigned by each call to the `correct()` method.
+
+    Methods
+    -------
+    __init__()
+        Accepts all the data required to execute the correction.
+    correct() -> LightCurve
+        Executes the correction, accepting any optional parameters that
+        can be used to modify the way the correction is applied.
+    diagnose() -> matplotlib.axes.Axes
+        Creates plots to elucidate the user's most recent call to `correct()`.
+    """
+
+    lc: LightCurve = None
+    corrected_lc: LightCurve = None
+
+    @abstractmethod
+    def correct(self) -> LightCurve:
+        """Returns a corrected LightCurve, and also stores it as the
+        `Corrector.corrected_lc` attribute."""
+        pass
+
+    @abstractmethod
+    def diagnose(self) -> matplotlib.axes.Axes:
         """Returns plots which elucidate the most recent call to `correct()`."""
-        raise NotImplementedError("This is an abstract base class.")
+        pass

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -68,14 +68,13 @@ class Corrector(ABC):
 
     @property
     def cadence_mask(self) -> np.array:
-        if hasattr(self, "_cadence_mask"):
-            return self._cadence_mask
-        else:
-            return np.ones(len(self.original_lc), dtype=bool)
+        if not hasattr(self, "_cadence_mask"):
+            self._cadence_mask = np.ones(len(self.original_lc), dtype=bool)
+        return self._cadence_mask
 
     @cadence_mask.setter
     def cadence_mask(self, cadence_mask):
-        self.cadence_mask = cadence_mask
+        self._cadence_mask = cadence_mask
 
     def __init__(self, original_lc: LightCurve) -> None:
         """Constructor method.
@@ -139,3 +138,16 @@ class Corrector(ABC):
             self.corrected_lc[self.cadence_mask],
             **kwargs
         )
+
+    def under_metric(self, **kwargs) -> float:
+        """Measures the degree of under-fitting the noise.
+
+        See the docstring of `lightkurve.correctors.metrics.underfit_metric_neighbors`
+        for details.
+
+        Returns
+        -------
+        underfit_metric : float
+            A float in the range [0,1] where 0 => Bad, 1 => Good
+        """
+        return underfit_metric_neighbors(self.corrected_lc[self.cadence_mask], **kwargs)

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -3,12 +3,10 @@
 from abc import ABC, abstractmethod
 
 import matplotlib
-from lightkurve.utils import is_notebook
-
 import numpy as np
 
-from .metrics import overfit_metric_lombscargle
 from .. import LightCurve
+from .metrics import overfit_metric_lombscargle, underfit_metric_neighbors
 
 
 class Corrector(ABC):

--- a/lightkurve/correctors/corrector.py
+++ b/lightkurve/correctors/corrector.py
@@ -1,6 +1,8 @@
 """Implements the abstract `Corrector` base class.
 """
 from abc import ABC, abstractmethod
+
+import matplotlib
 from lightkurve.utils import is_notebook
 
 import numpy as np
@@ -109,7 +111,7 @@ class Corrector(ABC):
         # return corrected_lc
 
     @abstractmethod
-    def diagnose(self) -> "matplotlib.axes.Axes":
+    def diagnose(self) -> matplotlib.axes.Axes:
         """Returns plots which elucidate the most recent call to `correct()`.
 
         This method shall plot useful diagnostic information which have been

--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -1,0 +1,327 @@
+"""Metrics to assess under- and over-fitting of systematic noise."""
+import logging
+
+import numpy as np
+from scipy.interpolate import PchipInterpolator
+
+from .. import LightCurve
+
+log = logging.getLogger(__name__)
+
+
+def overfit_metric_lombscargle(
+    original_lc: LightCurve, corrected_lc: LightCurve, n_samples: int = 10
+) -> float:
+    """Uses a LombScarglePeriodogram to assess the change in broad-band
+    power in a corrected light curve to measure the degree of over-fitting.
+
+    The to_periodogram Lomb-Scargle method is used and the sampling band is
+    from one frequency separation to the Nyquist frequency
+
+    This over-fitting goodness metric is calibrated such that a metric
+    value of 0.5 means the introduced noise due to over-fitting is at the
+    same power level as the uncertainties in the light curve.
+
+    Parameters
+    ----------
+    original_lc : LightCurve
+        Uncorrected light curve.
+    corrected_lc : LightCurve
+        Light curve from which systematics have been removed.
+    n_samples : int
+        The number of times to compute and average the metric
+        This can stabilize the value, default = 10
+
+    Returns
+    -------
+    overfit_metric : float
+        A float in the range [0,1] where 0 => Bad, 1 => Good
+    """
+    # The fit can sometimes result in NaNs
+    # Also ignore masked cadences
+    # Also median normalize original and correctod LCs
+    orig_lc = original_lc.copy()
+    orig_lc = orig_lc.remove_nans().normalize()
+    orig_lc -= 1.0
+    corrected_lc = corrected_lc.copy()
+    corrected_lc = corrected_lc.remove_nans().normalize()
+    corrected_lc -= 1.0
+    if len(corrected_lc) == 0:
+        return 1.0
+
+    # Perform the measurement multiple times and average to stabilize the metric
+    metric_per_iter = []
+    for idx in np.arange(n_samples):
+        pgOrig = orig_lc.to_periodogram()
+        # Use the same periods in the corrected flux as just used in the
+        # original flux
+        pgCorrected = corrected_lc.to_periodogram(frequency=pgOrig.frequency)
+
+        # Get an estimate of the PSD at the uncertainties limit
+        # The raw and corrected uncertainties should be essentially identical so
+        # use the corrected
+        # TODO: the periodogram of WGN should be analytical to compute!
+        nNonGappedCadences = len(orig_lc)
+        meanCorrectedUncertainties = np.nanmean(corrected_lc.flux_err)
+        WGNCorrectedUncert = (
+            np.random.randn(nNonGappedCadences, 1) * meanCorrectedUncertainties
+        ).T[0]
+        model_err = np.zeros(nNonGappedCadences)
+        noise_lc = LightCurve(
+            time=orig_lc.time, flux=WGNCorrectedUncert, flux_err=model_err
+        )
+        pgCorrectedUncert = noise_lc.to_periodogram()
+        meanCorrectedUncertPower = np.nanmean(np.array(pgCorrectedUncert.power))
+
+        # Compute the change in power
+        pgChange = np.array(pgCorrected.power) - np.array(pgOrig.power)
+
+        # Ignore nans
+        pgChange = pgChange[~np.isnan(pgChange)]
+
+        # If no increase in power in ANY bands then return a perfect loss
+        # function
+        if len(np.nonzero(pgChange > 0.0)[0]) == 0:
+            metric_per_iter.append(0.0)
+        else:
+            # We are only concerned with bands where the power increased so
+            # when(pgCorrected - pgOrig) > 0
+            # Normalize by the noise in the uncertainty
+            # We want the goodness to begin to degrade when the introduced
+            # noise is greater than the uncertainties.
+            # So, when Sigmoid > 0.5 (given twiceSigmoidInv defn.)
+            result = np.sum(pgChange[pgChange > 0.0]) / (
+                (len(np.nonzero(pgChange > 0.0)[0])) * meanCorrectedUncertPower
+            )
+            metric_per_iter.append(result)
+
+    metric = np.mean(metric_per_iter)
+
+    # We want the goodness to span (0,1]
+    # Use twice a reversed sigmoid to get a [0,1] range mapped from a [0,inf) range
+    def sigmoidInv(x):
+        return 2.0 / (1 + np.exp(x))
+
+    # Make sure maximum score is 1.0
+    metric = sigmoidInv(np.max([metric, 0.0]))
+
+    return metric
+
+
+def underfit_metric_neighbors(
+    corrected_lc: LightCurve,
+    radius: float = 6000,
+    min_targets: int = 30,
+    max_targets: int = 50,
+    interpolate: bool = False,
+):
+    """This goodness metric measures the degree of under-fitting of the
+    CBVs to the light curve. It does so by measuring the mean residual target to
+    target Pearson correlation between the target under study and a selection of
+    neighboring SPOC SAP target light curves.
+
+    This function will begin with the given search_radius in arcseconds and
+    finds all neighboring targets. If not enough were found (< min_targets)
+    the search_radius is increased until a minimum number are found.
+
+    For TESS, the default search_radius is 5000 arcseconds.
+    For Kepler/K2, the default search_radius is 1000 arcseconds
+
+    The downloaded neighboring targets will normally be "aligned" to the
+    corrected_lc meaning the cadence numbers are used to align the targets
+    to the corrected_lc. However, if the CBVCorrector object was
+    instantiated with interpolated_cbvs=True then the targets will be
+    interpolated to the corrected_lc cadence times.
+
+    The returned under-fitting goodness metric is callibrated such that a
+    value of 0.95 means the residual correlations in the target is
+    equivalent to chance correlations of White Gaussian Noise.
+
+    Parameters
+    ----------
+    corrected_lc : LightCurve
+        Light curve from which systematics have been removed.
+    radius : float
+        Search radius to find neighboring targets in arcseconds
+    min_targets : int
+        Minimum number of targets to use in correlation metric
+        Using too few can cause unreliable results. Default = 30
+    max_targets : int
+        Maximum number of targets to use in correlation metric
+        Using too many can slow down the metric due to large data
+        download. Default = 50
+
+    Returns
+    -------
+    under_fitting_metric : float
+        A float in the range [0,1] where 0 => Bad, 1 => Good
+    """
+    # Download neighbor light curves
+    lcfCol = download_neighbors(
+        lc=corrected_lc,
+        radius=radius,
+        min_targets=min_targets,
+        max_targets=max_targets,
+        flux_column="sap_flux",
+    )
+
+    # Pre-process the neighbor light curves
+    lc_neighborhood = []
+    lc_neighborhood_flux = []
+    # Extract SAP light curves
+    # We want zero-centered median normalized light curves
+    for lc in lcfCol:
+        lcSAP = lc.remove_nans().normalize()
+        lcSAP.flux -= 1.0
+        lc_neighborhood.append(lcSAP)
+        # Align or interpolate the neighboring target with the target under study
+        if interpolate:
+            # Interpolate to corrected_lc cadence times
+            fInterp = PchipInterpolator(
+                lc_neighborhood[-1].time.value,
+                lc_neighborhood[-1].flux.value,
+                extrapolate=False,
+            )
+            lc_neighborhood_flux.append(fInterp(corrected_lc.time.value))
+        else:
+            # The CBVs were aligned so also align the neighboring
+            # lightcurves
+            lc_trim_mask = np.in1d(
+                lc_neighborhood[-1].cadenceno, corrected_lc.cadenceno
+            )
+            lc_neighborhood_flux.append(lc_neighborhood[-1][lc_trim_mask].flux.value)
+
+    # Store the unmolested lightcurve neighborhood but also save the
+    # aligned or interpolated neighborhood flux
+    from .. import LightCurveCollection
+
+    lc_neighborhood = LightCurveCollection(lc_neighborhood)
+    lc_neighborhood_flux = lc_neighborhood_flux
+
+    # If there happens to be any cadences in the corrected_lc
+    # that are not in the neighboring targets then those need to
+    # be NaNed.
+    # If we interpolated the CBVs then this should not occur
+    corrected_lc = corrected_lc.copy().remove_nans()
+    if not interpolate:
+        corrected_lc_trim_mask = np.logical_not(
+            np.in1d(corrected_lc.cadenceno, lc_neighborhood[0].cadenceno)
+        )
+        corrected_lc.flux.value[corrected_lc_trim_mask] = np.nan
+
+    # Create fluxMatrix. The last entry is the target under study
+    fluxMatrix = np.zeros((len(lc_neighborhood_flux[0]), len(lc_neighborhood_flux) + 1))
+    for idx in np.arange(len(fluxMatrix[0, :]) - 1):
+        fluxMatrix[:, idx] = lc_neighborhood_flux[idx]
+    # Add in target under study, and median normalize it
+    fluxMatrix[:, -1] = corrected_lc.normalize().flux
+    fluxMatrix[:, -1] -= 1.0
+
+    # Ignore NaNs
+    mask = ~np.isnan(corrected_lc.flux)
+    fluxMatrix = fluxMatrix[mask, :]
+
+    # Determine the target-target correlation between target and
+    # neighborhood
+    correlationMatrix = _compute_correlation(fluxMatrix)
+
+    # The selection basis for targets used for the PDC-MAP SVD  uses median
+    # absolute correlation per star.  However, here we wish to overemphasize
+    # any residual correlation between a handfull of targets and not the
+    # overall correlation (which should almost always be low).
+
+    # We want a residual correlation larger than random correlations of WGN
+    # to mean a meaningful correlation. The median Pearson correlation of
+    # WGN of nCadences is approximated by the equation:
+    # 0.0010288 + 0.80304 nCadences^ -0.50128
+    nCadences = len(fluxMatrix[:, 0])
+    beta = [0.0007, 0.8083, -0.5023]
+    WGNCorrelation = beta[0] + beta[1] * (nCadences ** (beta[2]))
+
+    # badLimit is the goodness value for WGN correlations
+    # I.e. anything above this goodness value is equivalent to random correlations
+    # I.e. 0.95 = sigmoidInv(WGNCorr * correlationScale)
+    badLimit = 0.95
+    correlationScale = 1 / (WGNCorrelation) * np.log((2.0 / badLimit) - 1.0)
+
+    # Over-emphasize any individual correlation groups. Note the power of
+    # three after taking the absolute value
+    # of the correlation. Also, the mean is used so that outliers are *not* ignored.
+    # Zero diagonal elements
+    correlationMatrix = np.tril(correlationMatrix, k=-1) + np.triu(
+        correlationMatrix, k=+1
+    )
+
+    # Add up the correlation over all targets ignoring NaNs (no corrected fit)
+    correlation = correlationScale * np.nanmean(np.abs(correlationMatrix) ** 3, axis=0)
+
+    # We only want the last entry, which is for the target under study
+    correlation = correlation[-1]
+
+    # We want the goodness to span (0,1]
+    # Use twice a reversed sigmoid to get a [0,1] range mapped from a [0,inf) range
+    def sigmoidInv(x):
+        return 2.0 / (1 + np.exp(x))
+
+    metric = sigmoidInv(correlation)
+
+    return metric
+
+
+def download_neighbors(
+    lc: LightCurve,
+    radius: float = 6000.0,
+    min_targets: int = 30,
+    max_targets: int = 50,
+    flux_column="sap_flux",
+) -> "LightCurveCollection":
+    """Returns a collection of neighbor light curves.
+
+    Parameters
+    ----------
+    lc : LightCurve
+        Light curve around which to look for neighbors.
+    radius : float
+        Conesearch radius in arcseconds.
+    min_targets : int
+        Minimum number of targets to return.
+        A `ValueError` will be raised if this number cannot be obtained.
+    max_targets : int
+        Maximum number of targets to use in correlation metric
+        Using too many can slow down the metric due to large data
+        download.
+    """
+    search = lc.search_neighbors(limit=max_targets, radius=radius)
+    if len(search) < min_targets:
+        raise ValueError(
+            f"Unable to find at least {min_targets} neighbors within {radius} arcseconds radius."
+        )
+    log.info(
+        f"Downloading {len(search)} neighbor light curves. This might take a while."
+    )
+    return search.download_all(flux_column=flux_column)
+
+
+def _compute_correlation(fluxMatrix):
+    """Finds the empirical target to target flux time series Pearson correlation.
+
+    Parameters
+    ----------
+    fluxMatrix : float 2-d array[ntargets,ncadences]
+        The matrix of target flux. There should be no gaps or Nans
+
+    Returns
+    -------
+    correlation_matrix : [float 2-d array] (nTargets x nTargets)
+        The target-target correlation
+    """
+
+    nCadences = len(fluxMatrix[:, 0])
+
+    # Scale each flux value by the RMS flux for the given target.
+    rmsFlux = np.sqrt(np.sum(fluxMatrix ** 2.0, axis=0) / nCadences)
+    unitNormFlux = fluxMatrix / np.tile(rmsFlux, (nCadences, 1))
+
+    correlation_matrix = unitNormFlux.T.dot(unitNormFlux) / nCadences
+
+    return correlation_matrix

--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -46,7 +46,6 @@ def overfit_metric_lombscargle(
         A float in the range [0,1] where 0 => Bad, 1 => Good
     """
     # The fit can sometimes result in NaNs
-    # Also ignore masked cadences
     # Also median normalize original and correctod LCs
     orig_lc = original_lc.copy()
     orig_lc = orig_lc.remove_nans().normalize()
@@ -168,7 +167,7 @@ def underfit_metric_neighbors(
     under_fitting_metric : float
         A float in the range [0,1] where 0 => Bad, 1 => Good
     """
-    # Download neighbor light curves
+    # Download and pre-process neighboring light curves
     lc_neighborhood, lc_neighborhood_flux = _download_and_preprocess_neighbors(
         corrected_lc=corrected_lc,
         radius=radius,
@@ -270,7 +269,7 @@ def _download_and_preprocess_neighbors(
     interpolate: bool = False,
     flux_column: str = "sap_flux",
 ):
-    """Returns a collection of neighbor light curves.
+    """Returns a collection of neighboring light curves.
 
     Parameters
     ----------
@@ -304,11 +303,11 @@ def _download_and_preprocess_neighbors(
             f"Unable to find at least {min_targets} neighbors within {radius} arcseconds radius."
         )
     log.info(
-        f"Downloading {len(search)} neighbor light curves. This might take a while."
+        f"Downloading {len(search)} neighboring light curves. This might take a while."
     )
     lcfCol = search.download_all(flux_column=flux_column)
 
-    # Pre-process the neighbor light curves
+    # Pre-process the neighboring light curves
     lc_neighborhood = []
     lc_neighborhood_flux = []
     # Extract SAP light curves

--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -258,7 +258,7 @@ def _unique_key_for_processing_neighbors(
 ):
     """Returns a unique key that will determine whether a cached version of a
     call to `_download_and_preprocess_neighbors` can be re-used."""
-    return f"{corrected_lc.ra}{corrected_lc.dec}{radius}{min_targets}{max_targets}{flux_column}{interpolate}"
+    return f"{corrected_lc.ra}{corrected_lc.dec}{corrected_lc.cadenceno}{radius}{min_targets}{max_targets}{flux_column}{interpolate}"
 
 
 @cached(custom_key_maker=_unique_key_for_processing_neighbors)

--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -1,10 +1,16 @@
-"""Metrics to assess under- and over-fitting of systematic noise."""
+"""Metrics to assess under- and over-fitting of systematic noise.
+
+This module provides two metrics, `overfit_metric_lombscargle` and `underfit_metric_neighbors`,
+which enable users to assess whether the noise in a systematics-corrected light curve has been
+under- or over-fitted.  These features were contributed by Jeff Smith (cf. https://github.com/KeplerGO/lightkurve/pull/855)
+and are in turn inspired by similar metrics in use by the PDC module of the official Kepler/TESS pipeline.
+"""
 import logging
 
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
-from .. import LightCurve
+from .. import LightCurve, LightCurveCollection
 
 log = logging.getLogger(__name__)
 
@@ -157,7 +163,7 @@ def underfit_metric_neighbors(
         A float in the range [0,1] where 0 => Bad, 1 => Good
     """
     # Download neighbor light curves
-    lcfCol = download_neighbors(
+    lcfCol = _download_neighbors(
         lc=corrected_lc,
         radius=radius,
         min_targets=min_targets,
@@ -268,13 +274,13 @@ def underfit_metric_neighbors(
     return metric
 
 
-def download_neighbors(
+def _download_neighbors(
     lc: LightCurve,
     radius: float = 6000.0,
     min_targets: int = 30,
     max_targets: int = 50,
     flux_column="sap_flux",
-) -> "LightCurveCollection":
+) -> LightCurveCollection:
     """Returns a collection of neighbor light curves.
 
     Parameters

--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
-from .. import LightCurve, LightCurveCollection
+from .. import LightCurve
 
 log = logging.getLogger(__name__)
 
@@ -280,7 +280,7 @@ def _download_neighbors(
     min_targets: int = 30,
     max_targets: int = 50,
     flux_column="sap_flux",
-) -> LightCurveCollection:
+):
     """Returns a collection of neighbor light curves.
 
     Parameters

--- a/lightkurve/correctors/tests/test_metrics.py
+++ b/lightkurve/correctors/tests/test_metrics.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
+from numpy.testing import (assert_allclose)
 
 from ... import LightCurve, search_lightcurve
-from ..metrics import overfit_metric_lombscargle, underfit_metric_neighbors
+from ..metrics import overfit_metric_lombscargle, underfit_metric_neighbors, _compute_correlation
 
 
 def test_overfit_metric_lombscargle():
@@ -47,3 +48,25 @@ def test_underfit_metric_neighbors():
     notnan = ~np.isnan(lc_sap.flux)
     lc_sap.flux.value[notnan] = np.ones(notnan.sum())
     assert underfit_metric_neighbors(lc_sap, min_targets=3, max_targets=3) == 1.0
+
+
+
+def test_compute_correlation():
+    """ Simple test to verify the correction function works"""
+    
+    # Fully correlated matrix
+    fluxMatrix = np.array([[1,1,1,1], [1,1,1,1], [1,1,1,1], [1,1,1,1]])
+    correlation_matrix = _compute_correlation(fluxMatrix)
+    assert np.all(correlation_matrix == 1.0)
+
+    # Partially correlated
+    fluxMatrix = np.array([[ 1.0, -1.0,  1.0, -1.0], 
+                           [-1.0,  1.0,  1.0, -1.0], 
+                           [ 1.0, -1.0,  1.0, -1.0], 
+                           [-1.0,  1.0, -1.0,  1.0]])
+    correlation_matrix = _compute_correlation(fluxMatrix)
+    correlation_truth = np.array([[ 1.0, -1.0,  0.5, -0.5], 
+                           [-1.0,  1.0, -0.5,  0.5], 
+                           [ 0.5, -0.5,  1.0, -1.0], 
+                           [-0.5,  0.5, -1.0,  1.0]])
+    assert_allclose(correlation_matrix, correlation_truth)

--- a/lightkurve/correctors/tests/test_metrics.py
+++ b/lightkurve/correctors/tests/test_metrics.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from ... import LightCurve, search_lightcurve
+from ..metrics import overfit_metric_lombscargle, underfit_metric_neighbors
+
+
+def test_overfit_metric_lombscargle():
+    """Sanity checks for `overfit_metric_lombscargle`"""
+    # Create artificial flat and sinusoid light curves
+    time = np.arange(1, 100, 0.1)
+    lc_flat = LightCurve(time=time, flux=1, flux_err=0.0)
+    lc_sine = LightCurve(time=time, flux=np.sin(time) + 1, flux_err=0.0)
+
+    # If the light curve didn't change, it should be "perfect", i.e. metric == 1
+    assert overfit_metric_lombscargle(lc_flat, lc_flat) == 1.0
+    assert overfit_metric_lombscargle(lc_sine, lc_sine) == 1.0
+
+    # If the light curve went from a sine to a flat line,
+    # no noise was introduced, hence metric == 1 (good)
+    assert overfit_metric_lombscargle(lc_sine, lc_flat) == 1.0
+
+    # If the light curve went from flat to sine, metric == 0 (bad)
+    assert overfit_metric_lombscargle(lc_flat, lc_sine) == 0.0
+    # However, if the light curves were noisy to begin with, it shouldn't be considered that bad
+    lc_flat.flux_err += 0.5
+    lc_sine.flux_err += 0.5
+    assert overfit_metric_lombscargle(lc_flat, lc_sine) > 0.5
+
+
+@pytest.mark.remote_data
+def test_underfit_metric_neighbors():
+    """Sanity checks for `underfit_metric_neighbors`."""
+    # PDCSAP_FLUX has a very good score (>0.99) because it has been corrected
+    lc_pdcsap = search_lightcurve("Proxima Cen", sector=11).download(
+        flux_column="pdcsap_flux"
+    )
+    assert underfit_metric_neighbors(lc_pdcsap, min_targets=3, max_targets=3) > 0.99
+
+    # SAP_FLUX has a worse score (<0.9) because it hasn't been corrected
+    lc_sap = lc_pdcsap.copy()
+    lc_sap.flux = lc_pdcsap.sap_flux
+    lc_sap.flux_err = lc_pdcsap.sap_flux_err
+    assert underfit_metric_neighbors(lc_sap, min_targets=3, max_targets=3) < 0.9
+
+    # A flat light curve should have a perfect score (1)
+    notnan = ~np.isnan(lc_sap.flux)
+    lc_sap.flux.value[notnan] = np.ones(notnan.sum())
+    assert underfit_metric_neighbors(lc_sap, min_targets=3, max_targets=3) == 1.0

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -3,7 +3,7 @@ import os
 import datetime
 import logging
 import warnings
-
+from functools import lru_cache
 import collections
 
 import numpy as np
@@ -25,7 +25,7 @@ from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import PACKAGEDIR, MPLSTYLE
-from .utils import (running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
+from .utils import (is_notebook, running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
     validate_method, _query_solar_system_objects
 )
 from .utils import LightkurveWarning, LightkurveDeprecationWarning
@@ -2166,6 +2166,67 @@ class LightCurve(QTimeSeries):
             in_transit |= np.abs((self.time.value - tt + hp) % per - hp) < 0.5*dur
 
         return in_transit
+
+
+    def search_neighbors(self, limit: int = 10, radius: float = 3600.,
+                         **search_criteria) -> "SearchResult":
+        """Search the data archive at MAST for the most nearby light curves.
+
+        By default, the 10 nearest neighbors located within 3600 arcseconds
+        are returned. You can override these defaults by changing the `limit`
+        and `radius` parameters.
+
+        If the LightCurve object is a Kepler, K2, or TESS light curve,
+        the default behavior of this method is to only return light curves
+        obtained during the exact same quarter, campaign, or sector.
+        This is useful to enable coeval light curves to be inspected for
+        spurious noise signals in common between multiple neighboring targets.
+        You can override this default behavior by passing a `mission`,
+        `quarter`, `campaign`, or `sector` argument yourself.
+
+        Please refer to the docstring of `search_lightcurve` for a complete
+        list of search parameters accepted.
+
+        Parameters
+        ----------
+        limit : int
+            Maximum number of results to return.
+        radius : float or `astropy.units.Quantity` object
+            Conesearch radius.  If a float is given it will be assumed to be in
+            units of arcseconds.
+        **search_criteria : kwargs
+            Extra criteria to be passed to `search_lightcurve`.
+
+        Returns
+        -------
+        result : :class:`SearchResult` object
+            Object detailing the neighbor light curves found, sorted by
+            distance from the current light curve.
+        """
+        # Local import to avoid circular dependency
+        from .search import search_lightcurve
+
+        # By default, only return results from the same sector/quarter/campaign
+        if ('mission' not in search_criteria
+                and 'sector' not in search_criteria
+                and 'quarter' not in search_criteria
+                and 'campaign' not in search_criteria):
+            if (self.mission == 'TESS'):
+                search_criteria['sector'] = self.sector
+            elif (self.mission == 'Kepler'):
+                search_criteria['quarter'] = self.quarter
+            elif (self.mission == 'K2'):
+                search_criteria['campaign'] = self.campaign
+
+        # Note: we increase `limit` by one below to account for the fact that the
+        # current light curve will be returned by the search operation
+        result = search_lightcurve(f"{self.ra} {self.dec}",
+                                   radius=radius,
+                                   limit=limit + 1,
+                                   **search_criteria)
+
+        # Filter by distance > 0 to avoid returning the current light curve
+        return result[result.distance > 0]
 
 
 class FoldedLightCurve(LightCurve):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -3,7 +3,6 @@ import os
 import datetime
 import logging
 import warnings
-from functools import lru_cache
 import collections
 
 import numpy as np
@@ -25,7 +24,7 @@ from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import PACKAGEDIR, MPLSTYLE
-from .utils import (is_notebook, running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
+from .utils import (running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
     validate_method, _query_solar_system_objects
 )
 from .utils import LightkurveWarning, LightkurveDeprecationWarning

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -2167,7 +2167,6 @@ class LightCurve(QTimeSeries):
 
         return in_transit
 
-
     def search_neighbors(self, limit: int = 10, radius: float = 3600.,
                          **search_criteria) -> "SearchResult":
         """Search the data archive at MAST for the most nearby light curves.
@@ -2220,13 +2219,16 @@ class LightCurve(QTimeSeries):
 
         # Note: we increase `limit` by one below to account for the fact that the
         # current light curve will be returned by the search operation
+        log.info(f"Started searching for up to {limit} neighbors within {radius} arcseconds.")
         result = search_lightcurve(f"{self.ra} {self.dec}",
                                    radius=radius,
                                    limit=limit + 1,
                                    **search_criteria)
 
         # Filter by distance > 0 to avoid returning the current light curve
-        return result[result.distance > 0]
+        result = result[result.distance > 0]
+        log.info(f"Found {len(result)} neighbors.")
+        return result
 
 
 class FoldedLightCurve(LightCurve):

--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -2167,7 +2167,7 @@ class LightCurve(QTimeSeries):
         return in_transit
 
     def search_neighbors(self, limit: int = 10, radius: float = 3600.,
-                         **search_criteria) -> "SearchResult":
+                         **search_criteria):
         """Search the data archive at MAST for the most nearby light curves.
 
         By default, the 10 nearest neighbors located within 3600 arcseconds

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -7,6 +7,7 @@ import re
 import warnings
 from requests import HTTPError
 
+from memoization import cached
 import numpy as np
 from astropy.table import join, Table, Row
 from astropy.coordinates import SkyCoord
@@ -423,7 +424,7 @@ class SearchResult(object):
             log.debug("Finished downloading.")
         return path
 
-
+@cached
 def search_targetpixelfile(target, radius=None, cadence=None,
                            mission=('Kepler', 'K2', 'TESS'),
                            author=('Kepler', 'K2', 'SPOC'),
@@ -533,6 +534,7 @@ def search_lightcurvefile(*args, **kwargs):
     return search_lightcurve(*args, **kwargs)
 
 
+@cached
 def search_lightcurve(target, radius=None, cadence=None,
                       mission=('Kepler', 'K2', 'TESS'),
                       author=('Kepler', 'K2', 'SPOC'),
@@ -638,6 +640,7 @@ def search_lightcurve(target, radius=None, cadence=None,
         return SearchResult(None)
 
 
+@cached
 def search_tesscut(target, sector=None):
     """Searches MAST for TESS Full Frame Image cutouts containing a desired target or region.
 

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -125,6 +125,8 @@ class SearchResult(object):
 
     @property
     def t_exptime(self):
+        """Returns an array of cadence exposure times for targets in search
+        in seconds"""
         return self.table['t_exptime'].quantity
 
     @property
@@ -133,6 +135,7 @@ class SearchResult(object):
 
     @property
     def distance(self):
+        """Returns an array of distance to search point in arceseconds"""
         return self.table['distance'].quantity
 
     def _download_one(self, table, quality_bitmask, download_dir, cutout_size, **kwargs):

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1358,3 +1358,13 @@ def test_timedelta():
 def test_issue_916():
     """Regression test for #916: Can we flatten after folding?"""
     LightCurve(flux=np.random.randn(100)).fold(period=2.5).flatten()
+
+
+@pytest.mark.remote_data
+def test_search_neighbors():
+    """The closest neighbor to Proxima Cen in Sector 11 is TIC 388852407."""
+    lc = search_lightcurve("Proxima Cen", sector=11).download()
+    search = lc.search_neighbors(limit=1, radius=300)
+    assert len(search) == 1
+    assert search.distance.value < 300
+    assert search.target_name[0] == '388852407'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ fbpca = ">=1.0"
 numba = ">=0.39.0"
 bokeh = ">=1.0"
 ipython = ">=6.0.0"
-memoization = ">=0.3.0"
+memoization = ">=0.3.1"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = "^2.0.0"
@@ -48,6 +48,7 @@ pytest-cov = "^2.10.1"
 pytest-remotedata = "^0.3.2"
 pytest-doctestplus = "^0.8.0"
 pytest-xdist = "^2.1.0"
+line-profiler = "^3.1.0"
 
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ fbpca = ">=1.0"
 numba = ">=0.39.0"
 bokeh = ">=1.0"
 ipython = ">=6.0.0"
+memoization = "^0.3.1"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = "^2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ fbpca = ">=1.0"
 numba = ">=0.39.0"
 bokeh = ">=1.0"
 ipython = ">=6.0.0"
-memoization = "^0.3.1"
+memoization = ">=0.3.0"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = "^2.0.0"


### PR DESCRIPTION
Over in #855, @jcsmithhere opened a fabulous PR to add a much-improved `CBVCorrector` class to Lightkurve.

One of the questions raised in that PR was whether it would be good to move the generic over- and under-fitting metrics it implements outside of `CBVCorrector`.  This seems like an excellent idea because they are sufficiently generic that any correction method could benefit from them.

Because I struggle to think about software design without trying things out, I went ahead and created this branch which explores how best to add Jeff's over- and underfitting metrics into the existing Lightkurve infrastructure.

Specifically, this PR makes the following changes:
* I added a dedicated `correctors.metrics` module to host the `under_fitting_metric` and `over_fitting_metric` methods created by @jcsmithhere in #855 as two standalone functions.
* To make it easier to add alternative under/over-fitting metrics in the future, I went ahead and gave these functions more specific names, namely `overfit_metric_lombscargle` and `underfit_metric_neighbors`.  I don't necessarily love these names, so I'm happy for them to be changed!
* I added two simple unit tests focused specifically on these metrics in `correctors/tests/test_metrics.py`.
* I added `compute_underfit_metric()` and `compute_overfit_metric()` to the base `Corrector` class over in `correctors/corrector.py`.  These methods are lightweight wrappers for the functions defined in `correctors/metrics.py` and makes them easily accessible to *any* corrector class.
* I expanded the base `Corrector` class over in `correctors/corrector.py` to better document a vision on a uniform structure for all corrector classes.

Some minor changes:
* I ran `black` on `metrics.py` for consistent formatting. (I plan to run `black` on all of Lightkurve in the near future.)
* I changed a couple of `print()` statements in `under_fitting_metric` to use `log.info()`, so they can be turned on or off (using e.g. `lk.log.setLevel("INFO").`).  Admittedly the under fitting metric can take a long time to run, so maybe we do want to add a `verbose=True` argument which would enable a `tqdm` progress bar to be displayed while downloading the neighbors.
* I noticed that the `under_fitting_metric` function implemented logic to search and obtain neighbor light curves.  Because this is a really neat feature, I moved that logic to a dedicated `LightCurve.search_neighbors()` method.
* The `under_fitting_metric` function was keeping a local cache (`self.lc_neighborhood`).  For simplicity, I modified `lightkurve/search.py` to cache the search operations directly, so client functions no longer need to worry about caching search operations. (File downloads were already being cached.)
* `under_fitting_metric` used a dynamic search radius to identify a sufficient number of neighbors.  I was a bit lazy during refactoring and wondered if we can simply use a very large default radius instead, but I haven't verified that this will work well in most cases.

If we merge this PR (with @jcsmithhere's approval), I think we'll be very close to merging the rest of `CBVCorrector` via #855.  The next steps would be:
1. Update #855 to take advantage of the fact that the metrics have been merged into Lightkurve via this PR.
2. Have a think about remaining design questions, including:
   * How best to support the use case demonstrated in the "More Generalized Design Matrix Priors" section of the excellent tutorial notebook in #855 (in which additional data is added to the CBV Design Matrix).
   * How the optimization and scan plot features of `CBVCorrector` may be adopted by other correctors in a consistent way.

Thanks again for the excellent work @jcsmithhere.  These metrics are a really neat contribution!  Please feel free to push commits directly to this PR branch, should you wish to do so.