### PR TITLE
Fix bug in slicing a SearchResult

### DIFF
--- a/lightkurve/search.py
+++ b/lightkurve/search.py
@@ -98,7 +98,8 @@ class SearchResult(object):
         """Adds a user-friendly index (``#``) column and adds column unit
         and display format information.
         """
-        self.table['#'] = None
+        if '#' not in self.table.columns:
+            self.table['#'] = None
         self.table['exptime'].unit = "s"
         self.table['exptime'].format = ".0f"
         self.table['distance'].unit = "arcsec"

--- a/lightkurve/tests/test_search.py
+++ b/lightkurve/tests/test_search.py
@@ -344,6 +344,30 @@ def test_cadence_filtering():
     assert res.table['t_exptime'][0] == 20
     assert "fast" in res.table['productFilename'][0]
 
+    # Now do the same with the new exptime argument,
+    # because `cadence` may be deprecated.
+    # Try `exptime="fast"`
+    res = search_lightcurve("AU Mic", sector=27, exptime="fast")
+    assert(len(res) == 1)
+    assert res.exptime[0].value == 20
+    # Try `exptime="short"`
+    res = search_lightcurve("AU Mic", sector=27, exptime="short")
+    assert(len(res) == 1)
+    assert res.table['t_exptime'][0] == 120
+    # Try `exptime=20`
+    res = search_lightcurve("AU Mic", sector=27, exptime=20)
+    assert(len(res) == 1)
+    assert res.table['t_exptime'][0] == 20
+    assert "fast" in res.table['productFilename'][0]
+
+
+@pytest.mark.remote_data
+def test_search_slicing_regression():
+    # Regression test: slicing after calling __repr__ failed.
+    res = search_lightcurve("AU Mic", exptime=20)
+    res.__repr__()
+    res[res.exptime.value < 100]
+
 
 @pytest.mark.remote_data
 def test_ffi_hlsp():


### PR DESCRIPTION
This PR addresses a bug which caused the slicing of a SearchResult to fail after its __repr__ had been called. 
The PR fixes the bug and adds a regression test.

<img width="989" alt="Screen Shot 2021-02-08 at 12 18 15 PM" src="https://user-images.githubusercontent.com/817669/107276458-e12bee00-6a07-11eb-887f-1a050d294b77.png">

