### PR TITLE
PATHOS HLSP reader

### DIFF
--- a/lightkurve/io/__init__.py
+++ b/lightkurve/io/__init__.py
@@ -2,7 +2,7 @@
 from .detect import *
 from .read import *
 
-from . import kepler, tess, qlp, k2sff, everest
+from . import kepler, tess, qlp, k2sff, everest, pathos
 from .. import LightCurve
 
 from astropy.io import registry
@@ -19,5 +19,6 @@ try:
     registry.register_reader('qlp', LightCurve, qlp.read_qlp_lightcurve)
     registry.register_reader('k2sff', LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader('everest', LightCurve, everest.read_everest_lightcurve)
+    registry.register_reader('pathos', LightCurve, pathos.read_pathos_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -48,7 +48,7 @@ def detect_filetype(hdulist: HDUList) -> str:
     # The 'pathos' name doesn't stay in the filename if when we use fits.open
     # to download a file, so we have to check for all the important columns
     # This will cause problems if another HLSP has the exact same colnames...
-    if all(x in f[1].columns.names for x in ["PSF_FLUX_RAW", "PSF_FLUX_COR", "AP4_FLUX_RAW", "AP4_FLUX_COR", "SKY_LOCAL"]):
+    if all(x in hdulist[1].columns.names for x in ["PSF_FLUX_RAW", "PSF_FLUX_COR", "AP4_FLUX_RAW", "AP4_FLUX_COR", "SKY_LOCAL"]):
         return "PATHOS"
 
     # Is it a K2VARCAT file?

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -45,7 +45,7 @@ def detect_filetype(hdulist: HDUList) -> str:
 
     # Is it a PATHOS TESS light curve?
     # cf. http://archive.stsci.edu/hlsp/pathos
-    if "pathos" in hdulist[0].header.get('origin', '').lower():
+    if "pathos" in (hdulist.filename() or ""):
         return "PATHOS"
 
     # Is it a K2VARCAT file?

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -22,6 +22,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'K2SC'`
         * `'K2VARCAT'`
         * `'QLP'`
+        * `'PATHOS'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -36,10 +37,16 @@ def detect_filetype(hdulist: HDUList) -> str:
         A string describing the detected filetype. If the filetype is not
         recognized, `None` will be returned.
     """
+
     # Is it a MIT/QLP TESS FFI Quicklook Pipeline light curve?
     # cf. http://archive.stsci.edu/hlsp/qlp
     if "mit/qlp" in hdulist[0].header.get('origin', '').lower():
         return "QLP"
+
+    # Is it a PATHOS TESS light curve?
+    # cf. http://archive.stsci.edu/hlsp/pathos
+    if "pathos" in hdulist[0].header.get('origin', '').lower():
+        return "PATHOS"
 
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -45,7 +45,10 @@ def detect_filetype(hdulist: HDUList) -> str:
 
     # Is it a PATHOS TESS light curve?
     # cf. http://archive.stsci.edu/hlsp/pathos
-    if "pathos" in (hdulist.filename() or ""):
+    # The 'pathos' name doesn't stay in the filename if when we use fits.open
+    # to download a file, so we have to check for all the important columns
+    # This will cause problems if another HLSP has the exact same colnames...
+    if all(x in f[1].columns.names for x in ["PSF_FLUX_RAW", "PSF_FLUX_COR", "AP4_FLUX_RAW", "AP4_FLUX_COR", "SKY_LOCAL"]):
         return "PATHOS"
 
     # Is it a K2VARCAT file?

--- a/lightkurve/io/pathos.py
+++ b/lightkurve/io/pathos.py
@@ -1,0 +1,60 @@
+"""Reader for A PSF-Based Approach to TESS High Quality Data Of Stellar Clusters (PATHOS) light curve files.
+
+Website: https://archive.stsci.edu/hlsp/pathos
+A product description file wasn't obvious on the MAST website
+"""
+from ..lightcurve import TessLightCurve
+from ..utils import TessQualityFlags
+
+from .generic import read_generic_lightcurve
+
+
+def read_pathos_lightcurve(filename,
+                            flux_column="PSF_FLUX_COR",
+                            quality_bitmask="default"):
+    """Returns a `TessLightCurve`.
+
+    Parameters
+    ----------
+    filename : str
+        Local path or remote url of PATHOS light curve FITS file.
+    flux_column : 'PSF_FLUX_COR' or 'AP#_FLUX_COR' (# = 1, 2, 3, or 4)
+        or 'PSF_FLUX_RAW' or 'AP#_FLUX_RAW' (# = 1, 2, 3, or 4)
+        Which column in the FITS file contains the preferred flux data?
+    quality_bitmask : str or int
+        Bitmask (integer) which identifies the quality flag bitmask that should
+        be used to mask out bad cadences. If a string is passed, it has the
+        following meaning:
+
+            * "none": no cadences will be ignored (`quality_bitmask=0`).
+            * "default": cadences with severe quality issues will be ignored
+              (`quality_bitmask=1130799`).
+            * "hard": more conservative choice of flags to ignore
+              (`quality_bitmask=1664431`). This is known to remove good data.
+            * "hardest": removes all data that has been flagged
+              (`quality_bitmask=2096639`). This mask is not recommended.
+
+        See the :class:`TessQualityFlags` class for details on the bitmasks.
+    """
+    lc = read_generic_lightcurve(filename,
+                                 flux_column=flux_column,
+                                 time_format='btjd',
+                                 quality_column="DQUALITY")
+
+    # Filter out poor-quality data
+    # NOTE: Unfortunately Astropy Table masking does not yet work for columns
+    # that are Quantity objects, so for now we remove poor-quality data instead
+    # of masking. Details: https://github.com/astropy/astropy/issues/10119
+    quality_mask = TessQualityFlags.create_quality_mask(
+                                quality_array=lc['quality'],
+                                bitmask=quality_bitmask)
+    lc = lc[quality_mask]
+
+    lc.meta['TARGETID'] = lc.meta.get('TICID')
+    lc.meta['QUALITY_BITMASK'] = quality_bitmask
+    lc.meta['QUALITY_MASK'] = quality_mask
+
+    # QLP light curves are normalized by default
+    lc.meta['NORMALIZED'] = True
+
+    return TessLightCurve(data=lc)

--- a/lightkurve/io/pathos.py
+++ b/lightkurve/io/pathos.py
@@ -18,8 +18,8 @@ def read_pathos_lightcurve(filename,
     ----------
     filename : str
         Local path or remote url of PATHOS light curve FITS file.
-    flux_column : 'PSF_FLUX_COR' or 'AP#_FLUX_COR' (# = 1, 2, 3, or 4)
-        or 'PSF_FLUX_RAW' or 'AP#_FLUX_RAW' (# = 1, 2, 3, or 4)
+    flux_column : 'psf_flux_cor' or 'ap#_flux_cor' (# = 1, 2, 3, or 4)
+        or 'psf_flux_raw' or 'ap#_flux_raw' (# = 1, 2, 3, or 4)
         Which column in the FITS file contains the preferred flux data?
     quality_bitmask : str or int
         Bitmask (integer) which identifies the quality flag bitmask that should
@@ -37,7 +37,7 @@ def read_pathos_lightcurve(filename,
         See the :class:`TessQualityFlags` class for details on the bitmasks.
     """
     lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column,
+                                 flux_column=flux_column.lower(),
                                  time_format='btjd',
                                  quality_column="DQUALITY")
 

--- a/lightkurve/io/pathos.py
+++ b/lightkurve/io/pathos.py
@@ -46,7 +46,7 @@ def read_pathos_lightcurve(filename,
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = TessQualityFlags.create_quality_mask(
-                                quality_array=lc['quality'],
+                                quality_array=lc['dquality'],
                                 bitmask=quality_bitmask)
     lc = lc[quality_mask]
 

--- a/lightkurve/io/read.py
+++ b/lightkurve/io/read.py
@@ -92,6 +92,8 @@ def read(path_or_url, **kwargs):
         return TessLightCurve.read(path_or_url, format='tess', **kwargs)
     elif filetype == "QLP":
         return TessLightCurve.read(path_or_url, format='qlp', **kwargs)
+    elif filetype == "PATHOS":
+        return TessLightCurve.read(path_or_url, format='pathos', **kwargs)
     elif filetype == "K2SFF":
         return KeplerLightCurve.read(path_or_url, format='k2sff', **kwargs)
     elif filetype == "EVEREST":

--- a/lightkurve/io/tests/test_pathos.py
+++ b/lightkurve/io/tests/test_pathos.py
@@ -1,0 +1,42 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from ... import search_lightcurve
+from ..pathos import read_pathos_lightcurve
+
+
+@pytest.mark.remote_data
+def test_read_pathos():
+    """Can we read PATHOS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/pathos/s0008/hlsp_pathos_tess_lightcurve_tic-0093270923-s0008_tess_v1_llc.fits"
+    f = fits.open(url)
+    # Verify different extensions
+    fluxes = []
+
+    exts = ['PSF_FLUX_RAW', 'PSF_FLUX_COR']
+    exts.extend([f'AP{ap}_FLUX_RAW' for ap in [1,2,3,4]])
+    exts.extend([f'AP{ap}_FLUX_COR' for ap in [1,2,3,4]])
+
+    for ext in exts:
+        lc = read_pathos_lightcurve(url, ext=ext)
+        assert type(lc).__name__ == "TESSLightCurve"
+        # Are `time` and `flux` consistent with the FITS file?
+        assert_array_equal(f[1].data['TIME'], lc.time.value)
+        assert_array_equal(f[1].data[ext], lc.flux.value)
+        fluxes.append(lc.flux)
+    # Different extensions should show different fluxes
+    for i in range(9):
+        assert not np.array_equal(fluxes[i] , fluxes[i+1])
+
+@pytest.mark.remote_data
+def test_search_pathos():
+    """Can we search and download a PATHOS light curve?"""
+    search = search_lightcurve("TIC 93270923", author="PATHOS", sector=8)
+    assert len(search) == 1
+    assert search.table["author"][0] == "PATHOS"
+    lc = search.download()
+    assert type(lc).__name__ == "TESSLightCurve"
+    assert lc.sector == 8

--- a/lightkurve/io/tests/test_pathos.py
+++ b/lightkurve/io/tests/test_pathos.py
@@ -21,7 +21,7 @@ def test_read_pathos():
     exts.extend([f'AP{ap}_FLUX_COR' for ap in [1,2,3,4]])
 
     for ext in exts:
-        lc = read_pathos_lightcurve(url, ext=ext)
+        lc = read_pathos_lightcurve(url, flux_column=ext)
         assert type(lc).__name__ == "TESSLightCurve"
         # Are `time` and `flux` consistent with the FITS file?
         assert_array_equal(f[1].data['TIME'], lc.time.value)

--- a/lightkurve/io/tests/test_pathos.py
+++ b/lightkurve/io/tests/test_pathos.py
@@ -6,6 +6,15 @@ from numpy.testing import assert_array_equal
 
 from ... import search_lightcurve
 from ..pathos import read_pathos_lightcurve
+from .detect import detect_filetype
+
+@pytest.mark.remote_data
+def test_detect_pathos():
+    """Can we detect the correct format for PATHOS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/pathos/s0008/hlsp_pathos_tess_lightcurve_tic-0093270923-s0008_tess_v1_llc.fits"
+    f = fits.open(url)
+
+    assert detect_filetype(f)=="PATHOS"
 
 
 @pytest.mark.remote_data

--- a/lightkurve/io/tests/test_pathos.py
+++ b/lightkurve/io/tests/test_pathos.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_array_equal
 
 from ... import search_lightcurve
 from ..pathos import read_pathos_lightcurve
-from .detect import detect_filetype
+from ..detect import detect_filetype
 
 @pytest.mark.remote_data
 def test_detect_pathos():
@@ -31,10 +31,12 @@ def test_read_pathos():
 
     for ext in exts:
         lc = read_pathos_lightcurve(url, flux_column=ext)
-        assert type(lc).__name__ == "TESSLightCurve"
+        assert type(lc).__name__ == "TessLightCurve"
         # Are `time` and `flux` consistent with the FITS file?
-        assert_array_equal(f[1].data['TIME'], lc.time.value)
-        assert_array_equal(f[1].data[ext], lc.flux.value)
+        assert_array_equal(f[1].data['TIME'][lc.meta['QUALITY_MASK']],
+                           lc.time.value)
+        assert_array_equal(f[1].data[ext][lc.meta['QUALITY_MASK']],
+                           lc.flux.value)
         fluxes.append(lc.flux)
     # Different extensions should show different fluxes
     for i in range(9):
@@ -47,5 +49,5 @@ def test_search_pathos():
     assert len(search) == 1
     assert search.table["author"][0] == "PATHOS"
     lc = search.download()
-    assert type(lc).__name__ == "TESSLightCurve"
+    assert type(lc).__name__ == "TessLightCurve"
     assert lc.sector == 8


### PR DESCRIPTION
This partially addresses #918 , and adds code to search for and read TESS PATHOS HLSP light curves. 

1. Adds a custom reader function as lightkurve/io/pathos.py.
2. Registers the custom reader in lightkurve/io/__init__.py.
3. Updates lightkurve/io/detect.py and lightkurve/io/read.py to detect PATHOS products correctly.
4. Adds unit tests.

I'm submitting the PR now to run the unit tests (I'm having some pytest issues on my local machine)