### PR TITLE
Fix editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,5 @@ pytest-doctestplus = "^0.8.0"
 pytest-xdist = "^2.1.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["setuptools", "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pytest = "^6.1.2"
 pytest-cov = "^2.10.1"
 pytest-remotedata = "^0.3.2"
 pytest-doctestplus = "^0.8.0"
+pytest-xdist = "^2.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Fixes #908.

On the current master branch, editable installs (`pip install -e .`) are broken because they are not currently supported by `poetry`.  This PR implements a workaround by enabling `setuptools` to remain available to execute the shim `setup.py`.