### PR TITLE
Speed up opening cached light curve files by a factor ~5x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,9 @@ lightkurve.search
 - Added support for searching and reading QLP and SPOC Full Frame Image (FFI)
   light curves available as High Level Science Products from MAST. [#913]
 
+- Improved the performance of `download()` operations by checking if a file
+  exists in local cache prior to contacting MAST.
+
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,7 +94,7 @@ lightkurve.search
   light curves available as High Level Science Products from MAST. [#913]
 
 - Improved the performance of `download()` operations by checking if a file
-  exists in local cache prior to contacting MAST.
+  exists in local cache prior to contacting MAST. [#915]
 
 lightkurve.correctors
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lightkurve/io/generic.py
+++ b/lightkurve/io/generic.py
@@ -31,7 +31,7 @@ def read_generic_lightcurve(filename, flux_column,
     # Raise an exception if the requested extension is invalid
     if isinstance(ext, str):
         validate_method(ext, supported_methods=[hdu.name.lower() for hdu in hdulist])
-    tab = Table(hdulist[ext].data)
+    tab = Table.read(hdulist[ext], format="fits")
 
     # Make sure the meta data also includes header fields from extension #0
     tab.meta.update(hdulist[0].header)

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -76,8 +76,16 @@ def test_search_lightcurve(caplog):
     assert(len(search_lightcurve('297.5835, 40.98339', quarter=6).table) == 1)
     # Should be able to resolve a SkyCoord
     c = SkyCoord('297.5835 40.98339', unit=(u.deg, u.deg))
-    assert(len(search_lightcurve(c, quarter=6).table) == 1)
-    search_lightcurve(c, quarter=6).download()
+    search = search_lightcurve(c, quarter=6)
+    assert(len(search.table) == 1)
+    assert(len(search) == 1)
+    # We should be able to download a light curve
+    search.download()
+    # The second call to download should use the local cache
+    caplog.clear()
+    caplog.set_level("DEBUG")
+    search.download()
+    assert "found in local cache" in caplog.text
     # with mission='TESS', it should return TESS observations
     tic = 'TIC 273985862'
     assert(len(search_lightcurve(tic, mission='TESS').table) > 1)


### PR DESCRIPTION
As reported in #914, obtaining light curves via `download_all()` was surprisingly slow, even what all the files are available in the local cache.

Using `line_profiler`, I determined the primary culprit to be the fact that `astroquery.mast.Observations.download_products()` always submits a HTTP request to MAST to determine the length of the file prior to checking if the file already exists in the local cache.  This PR modifies `download()` and `download_all()` to skip that request.

This PR also includes a few easy speed-ups inside`lightkurve.io.generic.read_generic_lightcurve()`.

As a result, the time required to open 10 light curves (cf. example in #914) dropped from ~8.5s to ~1.5s, which is a ~5x improvement:

**Before:**
```python
>>> %time collection = search.download_all()
CPU times: user 4.55 s, sys: 169 ms, total: 4.72 s
Wall time: 8.71 s
```

**After:**
```python
>>> %time collection = search.download_all()
CPU times: user 1.26 s, sys: 100 ms, total: 1.36 s
Wall time: 1.56 s
```

