### PR TITLE
Ensure SPOC FFI products show up in search operations by default

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -430,7 +430,7 @@ class SearchResult(object):
 @cached
 def search_targetpixelfile(target, radius=None, cadence=None,
                            mission=('Kepler', 'K2', 'TESS'),
-                           author=('Kepler', 'K2', 'SPOC'),
+                           author=('Kepler', 'K2', 'SPOC', 'TESS-SPOC'),
                            quarter=None, month=None, campaign=None, sector=None,
                            limit=None):
     """Searches the `public data archive at MAST <https://archive.stsci.edu>`_
@@ -465,7 +465,7 @@ def search_targetpixelfile(target, radius=None, cadence=None,
         'Kepler', 'K2', or 'TESS'. By default, all will be returned.
     author : str, tuple of str, or "any"
         Author of the data product (`provenance_name` in the MAST API).
-        Defaults to the official products: ('Kepler', 'K2', 'SPOC').
+        Defaults to the official pipeline products ('Kepler', 'K2', 'SPOC', 'TESS-SPOC').
         Use "any" to retrieve all light curves regardless of the author.
     quarter, campaign, sector : int, list of ints
         Kepler Quarter, K2 Campaign, or TESS Sector number.
@@ -540,7 +540,7 @@ def search_lightcurvefile(*args, **kwargs):
 @cached
 def search_lightcurve(target, radius=None, cadence=None,
                       mission=('Kepler', 'K2', 'TESS'),
-                      author=('Kepler', 'K2', 'SPOC'),
+                      author=('Kepler', 'K2', 'SPOC', 'TESS-SPOC'),
                       quarter=None, month=None, campaign=None, sector=None,
                       limit=None):
     """Searches the `public data archive at MAST <https://archive.stsci.edu>`_ for a Kepler or TESS
@@ -575,7 +575,7 @@ def search_lightcurve(target, radius=None, cadence=None,
         'Kepler', 'K2', or 'TESS'. By default, all will be returned.
     author : str, tuple of str, or "any"
         Author of the data product (`provenance_name` in the MAST API).
-        Defaults to the official products: ('Kepler', 'K2', 'SPOC').
+        Defaults to the official products: ('Kepler', 'K2', 'SPOC', 'TESS-SPOC').
         Community-provided products that are supported include ('K2SFF', 'EVEREST').
         Use "any" to retrieve all light curves regardless of the author.
     quarter, campaign, sector : int, list of ints

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -275,7 +275,7 @@ def test_corrupt_download_handling():
 def test_indexerror_631():
     """Regression test for #631; avoid IndexError."""
     # This previously triggered an exception:
-    result = search_lightcurve("KIC 8462852", sector=15, radius=1)
+    result = search_lightcurve("KIC 8462852", sector=15, radius=1, author="spoc")
     assert len(result) == 1
 
 
@@ -309,7 +309,7 @@ def test_overlapping_targets_718():
 
     # Searching by `target_name` should not preven a KIC identifier to work
     # in a TESS data search
-    search = search_targetpixelfile('KIC 8462852', mission='TESS', sector=15)
+    search = search_targetpixelfile('KIC 8462852', mission='TESS', sector=15, author='spoc')
     assert len(search) == 1
 
 


### PR DESCRIPTION
This PR proposes to show TESS FFI-based data products produced by the NASA SPOC pipeline by default in the result of search operations.   It was already possible to show these products by passing `author="TESS-SPOC"` or `author="any"` to the search functions, but this PR adds TESS-SPOC to the list of authors that are shown by default.  See examples below.

An outstanding question is whether or not *all* HLSP products should be shown by default.  I'd welcome any and all opinions on this!  There is a trade-off between making sure all options are visible on one hand, and not overwhelming users on the other hand.

## Current behavior

<img width="839" alt="Screen Shot 2021-01-12 at 9 18 49 AM" src="https://user-images.githubusercontent.com/817669/104348985-33382d00-54b7-11eb-9f98-641347600304.png">

## New behavior after this PR

<img width="902" alt="Screen Shot 2021-01-12 at 9 18 26 AM" src="https://user-images.githubusercontent.com/817669/104348997-359a8700-54b7-11eb-8723-3ae77d334e76.png">

## Open question: should all HLSPs be shown by default?

Many more products could be shown by showing all products by default, at the risk of overwhelming the user.  What is the right thing to do?

<img width="911" alt="Screen Shot 2021-01-12 at 9 24 42 AM" src="https://user-images.githubusercontent.com/817669/104349641-09333a80-54b8-11eb-942e-afbea06919d9.png">

