### PR TITLE
Ensure *all* data products show up in search results by default

### DIFF
--- a/lightkurve/correctors/metrics.py
+++ b/lightkurve/correctors/metrics.py
@@ -254,11 +254,12 @@ def _unique_key_for_processing_neighbors(
     min_targets: int = 30,
     max_targets: int = 50,
     interpolate: bool = False,
+    author: tuple = ("Kepler", "K2", "SPOC"),
     flux_column: str = "sap_flux",
 ):
     """Returns a unique key that will determine whether a cached version of a
     call to `_download_and_preprocess_neighbors` can be re-used."""
-    return f"{corrected_lc.ra}{corrected_lc.dec}{corrected_lc.cadenceno}{radius}{min_targets}{max_targets}{flux_column}{interpolate}"
+    return f"{corrected_lc.ra}{corrected_lc.dec}{corrected_lc.cadenceno}{radius}{min_targets}{max_targets}{author}{flux_column}{interpolate}"
 
 
 @cached(custom_key_maker=_unique_key_for_processing_neighbors)
@@ -268,6 +269,7 @@ def _download_and_preprocess_neighbors(
     min_targets: int = 30,
     max_targets: int = 50,
     interpolate: bool = False,
+    author: tuple = ("Kepler", "K2", "SPOC"),
     flux_column: str = "sap_flux",
 ):
     """Returns a collection of neighboring light curves.
@@ -300,7 +302,7 @@ def _download_and_preprocess_neighbors(
         List containing the flux arrays of the neighboring light curves,
         interpolated and aligned with `corrected_lc` if requested.
     """
