### PR TITLE
Enable `flatten()` to run after `fold()` (fixes #916)

### DIFF
--- a/lightkurve/lightcurve.py
+++ b/lightkurve/lightcurve.py
@@ -190,7 +190,7 @@ class LightCurve(QTimeSeries):
             if time is None and flux is not None:
                 time = np.arange(len(flux))
             # We are tolerant of missing time format
-            if time is not None and not isinstance(time, Time):
+            if time is not None and not isinstance(time, (Time, TimeDelta)):
                 # Lightkurve v1.x supported specifying the time_format
                 # as a constructor kwarg
                 time = Time(time,
@@ -199,7 +199,7 @@ class LightCurve(QTimeSeries):
 
         # Also be tolerant of missing time format if time is passed via `data`
         if data and 'time' in data.keys():
-            if not isinstance(data['time'], Time):
+            if not isinstance(data['time'], (Time, TimeDelta)):
                 data['time'] = Time(data['time'],
                             format=deprecated_kws.get("time_format", self._default_time_format),
                             scale=deprecated_kws.get("time_scale", self._default_time_scale))

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1346,3 +1346,15 @@ def test_support_non_numeric_columns():
     lc['col1'] = ['a', 'b', 'c']
     lc_copy = lc.copy()
     assert_array_equal(lc_copy['col1'], lc['col1'])
+
+
+def test_timedelta():
+    """Can the time column be initialized using TimeDelta?"""
+    td = TimeDelta([-0.5, 0, +0.5])
+    LightCurve(time=td)
+    LightCurve(data={'time': td})
+
+
+def test_issue_916():
+    """Regression test for #916: Can we flatten after folding?"""
+    LightCurve(flux=np.random.randn(100)).fold(period=2.5).flatten()


### PR DESCRIPTION
Fixes #916.

As of AstroPy v4.2 it no longer appears possible to initialize a `Time` object from a `TimeDelta` object, leading to an exception if e.g. `flatten()` is called after `fold()`.

This PR implements a workaround and adds two regression tests.