### PR TITLE
Add support for the QLP & SPOC FFI light curve products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ lightkurve.search
   such as 'KIC 5112705' or 'TIC 261136679', only return products known under
   those names, unless a search radius is specified. [#796]
 
+- Added support for the QLP and SPOC FFI HLSP light curve products.
+
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,8 @@ lightkurve.search
   such as 'KIC 5112705' or 'TIC 261136679', only return products known under
   those names, unless a search radius is specified. [#796]
 
-- Added support for the QLP and SPOC FFI HLSP light curve products.
+- Added support for searching and reading QLP and SPOC Full Frame Image (FFI)
+  light curves available as High Level Science Products from MAST. [#913]
 
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lightkurve/io/__init__.py
+++ b/lightkurve/io/__init__.py
@@ -2,7 +2,7 @@
 from .detect import *
 from .read import *
 
-from . import kepler, tess, k2sff, everest
+from . import kepler, tess, qlp, k2sff, everest
 from .. import LightCurve
 
 from astropy.io import registry
@@ -16,6 +16,7 @@ __all__ = ['read', 'open']
 try:
     registry.register_reader('kepler', LightCurve, kepler.read_kepler_lightcurve)
     registry.register_reader('tess', LightCurve, tess.read_tess_lightcurve)
+    registry.register_reader('qlp', LightCurve, qlp.read_qlp_lightcurve)
     registry.register_reader('k2sff', LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader('everest', LightCurve, everest.read_everest_lightcurve)
 except registry.IORegistryError:

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -1,10 +1,11 @@
 """Provides a function to automatically detect Kepler/TESS file types."""
+from astropy.io.fits import HDUList
 
 
 __all__ = ['detect_filetype']
 
 
-def detect_filetype(hdulist):
+def detect_filetype(hdulist: HDUList) -> str:
     """Returns Kepler and TESS file types given a FITS object.
 
     This function will detect the file type by looking at both the TELESCOP and
@@ -20,6 +21,7 @@ def detect_filetype(hdulist):
         * `'EVEREST'`
         * `'K2SC'`
         * `'K2VARCAT'`
+        * `'QLP'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -34,6 +36,11 @@ def detect_filetype(hdulist):
         A string describing the detected filetype. If the filetype is not
         recognized, `None` will be returned.
     """
+    # Is it a MIT/QLP TESS FFI Quicklook Pipeline light curve?
+    # cf. http://archive.stsci.edu/hlsp/qlp
+    if "mit/qlp" in hdulist[0].header.get('origin', '').lower():
+        return "QLP"
+
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.
     if "hlsp_k2varcat" in (hdulist.filename() or ""):

--- a/lightkurve/io/qlp.py
+++ b/lightkurve/io/qlp.py
@@ -1,19 +1,23 @@
-"""Reader for official TESS light curve FITS files produced by the Ames SPOC pipeline."""
+"""Reader for MIT Quicklook Pipeline (QLP) light curve files.
+
+Website: http://archive.stsci.edu/hlsp/qlp
+Product description: https://archive.stsci.edu/hlsps/qlp/hlsp_qlp_tess_ffi_all_tess_v1_data-prod-desc.pdf
+"""
 from ..lightcurve import TessLightCurve
 from ..utils import TessQualityFlags
 
 from .generic import read_generic_lightcurve
 
 
-def read_tess_lightcurve(filename,
-                         flux_column="pdcsap_flux",
-                         quality_bitmask="default"):
+def read_qlp_lightcurve(filename,
+                        flux_column="kspsap_flux",
+                        quality_bitmask="default"):
     """Returns a `TessLightCurve`.
 
     Parameters
     ----------
     filename : str
-        Local path or remote url of a TESS light curve FITS file.
+        Local path or remote url of a QLP light curve FITS file.
     flux_column : 'pdcsap_flux' or 'sap_flux'
         Which column in the FITS file contains the preferred flux data?
     quality_bitmask : str or int
@@ -47,4 +51,8 @@ def read_tess_lightcurve(filename,
     lc.meta['TARGETID'] = lc.meta.get('TICID')
     lc.meta['QUALITY_BITMASK'] = quality_bitmask
     lc.meta['QUALITY_MASK'] = quality_mask
+
+    # QLP light curves are normalized by default
+    lc.meta['NORMALIZED'] = True
+
     return TessLightCurve(data=lc)

--- a/lightkurve/io/read.py
+++ b/lightkurve/io/read.py
@@ -90,6 +90,8 @@ def read(path_or_url, **kwargs):
         return KeplerLightCurve.read(path_or_url, format='kepler', **kwargs)
     elif filetype == "TessLightCurve":
         return TessLightCurve.read(path_or_url, format='tess', **kwargs)
+    elif filetype == "QLP":
+        return TessLightCurve.read(path_or_url, format='qlp', **kwargs)
     elif filetype == "K2SFF":
         return KeplerLightCurve.read(path_or_url, format='k2sff', **kwargs)
     elif filetype == "EVEREST":

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -100,11 +100,6 @@ class SearchResult(object):
         return np.asarray(np.unique(self.table['obsid']), dtype='int64')
 
     @property
-    def target_name(self):
-        """Returns an array of target names"""
-        return self.table['target_name'].data.data
-
-    @property
     def ra(self):
         """Returns an array of RA values for targets in search"""
         return self.table['s_ra'].data.data
@@ -113,6 +108,31 @@ class SearchResult(object):
     def dec(self):
         """Returns an array of dec values for targets in search"""
         return self.table['s_dec'].data.data
+
+    @property
+    def observation(self):
+        return self.table['observation'].data.data
+
+    @property
+    def author(self):
+        return self.table['author'].data.data
+
+    @property
+    def target_name(self):
+        """Returns an array of target names"""
+        return self.table['target_name'].data.data
+
+    @property
+    def t_exptime(self):
+        return self.table['t_exptime'].quantity
+
+    @property
+    def productFilename(self):
+        return self.table['productFilename'].data.data
+
+    @property
+    def distance(self):
+        return self.table['distance'].quantity
 
     def _download_one(self, table, quality_bitmask, download_dir, cutout_size, **kwargs):
         """Private method used by `download()` and `download_all()` to download

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -62,15 +62,15 @@ class SearchResult(object):
         self.table['#'] = None
         for idx in range(len(self.table)):
             self.table['#'][idx] = idx
+        self.table['t_exptime'].unit = "s"
+        self.table['t_exptime'].format = ".0f"
+        self.table['distance'].unit = "arcsec"
 
     def __repr__(self, html=False):
         out = 'SearchResult containing {} data products.'.format(len(self.table))
         if len(self.table) == 0:
             return out
         columns = ['#', 'observation', 'author', 'target_name', 't_exptime', 'productFilename', 'distance']
-        self.table['t_exptime'].unit = "sec"
-        self.table['t_exptime'].format = ".0f"
-        self.table['distance'].unit = "arcsec"
         return out + '\n\n' + '\n'.join(self.table[columns].pformat(max_width=300, html=html))
 
     def _repr_html_(self):

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -336,6 +336,7 @@ def test_cadence_filtering():
     assert "fast" in res.table['productFilename'][0]
 
 
+@pytest.mark.remote_data
 def test_ffi_hlsp():
     """Can SPOC, QLP (FFI), and TESS-SPOC (FFI) light curves be accessed?"""
     search = search_lightcurve("TrES-2 b", mission="tess", author="any", sector=26)  # aka TOI 2140.01
@@ -348,11 +349,23 @@ def test_ffi_hlsp():
     assert "SPOC" in search.table["author"]
 
 
-def test_qlp_lightcurve():
-    """Can we search and download an MIT QLP light curve?"""
+@pytest.mark.remote_data
+def test_qlp_ffi_lightcurve():
+    """Can we search and download an MIT QLP FFI light curve?"""
     search = search_lightcurve("TrES-2 b", sector=26, author="qlp")
     assert len(search) == 1
     assert search.author[0] == "QLP"
     assert search.t_exptime[0] == 30*u.minute  # Sector 26 had 30-minute FFIs
     lc = search.download()
     all(lc.flux == lc.kspsap_flux)
+
+
+@pytest.mark.remote_data
+def test_spoc_ffi_lightcurve():
+    """Can we search and download a SPOC FFI light curve?"""
+    search = search_lightcurve("TrES-2 b", sector=26, author="tess-spoc")
+    assert len(search) == 1
+    assert search.author[0] == "TESS-SPOC"
+    assert search.t_exptime[0] == 30*u.minute  # Sector 26 had 30-minute FFIs
+    lc = search.download()
+    all(lc.flux == lc.pdcsap_flux)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -334,3 +334,15 @@ def test_cadence_filtering():
     assert(len(res) == 1)
     assert res.table['t_exptime'][0] == 20
     assert "fast" in res.table['productFilename'][0]
+
+
+def test_ffi_hlsp():
+    """Can SPOC, QLP (FFI), and TESS-SPOC (FFI) light curves be accessed?"""
+    search = search_lightcurve("TrES-2 b", mission="tess", author="any", sector=26)  # aka TOI 2140.01
+    assert "QLP" in search.table["author"]
+    assert "TESS-SPOC" in search.table["author"]
+    assert "SPOC" in search.table["author"]
+    # tess-spoc also products tpfs
+    search = search_targetpixelfile("TrES-2 b", mission="tess", author="any", sector=26)
+    assert "TESS-SPOC" in search.table["author"]
+    assert "SPOC" in search.table["author"]

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -346,3 +346,13 @@ def test_ffi_hlsp():
     search = search_targetpixelfile("TrES-2 b", mission="tess", author="any", sector=26)
     assert "TESS-SPOC" in search.table["author"]
     assert "SPOC" in search.table["author"]
+
+
+def test_qlp_lightcurve():
+    """Can we search and download an MIT QLP light curve?"""
+    search = search_lightcurve("TrES-2 b", sector=26, author="qlp")
+    assert len(search) == 1
+    assert search.author[0] == "QLP"
+    assert search.t_exptime[0] == 30*u.minute  # Sector 26 had 30-minute FFIs
+    lc = search.download()
+    all(lc.flux == lc.kspsap_flux)


### PR DESCRIPTION
Fixes #912.

Both the MIT Quicklook Pipeline (QLP) and the Ames pipeline (SPOC) recently started delivering FFI-based light curve products and target pixel files as High Level Science Products (HLSP) to the data archive at MAST.  It is important for Lightkurve to support searching and reading these valuable products!

The following changes are required:
* Going forward, the `search_lightcurve` function will now return MAST portal products with filename suffix "lc.fits".  Previously it was looking for the string "Light Curve" appearing in the product description field, but this is not the case for these HLSPs.
* The `search_targetpixelfile` function will now return products with filename suffix "tp.fits" or "targ.fits.gz".  In the past it was looking for the string "Target Pixel" in the description field.

Note: to search for SPOC FFI light curves, users will have to pass `author="TESS-SPOC"`, whereas short cadence light curves will be known under `author="SPOC"`. Demo:

<img width="1102" alt="Screen Shot 2020-11-25 at 12 30 03" src="https://user-images.githubusercontent.com/817669/100278584-fbcaec80-2f19-11eb-8f7e-0ebcd070ff56.png">

This is a Work In Progress (WIP) because I have yet to test downloading and opening these products.