-    search = corrected_lc.search_neighbors(limit=max_targets, radius=radius)
+    search = corrected_lc.search_neighbors(limit=max_targets, radius=radius, author=author)
     if len(search) < min_targets:
         raise MinTargetsError(
             f"Unable to find at least {min_targets} neighbors within {radius} arcseconds radius."

--- a/lightkurve/correctors/tests/test_cbvcorrector.py
+++ b/lightkurve/correctors/tests/test_cbvcorrector.py
@@ -303,7 +303,7 @@ def test_CBVCorrector_retrieval():
     #***
     # A good TESS example of both over- and under-fitting
     # The "over-fitted" curve looks better to the eye, but eyes can be deceiving!
-    lc = search_lightcurve('TIC 357126143', mission='tess', sector=10).download(flux_column='sap_flux')
+    lc = search_lightcurve('TIC 357126143', mission='tess', author='spoc', sector=10).download(flux_column='sap_flux')
     cbvCorrector =  CBVCorrector(lc)
     assert isinstance(cbvCorrector, CBVCorrector)
 
@@ -349,13 +349,13 @@ def test_CBVCorrector_retrieval():
     
     #***
     # A Kepler and K2 example
-    lc = search_lightcurve('KIC 6508221', mission='kepler', quarter=5).download(flux_column='sap_flux')
+    lc = search_lightcurve('KIC 6508221', mission='kepler', author='kepler', quarter=5).download(flux_column='sap_flux')
     cbvCorrector =  CBVCorrector(lc)
     lc = cbvCorrector.correct_gaussian_prior(alpha=1.0)
     assert isinstance(lc, KeplerLightCurve) 
     assert lc.flux.unit == u.Unit("electron / second")
 
-    lc = search_lightcurve('EPIC 247887989', mission='K2').download(flux_column='sap_flux')
+    lc = search_lightcurve('EPIC 247887989', mission='k2', author='k2').download(flux_column='sap_flux')
     cbvCorrector =  CBVCorrector(lc)
     lc = cbvCorrector.correct_gaussian_prior(alpha=1.0)
     assert isinstance(lc, KeplerLightCurve) 

--- a/lightkurve/correctors/tests/test_metrics.py
+++ b/lightkurve/correctors/tests/test_metrics.py
@@ -33,7 +33,7 @@ def test_overfit_metric_lombscargle():
 def test_underfit_metric_neighbors():
     """Sanity checks for `underfit_metric_neighbors`."""
     # PDCSAP_FLUX has a very good score (>0.99) because it has been corrected
-    lc_pdcsap = search_lightcurve("Proxima Cen", sector=11).download(
+    lc_pdcsap = search_lightcurve("Proxima Cen", sector=11, author="SPOC").download(
         flux_column="pdcsap_flux"
     )
     assert underfit_metric_neighbors(lc_pdcsap, min_targets=3, max_targets=3) > 0.99

--- a/lightkurve/correctors/tests/test_sffcorrector.py
+++ b/lightkurve/correctors/tests/test_sffcorrector.py
@@ -188,6 +188,6 @@ def test_sff_tess_warning():
 def test_sff_nan_centroids():
     """Regression test for #827: SFF failed if light curve contained
     NaNs in its `centroid_col` or `centroid_row` columns."""
-    lc = search_lightcurve("EPIC 211083408").download()
+    lc = search_lightcurve("EPIC 211083408", author="K2").download()
     # This previously raised a ValueError:
     lc[200:500].remove_nans().to_corrector("sff").correct()

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -28,6 +28,9 @@ __all__ = ['search_targetpixelfile', 'search_lightcurve',
            'SearchResult']
 
 
+AUTHORS_SUPPORTED = ('kepler', 'k2', 'spoc', 'tess-spoc', 'qlp', 'k2sff', 'everest', 'k2sc', 'k2varcat')t
+
+
 class SearchError(Exception):
     pass
 
@@ -430,7 +433,7 @@ class SearchResult(object):
 @cached
 def search_targetpixelfile(target, radius=None, cadence=None,
                            mission=('Kepler', 'K2', 'TESS'),
-                           author=('Kepler', 'K2', 'SPOC'),
+                           author=None,
                            quarter=None, month=None, campaign=None, sector=None,
                            limit=None):
     """Searches the `public data archive at MAST <https://archive.stsci.edu>`_
@@ -465,8 +468,9 @@ def search_targetpixelfile(target, radius=None, cadence=None,
         'Kepler', 'K2', or 'TESS'. By default, all will be returned.
     author : str, tuple of str, or "any"
         Author of the data product (`provenance_name` in the MAST API).
-        Defaults to the official products: ('Kepler', 'K2', 'SPOC').
-        Use "any" to retrieve all light curves regardless of the author.
+        Official Kepler, K2, and TESS pipeline products have author names
+        'Kepler', 'K2', and 'SPOC'.
+        By default, all light curves are returned regardless of the author.
     quarter, campaign, sector : int, list of ints
         Kepler Quarter, K2 Campaign, or TESS Sector number.
         By default all quarters/campaigns/sectors will be returned.
@@ -540,7 +544,7 @@ def search_lightcurvefile(*args, **kwargs):
 @cached
 def search_lightcurve(target, radius=None, cadence=None,
                       mission=('Kepler', 'K2', 'TESS'),
-                      author=('Kepler', 'K2', 'SPOC'),
+                      author=None,
                       quarter=None, month=None, campaign=None, sector=None,
                       limit=None):
     """Searches the `public data archive at MAST <https://archive.stsci.edu>`_ for a Kepler or TESS
@@ -575,9 +579,10 @@ def search_lightcurve(target, radius=None, cadence=None,
         'Kepler', 'K2', or 'TESS'. By default, all will be returned.
     author : str, tuple of str, or "any"
         Author of the data product (`provenance_name` in the MAST API).
-        Defaults to the official products: ('Kepler', 'K2', 'SPOC').
-        Community-provided products that are supported include ('K2SFF', 'EVEREST').
-        Use "any" to retrieve all light curves regardless of the author.
+        Official Kepler, K2, and TESS pipeline products have author names
+        'Kepler', 'K2', and 'SPOC'.
+        Community-provided products that are supported include 'K2SFF', 'EVEREST'.
+        By default, all light curves are returned regardless of the author.
     quarter, campaign, sector : int, list of ints
         Kepler Quarter, K2 Campaign, or TESS Sector number.
         By default all quarters/campaigns/sectors will be returned.
@@ -680,7 +685,7 @@ def search_tesscut(target, sector=None):
 
 def _search_products(target, radius=None, filetype="Lightcurve", cadence=None,
                      mission=('Kepler', 'K2', 'TESS'),
-                     provenance_name=('Kepler', 'K2', 'SPOC'),
+                     provenance_name=None,
                      t_exptime=(0, 9999), quarter=None, month=None,
                      campaign=None, sector=None, limit=None,
                      **extra_query_criteria):
@@ -843,7 +848,7 @@ def _search_products(target, radius=None, filetype="Lightcurve", cadence=None,
 
 def _query_mast(target, radius=None,
                 project=('Kepler', 'K2', 'TESS'),
-                provenance_name=("Kepler", "K2", "SPOC"),
+                provenance_name=None,
                 t_exptime=(0, 9999),
                 sequence_number=None,
                 **extra_query_criteria):
@@ -959,7 +964,7 @@ def _query_mast(target, radius=None,
 def _filter_products(products, campaign=None, quarter=None, month=None,
                      sector=None, cadence=None, limit=None,
                      project=('Kepler', 'K2', 'TESS'),
-                     provenance_name=('Kepler', 'K2', 'SPOC'),
+                     provenance_name=None,
                      filetype='Target Pixel'):
     """Helper function which filters a SearchResult's products table by one or
     more criteria.

--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -28,9 +28,6 @@ __all__ = ['search_targetpixelfile', 'search_lightcurve',
            'SearchResult']
 
 
-AUTHORS_SUPPORTED = ('kepler', 'k2', 'spoc', 'tess-spoc', 'qlp', 'k2sff', 'everest', 'k2sc', 'k2varcat')t
-
-
 class SearchError(Exception):
     pass
 

--- a/lightkurve/tests/test_collections.py
+++ b/lightkurve/tests/test_collections.py
@@ -183,7 +183,7 @@ def test_tpfcollection_plot():
 @pytest.mark.remote_data
 def test_stitch_repr():
     """Regression test for #884."""
-    lc = search_lightcurve("Pi Men", mission='TESS', sector=1).download()
+    lc = search_lightcurve("Pi Men", mission='TESS', author='SPOC', sector=1).download()
     # The line below used to raise `ValueError: Unable to parse format string
     # "{:10d}" for entry "70445.0" in column "cadenceno"`
     LightCurveCollection((lc,lc)).stitch().__repr__()

--- a/lightkurve/tests/test_lightcurve.py
+++ b/lightkurve/tests/test_lightcurve.py
@@ -1063,8 +1063,8 @@ def test_fold_v2():
 @pytest.mark.remote_data
 def test_combine_kepler_tess():
     """Can we append or stitch a TESS light curve to a Kepler light curve?"""
-    lc_kplr = search_lightcurve("Kepler-10", mission='Kepler')[0].download()
-    lc_tess = search_lightcurve("Kepler-10", mission='TESS')[0].download()
+    lc_kplr = search_lightcurve("Kepler-10", mission='Kepler', author="Kepler")[0].download()
+    lc_tess = search_lightcurve("Kepler-10", mission='TESS', author="SPOC")[0].download()
     # Can we use append()?
     lc = lc_kplr.append(lc_tess)
     assert(len(lc) == len(lc_kplr)+len(lc_tess))
@@ -1364,7 +1364,7 @@ def test_issue_916():
 def test_search_neighbors():
     """The closest neighbor to Proxima Cen in Sector 11 is TIC 388852407."""
     lc = search_lightcurve("Proxima Cen", sector=11).download()
-    search = lc.search_neighbors(limit=1, radius=300)
+    search = lc.search_neighbors(limit=1, radius=300, author="spoc", sector="11")
     assert len(search) == 1
     assert search.distance.value < 300
     assert search.target_name[0] == '388852407'

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -89,9 +89,9 @@ def test_search_lightcurve(caplog):
     # with mission='TESS', it should return TESS observations
     tic = 'TIC 273985862'
     assert(len(search_lightcurve(tic, mission='TESS').table) > 1)
-    assert(len(search_lightcurve(tic, mission='TESS', sector=1, radius=100).table) == 2)
-    search_lightcurve(tic, mission='TESS', sector=1).download()
-    assert(len(search_lightcurve("pi Mensae", sector=1).table) == 1)
+    assert(len(search_lightcurve(tic, mission='TESS', author='spoc', sector=1, radius=100).table) == 2)
+    search_lightcurve(tic, mission='TESS', author='SPOC', sector=1).download()
+    assert(len(search_lightcurve("pi Mensae", author='SPOC', sector=1).table) == 1)
 
 
 @pytest.mark.remote_data
@@ -197,12 +197,12 @@ def test_collections():
     # TargetPixelFileCollection class
     assert(len(search_targetpixelfile('EPIC 205998445', mission='K2',radius=900).table) == 4)
     # LightCurveFileCollection class with set targetlimit
-    assert(len(search_lightcurve('EPIC 205998445', mission='K2', radius=900, limit=3).download_all()) == 3)
+    assert(len(search_lightcurve('EPIC 205998445', mission='K2', radius=900, limit=3, author='K2').download_all()) == 3)
     # if fewer targets are found than targetlimit, should still download all available
     assert(len(search_targetpixelfile('EPIC 205998445', mission='K2', radius=900, limit=6).table) == 4)
     # if download() is used when multiple files are available, should only download 1
     with pytest.warns(LightkurveWarning, match='4 files available to download'):
-        assert(isinstance(search_targetpixelfile('EPIC 205998445', mission='K2', radius=900).download(),
+        assert(isinstance(search_targetpixelfile('EPIC 205998445', mission='K2', radius=900, author="K2").download(),
                           KeplerTargetPixelFile))
 
 
@@ -275,7 +275,7 @@ def test_corrupt_download_handling():
 def test_indexerror_631():
     """Regression test for #631; avoid IndexError."""
     # This previously triggered an exception:
-    result = search_lightcurve("KIC 8462852", sector=15, radius=1)
+    result = search_lightcurve("KIC 8462852", sector=15, radius=1, author="spoc")
     assert len(result) == 1
 
 
@@ -309,7 +309,7 @@ def test_overlapping_targets_718():
 
     # Searching by `target_name` should not preven a KIC identifier to work
     # in a TESS data search
-    search = search_targetpixelfile('KIC 8462852', mission='TESS', sector=15)
+    search = search_targetpixelfile('KIC 8462852', mission='TESS', sector=15, author="spoc")
     assert len(search) == 1
 
 
@@ -323,7 +323,7 @@ def test_tesscut_795():
 @pytest.mark.remote_data
 def test_download_flux_column():
     """Can we pass reader keyword arguments to the download method?"""
-    lc = search_lightcurve("Pi Men", sector=12).download(flux_column='sap_flux')
+    lc = search_lightcurve("Pi Men", author='SPOC', sector=12).download(flux_column='sap_flux')
     assert_array_equal(lc.flux, lc.sap_flux)
 
 


### PR DESCRIPTION
This is a follow-up on #929.

This PR changes the default behavior of all search operations to show *all* available data products at MAST by default, as opposed to only showing the official data products.

For example, searching for Polaris will now show MIT QLP, SPOC 2-minute, and SPOC FFI products:

<img width="916" alt="Screen Shot 2021-01-22 at 2 22 40 PM" src="https://user-images.githubusercontent.com/817669/105554985-4f10af80-5cbd-11eb-85b8-a00fd535c09d.png">

The selection can be narrowed down by passing the `author` argument:

<img width="861" alt="Screen Shot 2021-01-22 at 2 25 29 PM" src="https://user-images.githubusercontent.com/817669/105555191-b6c6fa80-5cbd-11eb-91d0-6bb9ecb699ac.png">

Outstanding question: how should the search results be sorted?  Right now they are sorted on`productFilename`, but I'm happy to take alternative suggestions. (/cc @mrtommyb @kcolon @rebekah9969 ?)

