### PR TITLE
Update GitHub Actions CI config

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.7, 3.8, 3.9-remote-data]
+        name: [3.6, 3.7, 3.8-remote-data]
         include:
+          - name: 3.6
+            python-version: 3.6
+            pytest-command: poetry run pytest
           - name: 3.7
             python-version: 3.7
             pytest-command: poetry run pytest
-          - name: 3.8
+          - name: 3.8-remote-data
             python-version: 3.8
-            pytest-command: poetry run pytest
-          - name: 3.9-remote-data
-            python-version: 3.9
             pytest-command: poetry run pytest --remote-data --doctest-modules
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -19,20 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data, 3.8-no-optional-dependencies]
+        name: [3.7, 3.8, 3.9-remote-data]
         include:
-          - name: 3.6
-            python-version: 3.6
-            pytest-command: poetry run pytest
           - name: 3.7
             python-version: 3.7
             pytest-command: poetry run pytest
-          - name: 3.8-remote-data
-            python-version: 3.8
-            pytest-command: poetry run pytest --remote-data --doctest-modules
-          - name: 3.8-no-optional-dependencies
+          - name: 3.8
             python-version: 3.8
             pytest-command: poetry run pytest
+          - name: 3.9-remote-data
+            python-version: 3.9
+            pytest-command: poetry run pytest --remote-data --doctest-modules
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -52,7 +49,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        name: [3.8-remote-data]
+        name: [3.8]
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v1
@@ -64,9 +61,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip poetry
         poetry install
-    - name: Test with pytest --remote-data
+    - name: Test with pytest
       run: |
-        poetry run pytest --remote-data
+        poetry run pytest
 
   # Run unit tests on Mac OSX
   pytest-osx:

--- a/lightkurve/io/tests/test_read.py
+++ b/lightkurve/io/tests/test_read.py
@@ -64,17 +64,25 @@ def test_filenotfound():
 def test_basic_ascii_io():
     """Verify we do not break the basic ascii i/o functionality provided by AstroPy Table."""
     # Part I: Can we read a LightCurve from a CSV file?
-    with tempfile.NamedTemporaryFile() as csvfile:
+    csvfile = tempfile.NamedTemporaryFile(delete=False)  # using delete=False to make tests pass on Windows
+    try:
         csvfile.write(b"time,flux,flux_err,color\n1,2,3,red\n4,5,6,green\n7,8,9,blue")
         csvfile.flush()
         lc_csv = LightCurve.read(csvfile.name, format="ascii.csv")
         assert lc_csv.time[0].value == 1
         assert lc_csv.flux[1] == 5
         assert lc_csv.color[2] == "blue"
+    finally:
+        csvfile.close()
+        os.remove(csvfile.name)
 
     # Part II: can we write the light curve to a tab-separated ascii file, and read it back in?
-    with tempfile.NamedTemporaryFile() as tabfile:
+    tabfile = tempfile.NamedTemporaryFile(delete=False)
+    try:
         lc_csv.write(tabfile.name, format='ascii.tab', overwrite=True)
         lc_rst = LightCurve.read(tabfile.name, format='ascii.tab')
         assert lc_rst.color[2] == "blue"
         assert (lc_csv == lc_rst).all()
+    finally:
+        tabfile.close()
+        os.remove(tabfile.name)


### PR DESCRIPTION
This PR updates how the unit tests are executed on GitHub Actions in two ways:
* Remove redundant Python 3.8 test.
* Remove the `--remote-data` flag on Windows due to the ongoing pytest issue on Windows.

I'd have liked to add Python 3.9 to the tests, but there remains an ongoing issue with numba/llvmlite which should soon be resolved (as of numba 0.53?  cf. https://github.com/numba/numba/issues/6345#issuecomment-774066083).